### PR TITLE
Bond-length pair targets: cell objective aims for covalent bond lengths

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,9 +46,9 @@ Highlights of version 3:
   labels are metadata, not gates, which makes low-symmetry vertices
   usable.
 - **Physically meaningful cells**: the cell is optimized so that
-  bonded connection points coincide. The MOF-5 prototype (pcu + Zn4O +
-  benzenedicarboxylate) comes out cubic at 12.8 Angstrom against the
-  experimental 12.9.
+  every inter-SBU bond sits at its covalent bond length. The MOF-5
+  prototype (pcu + Zn4O + benzenedicarboxylate) comes out cubic at
+  12.89 Angstrom against the experimental 12.9.
 - **Deterministic**: identical inputs give identical structures.
 
 Installation
@@ -94,7 +94,7 @@ Quickstart: MOF-5
 
     mof = mofgen.build(topology, mappings=mappings)
     print(mof)
-    # Framework('pcu', 'Zn4 H12 C24 O13', abc=(12.77, 12.77, 12.77))
+    # Framework('pcu', 'Zn4 H12 C24 O13', abc=(12.89, 12.89, 12.89))
 
     mof.write_cif("mof5.cif")
 
@@ -200,7 +200,7 @@ COF-1 prototype:
         )
 
     layer = mofgen.build(hcb, mappings=mappings)
-    print(layer)   # hexagonal layer, a = b = 15.6, gamma = 120
+    print(layer)   # hexagonal layer, a = b = 14.7, gamma = 120
 
     # turn the layer into a crystal by choosing the stacking
     cof = layer.stack(mode="AA", interlayer=3.35)   # eclipsed

--- a/progress.md
+++ b/progress.md
@@ -210,6 +210,26 @@ Branch `distance-screening` (off `mypy-burndown`).
   calculator, so this needs a dependency decision first.
 - CLI wizard intentionally untouched (no min-distance prompt yet).
 
+## Bond-length pair targets branch — 2026-07-08
+Branch `bond-length-targets`. Closes the Step 3 backlog item.
+- [x] The cell objective now targets one Cordero covalent bond length
+      between paired *anchors* (each dummy's nearest real atom — the
+      atoms that actually bond in the output), replacing dummy
+      coincidence, which hard-coded whatever bond the SBU library's
+      dummy placement implied (0.7 A dummies = 1.4 A bonds for every
+      element pair).
+- [x] Golden numbers: MOF-5 12.77 → **12.895 A** (exp. 12.9); COF-1
+      15.58 → **14.67 A** (exp. 15.0 — boroxine's dummy placement
+      implied a 1.9 A B-C bond; now pinned at Cordero 1.57, remaining
+      gap is SBU-internal geometry). Tests tightened accordingly +
+      new assertion that every tag-paired bond sits at its Cordero
+      target.
+- [x] initial_parameters() analytic seed updated to the same target
+      (still exact for uninodal isotropic nets).
+- All-dummy fragments (synthetic test SBUs) fall back to coincidence:
+  anchor = dummy, radius 0. Elements missing from the Cordero table
+  keep the half-bond convention (radius = dummy-anchor distance).
+
 ## COF branch — 2D plane-group nets + stacking (cof_plan.md) — COMPLETE
 Branch `cof-implementation`, 2026-07-08. All five parts of cof_plan.md.
 

--- a/src/autografs/alignment.py
+++ b/src/autografs/alignment.py
@@ -11,13 +11,18 @@ replacing the earlier pymatgen-object pipeline. Two ideas drive it:
    slot's unit arm vectors (Hungarian assignment + Kabsch, proper
    rotations only, so chiral SBUs are never silently mirrored).
 
-2. **Pair-coincidence cell objective.** Every blueprint dummy site is
+2. **Bond-length pair objective.** Every blueprint dummy site is
    shared by the two slots it connects (their tags coincide), and the
-   built structure bonds those two SBU dummies together. The correct
-   cell is therefore the one where paired dummy images coincide, and
-   the optimization objective is the RMS distance between paired
-   dummies - not the distance to blueprint positions, whose arbitrary
-   arm lengths previously pulled cubic nets into anisotropic cells.
+   built structure bonds the two SBU atoms that carried those dummies
+   (the *anchors*). The correct cell is therefore the one where each
+   paired anchor image sits one covalent bond length from its partner,
+   and the optimization objective is the RMS deviation of the paired
+   anchor distances from their Cordero covalent-radius targets - not
+   the distance to blueprint positions, whose arbitrary arm lengths
+   previously pulled cubic nets into anisotropic cells, and not dummy
+   coincidence, which hard-codes whatever bond length the SBU library's
+   dummy placement implies (0.7 A dummies = a 1.4 A bond for every
+   element pair; MOF-5 came out at 12.77 A instead of ~12.9).
 
 Everything is precomputed once per build into plain numpy arrays: the
 cell optimization loop runs no pymatgen construction and no deep
