### PR TITLE
Post-build overlap screening: Framework.min_contact + min_distance gate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,7 @@ slot indices) to SBUs, given as library names or ``Fragment`` objects:
         mappings={slot_type: "Zn_mof5_octahedral", edge_type: "Benzene_linear"},
         refine_cell=True,   # optimize cell parameters (default)
         max_rmsd=0.3,       # reject builds with bad shape matches
+        min_distance=1.0,   # reject builds with overlapping atoms
     )
 
 - ``max_rmsd`` gates the *directional* mismatch between an SBU's
@@ -141,6 +142,11 @@ slot indices) to SBUs, given as library names or ``Fragment`` objects:
   shape match). Incompatible geometry raises
   ``autografs.AlignmentError`` instead of returning a distorted
   structure.
+- ``min_distance`` screens the built structure: if any two non-bonded
+  atoms (all periodic images included) are closer than this many
+  Angstroms, ``autografs.OverlapError`` is raised instead of returning
+  overlapping or interpenetrating output. The same check is available
+  on any result as ``Framework.min_contact()``.
 - Slot indices (integers) may be used as mapping keys to place a
   specific SBU on a specific slot, overriding the slot-type choice.
 
@@ -151,6 +157,7 @@ To enumerate every compatible combination:
     frameworks = mofgen.build_all(
         topology_subset=["pcu", "dia", "srs"],
         max_rmsd=0.3,
+        min_distance=1.0,
     )
 
 Working with the result

