### PR TITLE
mypy burn-down: 47 errors to zero, CI typecheck now blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
 
-      # advisory while the historical error count is burned down;
-      # flip to blocking once mypy src/autografs is clean
       - name: Type check
         run: mypy src/autografs
-        continue-on-error: true
 
   test:
     runs-on: ubuntu-latest
@@ -88,7 +85,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, typecheck, test]
 
     steps:
       - uses: actions/checkout@v4

--- a/progress.md
+++ b/progress.md
@@ -156,9 +156,14 @@ Run tests: `python -m pytest tests/ -q` (pytest config in pyproject handles `src
       codecs.escape_decode dropped (02d8588)
 
 ### Step 6 leftover
-- mypy burn-down: 50 errors (mostly numpy/pymatgen strictness plus a
-  few loose internal annotations); flip the CI typecheck job to
-  blocking when clean.
+- [x] mypy burn-down done (branch `mypy-burndown`, 2026-07-08): 47
+      errors -> 0. Mostly annotations + variable-rebinding cleanups;
+      real changes: SlotPlacement.arm_for_target is now a required
+      field (was Optional, always set immediately after construction),
+      match_directions uses an impossible-index sentinel instead of
+      perm=None, verbose build logging prints SBU names instead of
+      Fragment reprs. CI typecheck job flipped to blocking and added
+      to the build job's needs.
 
 ## Session log (final)
 - **2026-07-03**: Steps 1-7 all complete. Branch ready for PR to master:

--- a/src/autografs/alignment.py
+++ b/src/autografs/alignment.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import functools
 import itertools
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import numpy as np
 from pymatgen.core.lattice import Lattice
@@ -80,7 +80,7 @@ def kabsch(sources: np.ndarray, targets: np.ndarray) -> np.ndarray:
     u, _, vt = np.linalg.svd(covariance)
     sign = np.sign(np.linalg.det(vt.T @ u.T))
     correction = np.diag([1.0, 1.0, sign])
-    return vt.T @ correction @ u.T
+    return np.asarray(vt.T @ correction @ u.T)
 
 
 def match_directions(
@@ -114,13 +114,15 @@ def match_directions(
     best: tuple[float, np.ndarray, np.ndarray] | None = None
     for start in _CUBE_ROTATIONS:
         rotation = start
-        perm = None
+        # impossible assignment: never equal to a real permutation, so
+        # the first iteration always refines
+        perm = np.full(n, -1)
         for _ in range(_MATCH_ITERATIONS):
             rotated = arms @ rotation.T
             # cost = squared distance between unit vectors
             cost = -2.0 * (targets @ rotated.T)
             _, new_perm = linear_sum_assignment(cost)
-            if perm is not None and np.array_equal(new_perm, perm):
+            if np.array_equal(new_perm, perm):
                 break
             perm = new_perm
             rotation = kabsch(arms[perm], targets)
@@ -130,6 +132,8 @@ def match_directions(
             best = (score, rotation, perm)
             if score < 1e-9:
                 break
+    if best is None:  # pragma: no cover - _CUBE_ROTATIONS is never empty
+        raise AlignmentError("No rotation start produced a match.")
     score, rotation, perm = best
     return rotation, perm, score
 
@@ -139,7 +143,7 @@ def _unit(vectors: np.ndarray) -> np.ndarray:
     norms = np.linalg.norm(vectors, axis=1, keepdims=True)
     if np.any(norms < 1e-9):
         raise AlignmentError("Degenerate (zero-length) arm vector.")
-    return vectors / norms
+    return np.asarray(vectors / norms)
 
 
 # cell angles are clipped into this range during optimization to keep
@@ -317,7 +321,7 @@ class SlotPlacement:
     sbu_center: np.ndarray  # (3,) SBU dummy centroid, cartesian
     dummy_indices: list[int]  # SBU atom index per arm
     # arm assignment (perm) computed at the reference cell
-    arm_for_target: np.ndarray | None = field(default=None)
+    arm_for_target: np.ndarray
 
     def rotation_for(self, matrix: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         """Rotation and target directions in the given cell matrix."""
@@ -330,7 +334,7 @@ class SlotPlacement:
         rotation, _ = self.rotation_for(matrix)
         center = self.frac_center @ matrix
         ordered = (self.arm_units * self.arm_lengths[:, None])[self.arm_for_target]
-        return center + ordered @ rotation.T
+        return np.asarray(center + ordered @ rotation.T)
 
 
 @dataclass
@@ -357,7 +361,8 @@ class BuildPlan:
 
     @functools.cached_property
     def _blueprint_matrix(self) -> np.ndarray:
-        return Lattice.from_parameters(*self.blueprint_abc, *self.angles).matrix
+        a, b, c = self.blueprint_abc
+        return Lattice.from_parameters(a, b, c, *self.angles).matrix
 
     def matrix_for(self, free: np.ndarray) -> np.ndarray:
         return Lattice.from_parameters(*self.cell_param.expand(free)).matrix
@@ -378,12 +383,12 @@ class BuildPlan:
         for index_a, target_a, index_b, target_b, offset in self.pairs:
             pa = self.placements[index_a]
             pb = self.placements[index_b]
-            required += (
+            required += float(
                 pa.arm_lengths[pa.arm_for_target[target_a]]
                 + pb.arm_lengths[pb.arm_for_target[target_b]]
             )
             separation = (pa.frac_center - pb.frac_center - offset) @ blueprint
-            current += np.linalg.norm(separation)
+            current += float(np.linalg.norm(separation))
         if not self.pairs or current < 1e-9:
             # no shared dummies: fall back to matching mean arm lengths
             arms = np.concatenate([p.arm_lengths for p in self.placements]).mean()
@@ -509,21 +514,22 @@ def prepare_build(topology: Topology, mappings: dict[int, Fragment]) -> BuildPla
         arm_lengths = np.linalg.norm(arm_vectors, axis=1)
         arm_units = _unit(arm_vectors)
 
+        frac_arms = slot_frac - frac_center
+        # reference assignment at the blueprint cell
+        directions = _unit(frac_arms @ blueprint.matrix)
+        _, perm, _ = match_directions(directions, arm_units)
         placement = SlotPlacement(
             slot_index=slot_index,
             frac_center=frac_center,
-            frac_arms=slot_frac - frac_center,
+            frac_arms=frac_arms,
             tags=slot_tags,
             sbu=sbu,
             arm_units=arm_units,
             arm_lengths=arm_lengths,
             sbu_center=sbu_center,
             dummy_indices=sbu_dummy_idx,
+            arm_for_target=perm,
         )
-        # reference assignment at the blueprint cell
-        directions = _unit(placement.frac_arms @ blueprint.matrix)
-        _, perm, _ = match_directions(directions, arm_units)
-        placement.arm_for_target = perm
         index = len(placements)
         placements.append(placement)
         for target_index, (tag, frac) in enumerate(
@@ -550,10 +556,14 @@ def prepare_build(topology: Topology, mappings: dict[int, Fragment]) -> BuildPla
             "not constrain the cell."
         )
     abc = np.array(blueprint.abc, dtype=float)
-    angles = tuple(float(x) for x in blueprint.angles)
+    angles = (
+        float(blueprint.angles[0]),
+        float(blueprint.angles[1]),
+        float(blueprint.angles[2]),
+    )
     cell_param = CellParametrization(
         spacegroup_number=getattr(topology, "spacegroup_number", None),
-        blueprint_abc=tuple(float(x) for x in abc),
+        blueprint_abc=(float(abc[0]), float(abc[1]), float(abc[2])),
         blueprint_angles=angles,
         is_2d=getattr(topology, "is_2d", False),
     )

--- a/src/autografs/builder.py
+++ b/src/autografs/builder.py
@@ -25,7 +25,7 @@ import itertools
 import logging
 import math
 import time
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
@@ -302,10 +302,13 @@ class Autografs:
                 options = [sbu_dict[slot_type] for slot_type in slot_types]
                 tasks = []
                 for choice in _iter_combinations(options, max_per_topology, rng):
-                    raw = dict(zip(slot_types, choice, strict=True))
+                    raw: dict[Fragment | int, Fragment | str] = dict(
+                        zip(slot_types, choice, strict=True)
+                    )
                     validated = self._validate_mappings(topology=topology, mappings=raw)
                     tasks.append((topology, validated, refine_cell, max_rmsd))
                 attempted += len(tasks)
+                results: Iterable[Framework | None]
                 if executor is None:
                     results = map(_build_task, tasks)
                 else:
@@ -367,16 +370,18 @@ class Autografs:
         ValueError
             If the mappings leave topology slots unfilled.
         """
-        mappings = self._validate_mappings(topology=topology, mappings=mappings)
+        validated = self._validate_mappings(topology=topology, mappings=mappings)
         if verbose:
             logger.info("Starting building process:")
             logger.info(f"\tTopology =  {topology}")
-            formatted_mappings = autografs.utils.format_mappings(mappings)
+            formatted_mappings = autografs.utils.format_mappings(
+                {slot: sbu.name for slot, sbu in validated.items()}
+            )
             logger.info(f"\tMappings =  {formatted_mappings}")
             logger.info("Aligning with cell scaling...")
         return build_framework(
             topology,
-            mappings,
+            validated,
             refine_cell=refine_cell,
             verbose=verbose,
             max_rmsd=max_rmsd,
@@ -477,19 +482,20 @@ class Autografs:
             data_dir = Path(autografs.data.__path__[0])
             json_default = data_dir / "topologies.json.gz"
             if json_default.exists():
-                topofile = json_default
+                path = json_default
             else:
-                topofile = data_dir / "topologies.pkl"
-        topofile = Path(topofile)
-        if topofile.name.endswith((".json", ".json.gz")):
-            topologies = autografs.topology_io.load_topologies(topofile)
+                path = data_dir / "topologies.pkl"
+        else:
+            path = Path(topofile)
+        if path.name.endswith((".json", ".json.gz")):
+            topologies = autografs.topology_io.load_topologies(path)
         else:
             logger.warning(
                 "Loading topologies from a pickle file. Pickles can execute "
                 "arbitrary code and break across pymatgen versions; convert "
                 "to JSON with autografs.topology_io.save_topologies."
             )
-            with open(topofile, "rb") as topo:
+            with open(path, "rb") as topo:
                 topologies = dill.load(topo)
         logger.info(
             f"\t[x] loaded {len(topologies)} topologies in {time.time() - t0:.0f} seconds."

--- a/src/autografs/cgd.py
+++ b/src/autografs/cgd.py
@@ -36,7 +36,7 @@ import numpy as np
 import pymatgen.symmetry
 import requests
 from pymatgen.core.lattice import Lattice
-from pymatgen.core.periodic_table import get_el_sp
+from pymatgen.core.periodic_table import Element, Species, get_el_sp
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.symmetry.analyzer import PointGroupAnalyzer, SpacegroupAnalyzer
 from pymatgen.symmetry.groups import SpaceGroup
@@ -79,9 +79,10 @@ def build_group_lookup() -> dict[str, str]:
     encoding table). Without this translation, over half of the RCSR
     nets fail the spacegroup lookup and are silently dropped.
     """
-    spacegroups = json.loads(
-        pkgutil.get_data(pymatgen.symmetry.__name__, "symm_data.json")
-    )["space_group_encoding"]
+    symm_data = pkgutil.get_data(pymatgen.symmetry.__name__, "symm_data.json")
+    if symm_data is None:
+        raise RuntimeError("pymatgen symm_data.json package data not found.")
+    spacegroups = json.loads(symm_data)["space_group_encoding"]
     lookup: dict[str, str] = {}
     for key in spacegroups:
         lookup.setdefault(key.replace("_", ""), key)
@@ -128,7 +129,7 @@ def topology_from_string(
     plane-group number (1-17) and is_2d is True.
     """
     lines = [line[2:].split() for line in cgd.splitlines() if len(line) > 2]
-    elements = []
+    elements: list[Element | Species] = []
     xyz = []
     name: str | None = None
     is_2d = False
@@ -204,7 +205,7 @@ def topology_from_string(
         # and the group's int number would silently drop (reverting
         # e.g. Fd-3m:2 to origin choice 1 and generating a wrong net).
         topology = Structure.from_spacegroup(
-            sg=groupname, lattice=lattice, species=elements, coords=coords
+            sg=groupname, lattice=lattice, species=elements, coords=coords.tolist()
         )
         group_number = spacegroup.int_number
     # remove any duplicate sites

--- a/src/autografs/cli.py
+++ b/src/autografs/cli.py
@@ -183,12 +183,13 @@ def _validate_positive_int(text: str) -> bool | str:
 
 def _pick_name(message: str, names: list[str]) -> str | None:
     """Type-to-search prompt over a list of names; None on cancel."""
-    return questionary.autocomplete(
+    answer: str | None = questionary.autocomplete(
         message,
         choices=names,
         match_middle=True,
         validate=lambda text: text in names or "Pick one of the suggested names",
     ).ask()
+    return answer
 
 
 def _pick_max_rmsd() -> float | None | str:
@@ -315,7 +316,9 @@ def choose_topology(session: Session) -> Topology | None:
             return topology
 
 
-def choose_sbus(session: Session, topology: Topology) -> dict[Fragment, str] | None:
+def choose_sbus(
+    session: Session, topology: Topology
+) -> dict[Fragment | int, Fragment | str] | None:
     """One SBU per slot type, from the compatibility sieve; None on
     cancel or when a slot type has no compatible SBU at all."""
     options = session.gen.list_building_units(sieve=topology.name)
@@ -331,7 +334,7 @@ def choose_sbus(session: Session, topology: Topology) -> dict[Fragment, str] | N
             console.print(f"  - {label}")
         console.print("Add candidates with [bold]--xyz your_sbus.xyz[/bold].")
         return None
-    chosen: dict[Fragment, str] = {}
+    chosen: dict[Fragment | int, Fragment | str] = {}
     for slot_type in sorted_slot_types(topology):
         candidates = options[slot_type]
         message = f"SBU for {labels[slot_type]}:"
@@ -347,13 +350,13 @@ def choose_sbus(session: Session, topology: Topology) -> dict[Fragment, str] | N
 
 def choose_build_options() -> tuple[bool, float | None] | None:
     """(refine_cell, max_rmsd); None on cancel."""
-    refine_cell = questionary.confirm(
+    refine_cell: bool | None = questionary.confirm(
         "Refine the cell parameters? (recommended)", default=True
     ).ask()
     if refine_cell is None:
         return None
     max_rmsd = _pick_max_rmsd()
-    if max_rmsd == "cancel":
+    if isinstance(max_rmsd, str):  # "cancel"
         return None
     return refine_cell, max_rmsd
 
@@ -361,10 +364,10 @@ def choose_build_options() -> tuple[bool, float | None] | None:
 def run_build(
     session: Session,
     topology: Topology,
-    mappings: dict[Fragment, str],
+    mappings: dict[Fragment | int, Fragment | str],
     refine_cell: bool,
     max_rmsd: float | None,
-) -> tuple[Framework, dict[Fragment, str]] | None:
+) -> tuple[Framework, dict[Fragment | int, Fragment | str]] | None:
     """Build with an interactive recovery loop on alignment failure.
 
     Returns the framework together with the mappings actually used
@@ -499,7 +502,8 @@ def build_wizard(session: Session) -> None:
         return
     framework, mappings = result
     framework = maybe_stack(framework, topology)
-    export_step(framework, default_output_name(topology.name, list(mappings.values())))
+    sbu_names = [sbu if isinstance(sbu, str) else sbu.name for sbu in mappings.values()]
+    export_step(framework, default_output_name(topology.name, sbu_names))
 
 
 def browse_topologies(session: Session) -> None:
@@ -577,7 +581,7 @@ def batch_build(session: Session) -> None:
     if per_topology is None:
         return
     max_rmsd = _pick_max_rmsd()
-    if max_rmsd == "cancel":
+    if isinstance(max_rmsd, str):  # "cancel"
         return
     outdir = questionary.text("Output directory:", default="frameworks").ask()
     if outdir is None:

--- a/src/autografs/fragment.py
+++ b/src/autografs/fragment.py
@@ -151,6 +151,7 @@ class Fragment:
             Crystallographic orbit id for topology slots.
         """
         self._symmetry = symmetry
+        self._pointgroup: str | None
         if symmetry is not None:
             self._pointgroup = symmetry.sch_symbol
         else:
@@ -247,11 +248,11 @@ class Fragment:
         connectivity; compatibility and alignment both work on them.
         """
         dummy_idx = list(self.atoms.indices_from_symbol("X"))
-        dummies = self.atoms.cart_coords[dummy_idx]
+        dummies = np.asarray(self.atoms.cart_coords)[dummy_idx]
         arms = dummies - dummies.mean(axis=0)
         norms = np.linalg.norm(arms, axis=1, keepdims=True)
         norms[norms < 1e-12] = 1.0
-        return arms / norms
+        return np.asarray(arms / norms)
 
     @functools.cached_property
     def _shape_signature(self) -> np.ndarray:

--- a/src/autografs/framework.py
+++ b/src/autografs/framework.py
@@ -80,7 +80,7 @@ class Framework:
     # ------------------------------------------------------------------
 
     def __len__(self) -> int:
-        return self.graph.number_of_nodes()
+        return int(self.graph.number_of_nodes())
 
     def __repr__(self) -> str:
         abc = tuple(round(float(x), 2) for x in self.lattice.abc)
@@ -306,7 +306,7 @@ class Framework:
         stacked = networkx.Graph(cell=new_cell)
         stacked.add_nodes_from(self.graph.nodes(data=True))
         stacked.add_edges_from(self.graph.edges(data=True))
-        if n_layers == 2:
+        if offset is not None:
             shift = offset[0] * cell[0] + offset[1] * cell[1]
             shift[2] += interlayer
             relabel = len(self.graph)

--- a/src/autografs/topology_io.py
+++ b/src/autografs/topology_io.py
@@ -148,7 +148,9 @@ def topology_from_dict(name: str, data: dict) -> Topology:
         )
         equivalence_classes.append(slot_data.get("equivalence_class"))
     known_classes = (
-        equivalence_classes if all(c is not None for c in equivalence_classes) else None
+        [c for c in equivalence_classes if c is not None]
+        if all(c is not None for c in equivalence_classes)
+        else None
     )
     return Topology(
         name=name,

--- a/src/autografs/utils.py
+++ b/src/autografs/utils.py
@@ -65,6 +65,14 @@ def format_indices(iterable: Iterable[int]) -> str:
         return f"{lst[0]}"
 
 
+def _format_runs(indices: list[int]) -> str:
+    """Format sorted indices with consecutive runs grouped (e.g. "0-2,5")."""
+    counter = count()
+    # n - next(counter) is constant along a consecutive run
+    grouped = groupby(sorted(indices), lambda n: n - next(counter))
+    return ",".join(format_indices(g) for _, g in grouped)
+
+
 def format_mappings(mappings: dict[int, str]) -> str:
     """Format slot-to-SBU mappings into a readable string.
 
@@ -87,16 +95,12 @@ def format_mappings(mappings: dict[int, str]) -> str:
     >>> print(format_mappings(mappings))
     SBU_A : 0-2; SBU_B : 3
     """
-    new_dict = defaultdict(list)
-    for k, v in mappings.items():
-        new_dict[v].append(k)
+    new_dict: defaultdict[str, list[int]] = defaultdict(list)
+    for slot, sbu_name in mappings.items():
+        new_dict[sbu_name].append(slot)
     out_mappings = []
-    for k, v in new_dict.items():
-        v = sorted(v)
-        # fresh count() per lambda: consecutive-run grouping idiom
-        grouped_indices = groupby(v, lambda n, c=count(): n - next(c))  # noqa: B008
-        v = ",".join(format_indices(g) for _, g in grouped_indices)
-        out_mappings.append(f"{k} : {v}")
+    for sbu_name, slots in new_dict.items():
+        out_mappings.append(f"{sbu_name} : {_format_runs(slots)}")
     return "; ".join(out_mappings)
 
 


### PR DESCRIPTION
## Summary
Closes out the last in-plan leftover from the v3 roadmap (Step 6): burns the historical mypy error count from 47 to 0 and flips the CI typecheck job from advisory (`continue-on-error`) to blocking. The build job now also depends on it.

Most fixes are annotations, explicit narrowing, and untangling variable rebinding (`k, v` reused with different types, `topofile` rebound `str -> Path`, etc.). Three touch behavior in benign ways:

- **alignment.py** — `SlotPlacement.arm_for_target` is now a required constructor field instead of an `Optional` that was always assigned immediately after construction; `match_directions` seeds its refinement loop with an impossible-index sentinel instead of `perm=None`. Same numerics, honest types.
- **builder.py** — verbose build logging prints SBU names (`Zn_mof5 : 0-3`) instead of full `Fragment` reprs, matching the `format_mappings` docstring example.
- **cgd.py** — `build_group_lookup` raises a clear `RuntimeError` if pymatgen's `symm_data.json` package data is missing, instead of feeding `None` to `json.loads`.

Also extracted the consecutive-run grouping in `format_mappings` into a `_format_runs` helper, fixing a latent ruff B023 (loop-variable capture in a lambda).

## Verification
- `mypy src/autografs`: clean (was 47 errors in 8 files)
- `ruff check` + `ruff format --check`: clean
- Full test suite green, including the slow full-library build tests (`pytest -m slow`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)