@@ -32,6 +37,7 @@ import logging
 from dataclasses import dataclass
 
 import numpy as np
+from pymatgen.analysis.local_env import CovalentRadius
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Molecule
 from scipy.optimize import linear_sum_assignment
@@ -320,6 +326,10 @@ class SlotPlacement:
     arm_lengths: np.ndarray  # (n,) SBU arm lengths, Angstrom
     sbu_center: np.ndarray  # (3,) SBU dummy centroid, cartesian
     dummy_indices: list[int]  # SBU atom index per arm
+    # per arm: the anchor is the SBU atom bonded through that arm (the
+    # dummy's nearest real atom); paired anchors bond in the output
+    anchor_vecs: np.ndarray  # (n, 3) anchor positions minus center, cartesian
+    anchor_radii: np.ndarray  # (n,) anchor covalent radii, Angstrom
     # arm assignment (perm) computed at the reference cell
     arm_for_target: np.ndarray
 
@@ -329,11 +339,11 @@ class SlotPlacement:
         ordered_arms = self.arm_units[self.arm_for_target]
         return kabsch(ordered_arms, directions), directions
 
-    def dummy_positions(self, matrix: np.ndarray) -> np.ndarray:
-        """Cartesian SBU dummy positions (target order) in this cell."""
+    def anchor_positions(self, matrix: np.ndarray) -> np.ndarray:
+        """Cartesian SBU anchor positions (target order) in this cell."""
         rotation, _ = self.rotation_for(matrix)
         center = self.frac_center @ matrix
-        ordered = (self.arm_units * self.arm_lengths[:, None])[self.arm_for_target]
+        ordered = self.anchor_vecs[self.arm_for_target]
         return np.asarray(center + ordered @ rotation.T)
 
 
@@ -370,12 +380,12 @@ class BuildPlan:
     def initial_parameters(self) -> np.ndarray:
         """Analytic starting parameters from bond-through distances.
 
-        Each dummy pair wants its two slot centers separated by the sum
-        of the two arm lengths; the blueprint separation scales with
-        the cell, so the ratio of sums is a near-optimal isotropic
-        starting scale (exact for uninodal cubic nets). The resulting
-        (a, b, c) guess is reduced to the crystal system's free
-        parameters.
+        Each anchor pair wants its two slot centers separated by the
+        center-to-anchor spans plus the bond length; the blueprint
+        separation scales with the cell, so the ratio of sums is a
+        near-optimal isotropic starting scale (exact for uninodal
+        cubic nets). The resulting (a, b, c) guess is reduced to the
+        crystal system's free parameters.
         """
         blueprint = self._blueprint_matrix
         required = 0.0
@@ -383,9 +393,12 @@ class BuildPlan:
         for index_a, target_a, index_b, target_b, offset in self.pairs:
             pa = self.placements[index_a]
             pb = self.placements[index_b]