--- a/progress.md
+++ b/progress.md
@@ -187,11 +187,28 @@ Run tests: `python -m pytest tests/ -q` (pytest config in pyproject handles `src
       spawn against serial results)
 - Deferred to post-PR branches (proper science features):
   - 2D plane-group nets for COFs (~200 nets; needs plane→space group
-    mapping + frozen-c cell parametrization + stacking options)
+    mapping + frozen-c cell parametrization + stacking options) — DONE
   - IZA zeolite framework import
   - RCSR data refresh (post-2019 nets)
   - bond-length-aware pair targets (MOF-5 12.77 vs exp 12.9)
-  - mypy burn-down (CI job advisory until clean)
+  - mypy burn-down (CI job advisory until clean) — DONE
+
+## Distance screening branch (v3_plan §3.6 sanity checks) — 2026-07-08
+Branch `distance-screening` (off `mypy-burndown`).
+- [x] `Framework.min_contact(cutoff=3.0)`: smallest periodic distance
+      between non-bonded atoms via Structure.get_neighbor_list — all
+      images included, so an atom too close to its own image in a
+      collapsed cell is caught; graph-bonded pairs exempt (at every
+      image). Returns inf when nothing is within cutoff.
+- [x] Opt-in `min_distance=` gate on build()/build_all()/
+      build_framework(): raises typed OverlapError (exported at package
+      level); build_all counts rejections as errors like max_rmsd.
+- [x] Verified get_neighbor_list semantics empirically: coincident
+      distinct atoms (d=0) and self-images survive; only the exact
+      self-pair is excluded.
+- Not done from §3.6: UFF relaxation via ASE — ASE ships no UFF
+  calculator, so this needs a dependency decision first.
+- CLI wizard intentionally untouched (no min-distance prompt yet).
 
 ## COF branch — 2D plane-group nets + stacking (cof_plan.md) — COMPLETE
 Branch `cof-implementation`, 2026-07-08. All five parts of cof_plan.md.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,10 @@ ignore = [
 known-first-party = ["autografs"]
 
 [tool.mypy]
-python_version = "3.11"
+# 3.12 target, not our 3.11 floor: current numpy stubs use PEP 695
+# `type` statements, which mypy refuses to parse below 3.12. Runtime
+# 3.11 compatibility is guarded by the CI test matrix instead.
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true

--- a/src/autografs/__init__.py
+++ b/src/autografs/__init__.py
@@ -64,13 +64,14 @@ __all__ = [
     "AutografsError",
     "Fragment",
     "Framework",
+    "OverlapError",
     "Topology",
 ]
 
 import logging
 
 from autografs.builder import Autografs
-from autografs.exceptions import AlignmentError, AutografsError
+from autografs.exceptions import AlignmentError, AutografsError, OverlapError
 from autografs.fragment import Fragment
 from autografs.framework import Framework
 from autografs.topology import Topology

--- a/src/autografs/builder.py
+++ b/src/autografs/builder.py
@@ -38,7 +38,7 @@ import autografs.alignment
 import autografs.data
 import autografs.topology_io
 import autografs.utils
-from autografs.exceptions import AlignmentError
+from autografs.exceptions import AlignmentError, OverlapError
 from autografs.fragment import Fragment
 from autografs.framework import Framework
 from autografs.topology import Topology
@@ -57,6 +57,7 @@ def build_framework(
     refine_cell: bool = True,
     verbose: bool = False,
     max_rmsd: float | None = None,
+    min_distance: float | None = None,
 ) -> Framework:
     """Build one framework from validated slot-index mappings.
 
@@ -79,6 +80,8 @@ def build_framework(
         Log alignment details.
     max_rmsd : float or None, optional
         Directional shape-mismatch gate; see Autografs.build.
+    min_distance : float or None, optional
+        Post-build overlap gate; see Autografs.build.
 
     Returns
     -------
@@ -128,19 +131,32 @@ def build_framework(
             f"\t[x] Aligned {len(best_alignment)} fragments in {time.time() - t0:.1f} seconds"
         )
     graph = autografs.utils.fragments_to_networkx(best_alignment, cell=lattice.matrix)
-    return Framework(graph, name=topology.name)
+    framework = Framework(graph, name=topology.name)
+    if min_distance is not None:
+        contact = framework.min_contact(cutoff=min_distance)
+        if contact < min_distance:
+            raise OverlapError(
+                f"Closest non-bonded contact is {contact:.2f} A, below "
+                f"min_distance={min_distance:.2f} A, on topology "
+                f"{topology.name}: overlapping or interpenetrating output."
+            )
+    return framework
 
 
 def _build_task(
-    args: tuple[Topology, dict[int, Fragment], bool, float | None],
+    args: tuple[Topology, dict[int, Fragment], bool, float | None, float | None],
 ) -> Framework | None:
     """Worker-safe build: expected failures become None, not raises."""
-    topology, mappings, refine_cell, max_rmsd = args
+    topology, mappings, refine_cell, max_rmsd, min_distance = args
     try:
         return build_framework(
-            topology, mappings, refine_cell=refine_cell, max_rmsd=max_rmsd
+            topology,
+            mappings,
+            refine_cell=refine_cell,
+            max_rmsd=max_rmsd,
+            min_distance=min_distance,
         )
-    except (AssertionError, AlignmentError, ValueError):
+    except (AssertionError, AlignmentError, OverlapError, ValueError):
         return None
 
 
@@ -242,6 +258,7 @@ class Autografs:
         topology_subset: list[str] | None = None,
         refine_cell: bool = True,
         max_rmsd: float | None = None,
+        min_distance: float | None = None,
         max_per_topology: int | None = None,
         seed: int | None = None,
         n_jobs: int = 1,
@@ -260,6 +277,10 @@ class Autografs:
         max_rmsd : float or None, optional
             Per-slot alignment RMSD gate forwarded to build(); rejected
             structures are counted as errors, by default None
+        min_distance : float or None, optional
+            Post-build overlap gate forwarded to build(); structures
+            with non-bonded atoms closer than this are counted as
+            errors, by default None
         max_per_topology : int or None, optional
             Cap on the SBU combinations attempted per topology. The
             full product over slot types explodes combinatorially on
@@ -306,7 +327,9 @@ class Autografs:
                         zip(slot_types, choice, strict=True)
                     )
                     validated = self._validate_mappings(topology=topology, mappings=raw)
-                    tasks.append((topology, validated, refine_cell, max_rmsd))
+                    tasks.append(
+                        (topology, validated, refine_cell, max_rmsd, min_distance)
+                    )
                 attempted += len(tasks)
                 results: Iterable[Framework | None]
                 if executor is None:
@@ -331,6 +354,7 @@ class Autografs:
         refine_cell: bool = True,
         verbose: bool = False,
         max_rmsd: float | None = None,
+        min_distance: float | None = None,
     ) -> Framework:
         """
         Generates a framework from a mapping of SBU to topology slots.
@@ -354,6 +378,12 @@ class Autografs:
             slot exceeds it, AlignmentError is raised instead of
             silently returning a distorted structure. None (default)
             disables the gate.
+        min_distance : float or None, optional
+            Minimum acceptable distance in Angstrom between non-bonded
+            atoms in the built framework, all periodic images
+            included. If any pair is closer, OverlapError is raised
+            instead of returning an overlapping or interpenetrating
+            structure. None (default) disables the screening.
 
         Returns
         -------
@@ -367,6 +397,9 @@ class Autografs:
         AlignmentError
             If an SBU's connection count does not match its slot, or if
             max_rmsd is set and any slot alignment exceeds it.
+        OverlapError
+            If min_distance is set and any non-bonded contact in the
+            output is closer than it.
         ValueError
             If the mappings leave topology slots unfilled.
         """
@@ -385,6 +418,7 @@ class Autografs:
             refine_cell=refine_cell,
             verbose=verbose,
             max_rmsd=max_rmsd,
+            min_distance=min_distance,
         )
 
     def _validate_mappings(

--- a/src/autografs/exceptions.py
+++ b/src/autografs/exceptions.py
@@ -22,3 +22,9 @@ class TopologyExtractionError(AutografsError):
 
 class StackingError(AutografsError):
     """Raised when a framework cannot be stacked as 2D layers."""
+
+
+class OverlapError(AutografsError):
+    """Raised when a built framework has non-bonded atoms closer than
+    the requested minimum distance (overlapping or interpenetrating
+    output)."""

--- a/src/autografs/framework.py
+++ b/src/autografs/framework.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import math
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -126,6 +127,44 @@ class Framework:
     def formula(self) -> str:
         """Chemical formula of the unit cell."""
         return self.structure.composition.formula
+
+    def min_contact(self, cutoff: float = 3.0) -> float:
+        """Smallest periodic distance between non-bonded atoms.
+
+        Screens for overlapping or interpenetrating output: every
+        periodic image is considered, so an atom sitting too close to
+        its own image in a collapsed cell is caught too. Pairs bonded
+        in the graph are exempt (at every image - a bonded pair is
+        never reported, even through a boundary).
+
+        Parameters
+        ----------
+        cutoff : float, optional
+            Search radius in Angstrom, by default 3.0. Contacts beyond
+            it are not examined.
+
+        Returns
+        -------
+        float
+            The smallest non-bonded contact distance found, or
+            ``math.inf`` when none is within ``cutoff``.
+        """
+        centers, points, _, distances = self.structure.get_neighbor_list(r=cutoff)
+        if len(distances) == 0:
+            return math.inf
+        # pair key = lo * n + hi; self-image contacts (i == i) can
+        # never collide with a bond key since the graph has no loops
+        n = len(self)
+        lo = np.minimum(centers, points).astype(np.int64)
+        hi = np.maximum(centers, points).astype(np.int64)
+        bonded = np.array(
+            sorted({min(i, j) * n + max(i, j) for i, j in self.graph.edges()}),
+            dtype=np.int64,
+        )
+        unbonded = ~np.isin(lo * n + hi, bonded)
+        if not unbonded.any():
+            return math.inf
+        return float(distances[unbonded].min())
 
     # ------------------------------------------------------------------
     # crystallographic exports

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -99,6 +99,91 @@ class TestFileExports:
         assert "library uff4mof" in gulp
 
 
+def _two_atom_framework(coords, bonded, cell_length=20.0):
+    """Two carbons at the given cartesian coords in a cubic cell."""
+    import networkx
+
+    from autografs.framework import Framework
+
+    graph = networkx.Graph(cell=np.diag([cell_length] * 3))
+    for i, coord in enumerate(coords):
+        graph.add_node(i, symbol="C", coord=np.array(coord), tag=0, ufftype="C_R")
+    if bonded:
+        graph.add_edge(0, 1, bond_order=1.0)
+    return Framework(graph, name="pair")
+
+
+class TestMinContact:
+    def test_close_nonbonded_pair_detected(self):
+        pair = _two_atom_framework([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]], bonded=False)
+        assert pair.min_contact() == pytest.approx(0.5)
+
+    def test_bonded_pair_exempt(self):
+        pair = _two_atom_framework([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]], bonded=True)
+        assert pair.min_contact() == np.inf
+
+    def test_own_periodic_image_detected(self):
+        import networkx
+
+        from autografs.framework import Framework
+
+        graph = networkx.Graph(cell=np.diag([2.0, 20.0, 20.0]))
+        graph.add_node(0, symbol="C", coord=np.zeros(3), tag=0, ufftype="C_R")
+        lone = Framework(graph, name="lone")
+        assert lone.min_contact() == pytest.approx(2.0)
+
+    def test_contact_through_boundary_detected(self):
+        # non-bonded atoms 1.0 A apart across the cell boundary
+        pair = _two_atom_framework([[0.2, 0.0, 0.0], [19.2, 0.0, 0.0]], bonded=False)
+        assert pair.min_contact() == pytest.approx(1.0)
+
+    def test_no_contact_within_cutoff(self):
+        pair = _two_atom_framework([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]], bonded=False)
+        assert pair.min_contact(cutoff=3.0) == np.inf
+
+    def test_mof5_contacts_are_physical(self, mof5):
+        # a correct MOF-5 prototype has no overlapping atoms: every
+        # non-bonded contact is above 1 A (shortest bonds are ~1 A)
+        contact = mof5.min_contact()
+        assert 1.0 < contact < 3.0
+
+
+class TestBuildDistanceGate:
+    @pytest.fixture(scope="class")
+    def mofgen(self):
+        from autografs import Autografs
+
+        return Autografs(topofile=FIXTURE_PATH)
+
+    def _mof5_mappings(self, topology):
+        mappings = {}
+        for key in topology.mappings:
+            conn = len(key.atoms.indices_from_symbol("X"))
+            mappings[key] = "Zn_mof5_octahedral" if conn == 6 else "Benzene_linear"
+        return mappings
+
+    def test_physical_build_passes_gate(self, mofgen):
+        topology = mofgen.topologies["pcu"]
+        framework = mofgen.build(
+            topology, mappings=self._mof5_mappings(topology), min_distance=1.0
+        )
+        assert len(framework) == 53
+
+    def test_impossible_threshold_raises(self, mofgen):
+        from autografs.exceptions import OverlapError
+
+        topology = mofgen.topologies["pcu"]
+        with pytest.raises(OverlapError, match="non-bonded contact"):
+            mofgen.build(
+                topology, mappings=self._mof5_mappings(topology), min_distance=5.0
+            )
+
+    def test_gate_off_by_default(self, mofgen):
+        topology = mofgen.topologies["pcu"]
+        framework = mofgen.build(topology, mappings=self._mof5_mappings(topology))
+        assert framework.min_contact() > 1.0
+
+
 @pytest.fixture
 def layer():
     """A hand-built flat layer in a padded slab, like a 2D build."""


### PR DESCRIPTION
## Summary
Implements the minimum-interatomic-distance screening from v3_plan §3.6 ("post-build sanity checks"): catch overlapping or interpenetrating output instead of returning it as if valid.

> **Note:** branched off `mypy-burndown`, so this PR includes #37's commit until that merges. Merge #37 first and this diff reduces to the screening change alone.

- **`Framework.min_contact(cutoff=3.0)`** — smallest periodic distance between non-bonded atoms, via `Structure.get_neighbor_list`. All periodic images are considered, so an atom sitting too close to its *own image* in a collapsed cell is caught too. Pairs bonded in the graph are exempt (at every image). Returns `inf` when nothing is within the cutoff.
- **`min_distance=` gate** on `build()`, `build_all()`, and `build_framework()` — opt-in (default `None`). If any non-bonded contact is closer, the new typed **`OverlapError`** (exported at package level) is raised instead of returning garbage; `build_all` counts rejections as errors, same as `max_rmsd`.
- README documents the new parameter next to `max_rmsd`.

`get_neighbor_list` semantics were verified empirically before relying on them: coincident distinct atoms (d=0) and self-image pairs survive the listing; only the exact self-pair is excluded.

**Deliberately out of scope:** the UFF-relaxation half of §3.6 — ASE ships no UFF calculator, so that needs a dependency decision first. The CLI wizard is also untouched (no min-distance prompt yet).

## Verification
- 9 new tests: close non-bonded pair, bonded-pair exemption, own-image detection, through-boundary contact, empty cutoff, MOF-5 physical-contact range, gate pass/fail/default-off on real fixture builds
- Full suite green including slow full-library builds; mypy clean (blocking after #37); ruff lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)