-            required += float(
-                pa.arm_lengths[pa.arm_for_target[target_a]]
-                + pb.arm_lengths[pb.arm_for_target[target_b]]
+            span_a = np.linalg.norm(pa.anchor_vecs[pa.arm_for_target[target_a]])
+            span_b = np.linalg.norm(pb.anchor_vecs[pb.arm_for_target[target_b]])
+            required += (
+                float(span_a)
+                + float(span_b)
+                + self._pair_bond_length(index_a, target_a, index_b, target_b)
             )
             separation = (pa.frac_center - pb.frac_center - offset) @ blueprint
             current += float(np.linalg.norm(separation))
@@ -403,10 +416,22 @@ class BuildPlan:
             abc_guess = self.blueprint_abc * (required / current)
         return self.cell_param.seed(abc_guess)
 
+    def _pair_bond_length(
+        self, index_a: int, target_a: int, index_b: int, target_b: int
+    ) -> float:
+        """Target bond length between a pair's two anchors."""
+        pa = self.placements[index_a]
+        pb = self.placements[index_b]
+        return float(
+            pa.anchor_radii[pa.arm_for_target[target_a]]
+            + pb.anchor_radii[pb.arm_for_target[target_b]]
+        )
+
     def residual(self, free: np.ndarray) -> float:
-        """RMS distance between paired dummy images at these parameters."""
+        """RMS deviation of paired anchor distances from their bond
+        lengths at these parameters."""
         matrix = self.matrix_for(free)
-        positions = [p.dummy_positions(matrix) for p in self.placements]
+        positions = [p.anchor_positions(matrix) for p in self.placements]
         total = 0.0
         for index_a, target_a, index_b, target_b, offset in self.pairs:
             delta = (
@@ -414,7 +439,10 @@ class BuildPlan:
                 - positions[index_b][target_b]
                 - offset @ matrix
             )
-            total += float(delta @ delta)
+            gap = float(np.sqrt(delta @ delta)) - self._pair_bond_length(
+                index_a, target_a, index_b, target_b
+            )
+            total += gap * gap
         return float(np.sqrt(total / len(self.pairs)))
 
     def finalize(
@@ -465,6 +493,35 @@ class BuildPlan:
         return fragments, lattice, slot_rmsds
 
 
+def _find_anchors(
+    sbu: Fragment, dummy_indices: list[int], center: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Anchor vectors (relative to center) and covalent radii per arm.
+
+    The anchor of an arm is the real atom bonded through it - the
+    dummy's nearest non-dummy atom; the built structure bonds paired
+    anchors together, so the cell objective targets one covalent bond
+    length between them. A fragment with no real atoms (synthetic test
+    fixtures) falls back to the dummies themselves with zero radius,
+    which turns the pair objective back into dummy coincidence.
+    """
+    coords = np.asarray(sbu.atoms.cart_coords)
+    real = [i for i, site in enumerate(sbu.atoms) if site.specie.symbol != "X"]
+    if not real:
+        return coords[dummy_indices] - center, np.zeros(len(dummy_indices))
+    vecs = np.empty((len(dummy_indices), 3))
+    radii = np.empty(len(dummy_indices))
+    for k, dummy in enumerate(dummy_indices):
+        distances = np.linalg.norm(coords[real] - coords[dummy], axis=1)
+        nearest = real[int(np.argmin(distances))]
+        vecs[k] = coords[nearest] - center
+        symbol = sbu.atoms[nearest].specie.symbol
+        # an element missing from the Cordero table keeps the library's
+        # half-bond convention: the dummy sits half a bond from its anchor
+        radii[k] = CovalentRadius.radius.get(symbol, float(distances.min()))
+    return vecs, radii
+
+
 def prepare_build(topology: Topology, mappings: dict[int, Fragment]) -> BuildPlan:
     """Precompute all geometry for building one framework.
 
@@ -513,6 +570,7 @@ def prepare_build(topology: Topology, mappings: dict[int, Fragment]) -> BuildPla
         arm_vectors = sbu_dummies - sbu_center
         arm_lengths = np.linalg.norm(arm_vectors, axis=1)
         arm_units = _unit(arm_vectors)
+        anchor_vecs, anchor_radii = _find_anchors(sbu, sbu_dummy_idx, sbu_center)
 
         frac_arms = slot_frac - frac_center
         # reference assignment at the blueprint cell
@@ -528,6 +586,8 @@ def prepare_build(topology: Topology, mappings: dict[int, Fragment]) -> BuildPla
             arm_lengths=arm_lengths,
             sbu_center=sbu_center,
             dummy_indices=sbu_dummy_idx,
+            anchor_vecs=anchor_vecs,
+            anchor_radii=anchor_radii,
             arm_for_target=perm,
         )
         index = len(placements)

--- a/src/autografs/builder.py
+++ b/src/autografs/builder.py
@@ -92,7 +92,7 @@ def build_framework(
     plan = autografs.alignment.prepare_build(topology, mappings)
     x0 = plan.initial_parameters()
     if refine_cell and plan.has_pairs:
-        # Nelder-Mead on the pair-coincidence residual over the
+        # Nelder-Mead on the bond-length pair residual over the
         # crystal system's free parameters only (a cubic net
         # optimizes a single length); the objective is pure numpy,
         # no object copies per evaluation

--- a/tests/test_fixture_builds.py
+++ b/tests/test_fixture_builds.py
@@ -102,9 +102,9 @@ class TestGoldenBuilds:
         """pcu + Zn4O + benzene = the MOF-5 prototype.
 
         Golden regression for the directional alignment core: the
-        pair-coincidence objective must find the cubic MOF-5 cell
-        (experimental a = 12.9 A; the dummy-overlap convention of the
-        SBU library gives ~12.8).
+        bond-length pair objective must find the cubic MOF-5 cell
+        (experimental a = 12.9 A; the old dummy-coincidence objective
+        landed at 12.77 by hard-coding 1.4 A inter-fragment bonds).
         """
         topology = mofgen.topologies["pcu"]
         mappings = self._mappings_by_connectivity(
@@ -126,10 +126,23 @@ class TestGoldenBuilds:
         # like MOF-5
         abc = np.linalg.norm(framework.cell, axis=1)
         np.testing.assert_allclose(abc, abc[0], rtol=1e-3)
-        assert 12.0 < abc[0] < 13.5
+        assert 12.8 < abc[0] < 13.0
         # every atom bonded: no isolated nodes
         degrees = [d for _, d in framework.graph.degree()]
         assert min(degrees) >= 1
+        # inter-fragment (tag-paired) bonds sit at the Cordero C-C
+        # bond length, not at whatever the dummy placement implies
+        structure = framework.structure
+        tags = structure.site_properties["tags"]
+        by_tag = {}
+        for i, tag in enumerate(tags):
+            if tag > 0:
+                by_tag.setdefault(tag, []).append(i)
+        assert by_tag, "no inter-fragment bonds found"
+        for pair in by_tag.values():
+            assert len(pair) == 2
+            distance = structure.get_distance(*pair)
+            assert distance == pytest.approx(1.46, abs=0.02)
 
     def test_mof5_build_is_deterministic(self, mofgen):
         topology = mofgen.topologies["pcu"]
@@ -234,9 +247,12 @@ class TestGoldenBuilds:
         assert abs(lattice.alpha - 90.0) < 1e-12
         assert abs(lattice.beta - 90.0) < 1e-12
         assert lattice.c == pad_c
-        # COF-1 experimental a = 15.0 A (dummy-overlap convention
-        # lands slightly short, like MOF-5 at 12.77 vs 12.9)
-        assert 13.0 < lattice.a < 16.5
+        # COF-1 experimental a = 15.0 A. The bond-length pair objective
+        # gives ~14.7 with B-C pinned at the Cordero 1.57 A (the old
+        # dummy-coincidence objective overshot to 15.6 because the
+        # boroxine dummy placement implied a 1.9 A B-C bond); the
+        # remaining gap is SBU-internal geometry, not the cell fit
+        assert 14.3 < lattice.a < 15.1
 
         # layer planarity: everything in a thin window around z = 0.
         # The default Boroxine_triangle SBU is slightly pyramidal


### PR DESCRIPTION
## Summary
Closes the Step 3 backlog item ("bond-length-aware pair targets"). The cell-optimization objective previously made bonded fragments meet at *coincident dummies*, which silently hard-codes whatever bond length the SBU library's dummy placement implies — with the 0.7 Å dummy convention, every inter-fragment bond comes out at exactly 1.4 Å regardless of the elements involved.

The objective now targets **one Cordero covalent bond length between paired anchors** — each dummy's nearest real atom, i.e. the atoms that actually bond in the output graph. The analytic starting guess uses the same target and remains exact for uninodal isotropic nets.

## Golden numbers (both prototypes move toward experiment, from opposite sides)
| Prototype | Before | After | Experimental |
|---|---|---|---|
| MOF-5 (pcu + Zn4O + BDC) | 12.77 Å | **12.895 Å** | 12.9 Å |
| COF-1 (hcb + boroxine + benzene) | 15.58 Å | **14.67 Å** | 15.0 Å |

MOF-5's inter-fragment C–C bonds now sit at exactly 1.460 Å (Cordero C+C). COF-1 was previously *oversized* because the boroxine SBU's dummy placement implied a 1.9 Å B–C bond; it's now pinned at the Cordero 1.57 Å, and the remaining gap to experiment is SBU-internal geometry, not the cell fit.

## Behavior edges
- All-dummy fragments (synthetic test SBUs) fall back to the old coincidence objective (anchor = dummy, radius 0).
- Elements missing from the Cordero table keep the library's half-bond convention (radius = dummy-to-anchor distance).
- `finalize()` and the bond graph are untouched — only the cell objective and its seed changed.

## Verification
- MOF-5 golden test tightened to 12.8–13.0 Å plus a new assertion that every tag-paired bond sits at its Cordero target (±0.02 Å); COF-1 tightened to 14.3–15.1 Å
- Full suite green including slow full-library builds; mypy clean; ruff lint + format clean
- README numbers updated (12.89 / 14.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)