### PR TITLE
UFF4MOF relaxation: Framework.relax() through LAMMPS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,27 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: false
 
+  # end-to-end LAMMPS/UFF4MOF relaxation; separate job because the
+  # LAMMPS wheel is heavy and only this path needs it
+  relax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install package with relax extras
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,relax]"
+
+      - name: Run relaxation tests (including slow)
+        run: pytest tests/test_relax.py -m "slow or not slow" -v
+
   build:
     runs-on: ubuntu-latest
     needs: [lint, typecheck, test]

--- a/README.rst
+++ b/README.rst
@@ -176,6 +176,28 @@ Working with the result
     mof.graph              # networkx bond graph: symbols, coords,
                            # UFF4MOF atom types, bond orders, tags
 
+UFF4MOF relaxation
+------------------
+
+``relax`` optimizes the geometry and cell with the UFF4MOF force
+field through LAMMPS, in-process, and returns a new ``Framework``
+with the same bond graph:
+
+.. code-block:: bash
+
+    pip install "autografs[relax]"
+
+.. code-block:: python
+
+    relaxed = mof.relax()          # UFF4MOF, alternating cell + FIRE
+    relaxed.energy                 # kcal/mol per unit cell
+    relaxed.write_cif("relaxed.cif")
+
+Cells smaller than the non-bonded cutoff (12.5 Angstrom by default)
+are relaxed as an internal supercell and folded back transparently.
+On Windows, the LAMMPS wheel additionally needs the Microsoft MPI
+runtime (``winget install Microsoft.MSMPI``).
+
 2D COFs
 -------
 

--- a/progress.md
+++ b/progress.md
@@ -210,6 +210,29 @@ Branch `distance-screening` (off `mypy-burndown`).
   calculator, so this needs a dependency decision first.
 - CLI wizard intentionally untouched (no min-distance prompt yet).
 
+## LAMMPS/UFF4MOF relaxation branch — 2026-07-08
+Branch `lammps-relax`. Damien's decision: LAMMPS route ("we can be
+heavy but the FF relaxation is important"). Closes the second half of
+v3_plan §3.6.
+- [x] `Framework.relax(force_field="UFF4MOF", cutoff=12.5)`:
+      lammps-interface types + generates inputs (its CLI flow driven
+      programmatically via a staged sys.argv), LAMMPS python module
+      runs the alternating box-relax/FIRE minimization in-process.
+      Returns a new Framework, same bond graph, relaxed coords + cell,
+      `.energy` in kcal/mol per unit cell.
+- [x] Supercell fold-back: lammps-interface replicates small cells for
+      the cutoff; relaxation preserves translational symmetry, so the
+      primitive cell is the supercell / replication counts and atoms
+      map back by species-constrained min-image linear_sum_assignment
+      (never trust atom ordering).
+- [x] Optional extras `autografs[relax]`; typed RelaxationError; CI
+      `relax` job (ubuntu) runs the real end-to-end minimization.
+- Windows: LAMMPS pip wheel needs the MS-MPI runtime (not installed
+  on this machine — admin prompt; local runs raise a helpful
+  RelaxationError at runtime load, everything upstream verified).
+- lammps-interface prompts interactively (input()) if it detects free
+  molecules; relax() converts the EOFError to RelaxationError.
+
 ## Bond-length pair targets branch — 2026-07-08
 Branch `bond-length-targets`. Closes the Step 3 backlog item.
 - [x] The cell objective now targets one Cordero covalent bond length

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,12 @@ docs = [
     "sphinx-rtd-theme>=2.0.0",
     "myst-parser>=3.0.0",
 ]
+# UFF4MOF relaxation backend (Framework.relax). On Windows the LAMMPS
+# wheel additionally requires the Microsoft MPI runtime.
+relax = [
+    "lammps-interface>=0.2.2",
+    "lammps",
+]
 
 [project.urls]
 Homepage = "https://github.com/DCoupry/autografs"

--- a/src/autografs/__init__.py
+++ b/src/autografs/__init__.py
@@ -59,19 +59,26 @@ __all__ = [
     "topology_io",
     "builder",
     "exceptions",
+    "relax",
     "Autografs",
     "AlignmentError",
     "AutografsError",
     "Fragment",
     "Framework",
     "OverlapError",
+    "RelaxationError",
     "Topology",
 ]
 
 import logging
 
 from autografs.builder import Autografs
-from autografs.exceptions import AlignmentError, AutografsError, OverlapError
+from autografs.exceptions import (
+    AlignmentError,
+    AutografsError,
+    OverlapError,
+    RelaxationError,
+)
 from autografs.fragment import Fragment
 from autografs.framework import Framework
 from autografs.topology import Topology

--- a/src/autografs/exceptions.py
+++ b/src/autografs/exceptions.py
@@ -28,3 +28,8 @@ class OverlapError(AutografsError):
     """Raised when a built framework has non-bonded atoms closer than
     the requested minimum distance (overlapping or interpenetrating
     output)."""
+
+
+class RelaxationError(AutografsError):
+    """Raised when the optional LAMMPS relaxation backend is missing
+    or a framework cannot be relaxed."""

--- a/src/autografs/framework.py
+++ b/src/autografs/framework.py
@@ -61,6 +61,9 @@ class Framework:
         ``bond_order``. Source of truth for connectivity.
     name : str
         Human-readable identifier, usually the topology name.
+    energy : float or None
+        Force-field energy per unit cell in kcal/mol; set by
+        ``relax()``, None for as-built frameworks.
     """
 
     def __init__(self, graph: networkx.Graph, name: str = "framework") -> None:
@@ -75,6 +78,7 @@ class Framework:
         """
         self.graph = graph
         self.name = name
+        self.energy: float | None = None
 
     # ------------------------------------------------------------------
     # basic views
@@ -248,6 +252,52 @@ class Framework:
         from ase.visualize import view
 
         view(self.to_ase())
+
+    def relax(
+        self,
+        force_field: str = "UFF4MOF",
+        cutoff: float = 12.5,
+        verbose: bool = False,
+    ) -> Framework:
+        """Relax geometry and cell with LAMMPS (UFF4MOF by default).
+
+        Requires the optional backends: ``pip install "autografs[relax]"``
+        (on Windows the LAMMPS wheel also needs the Microsoft MPI
+        runtime). Runs the lammps-interface minimization protocol
+        (alternating cell box-relax and FIRE) in-process and maps the
+        relaxed geometry back onto this framework's bond graph.
+
+        Parameters
+        ----------
+        force_field : str, optional
+            Force field known to lammps-interface, by default
+            "UFF4MOF"; "UFF" and "Dreiding" also work.
+        cutoff : float, optional
+            Non-bonded cutoff in Angstrom, by default 12.5. Cells too
+            small for it are relaxed as an internal supercell and
+            folded back.
+        verbose : bool, optional
+            Pass the backend output through instead of suppressing it.
+
+        Returns
+        -------
+        Framework
+            A new Framework with identical connectivity, relaxed
+            coordinates and cell, and the force-field energy per unit
+            cell (kcal/mol) in ``.energy``. This framework is
+            unchanged.
+
+        Raises
+        ------
+        RelaxationError
+            If the backends are missing or the structure cannot be
+            relaxed and mapped back.
+        """
+        from autografs.relax import relax_framework
+
+        return relax_framework(
+            self, force_field=force_field, cutoff=cutoff, verbose=verbose
+        )
 
     # ------------------------------------------------------------------
     # layer stacking

--- a/src/autografs/relax.py
+++ b/src/autografs/relax.py
@@ -1,0 +1,317 @@
+"""
+UFF4MOF relaxation of built frameworks through LAMMPS.
+
+lammps-interface (Boyd & Woo) types the framework and generates LAMMPS
+inputs for the requested force field (UFF4MOF by default - the same
+parameter set the rest of AuToGraFS speaks); the LAMMPS python module
+then runs the alternating box-relax / FIRE minimization those inputs
+define, in-process. The relaxed geometry is mapped back onto the
+framework's bond graph, so the result is a normal Framework with the
+same connectivity and updated coordinates, cell, and energy.
+
+Both backends are optional::
+
+    pip install "autografs[relax]"
+
+On Windows, the LAMMPS wheel additionally needs the Microsoft MPI
+runtime (https://learn.microsoft.com/en-us/message-passing-interface/microsoft-mpi).
+
+Notes
+-----
+lammps-interface replicates cells too small for the non-bonded cutoff
+into a supercell. The relaxation preserves translational symmetry
+(periodic starting point, deterministic minimizer), so the supercell
+folds back exactly: the primitive cell is the relaxed supercell scaled
+by the replication counts, and every atom maps onto its nearest
+relaxed image, species-constrained and one-to-one.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import logging
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import networkx
+import numpy as np
+from scipy.optimize import linear_sum_assignment
+
+from autografs.exceptions import RelaxationError
+
+if TYPE_CHECKING:
+    from autografs.framework import Framework
+
+logger = logging.getLogger(__name__)
+
+# leading element symbol of a UFF4MOF type: C_R -> C, Zn4+2 -> Zn
+_ELEMENT_OF_TYPE = re.compile(r"^([A-Z][a-z]?)")
+
+
+def _import_backends():
+    """Import the optional LAMMPS backends with a helpful error."""
+    try:
+        import lammps
+        from lammps_interface.InputHandler import Options
+        from lammps_interface.lammps_main import LammpsSimulation
+        from lammps_interface.structure_data import from_CIF
+    except ImportError as exc:
+        raise RelaxationError(
+            "UFF4MOF relaxation needs the optional LAMMPS backend: "
+            'pip install "autografs[relax]". On Windows, the LAMMPS '
+            "wheel also needs the Microsoft MPI runtime."
+        ) from exc
+    return lammps, Options, LammpsSimulation, from_CIF
+
+
+def _make_options(options_cls, cif_path: str, force_field: str, cutoff: float):
+    """Build a lammps-interface Options object programmatically.
+
+    Options parses sys.argv, so the CLI arguments are staged there for
+    the duration of the call; this tracks their schema instead of
+    duplicating every default the simulation object reads.
+    """
+    staged = [
+        "lammps-interface",
+        "--minimize",
+        "--force_field",
+        force_field,
+        "--cutoff",
+        str(cutoff),
+        cif_path,
+    ]
+    original = sys.argv
+    sys.argv = staged
+    try:
+        return options_cls()
+    finally:
+        sys.argv = original
+
+
+def _parse_type_elements(data_file: Path) -> dict[int, str]:
+    """LAMMPS atom type id -> element, from the data file Masses block.
+
+    lammps-interface comments every Masses line with the force-field
+    type (``1 12.0107 # C_R``); the element is its leading symbol.
+    """
+    elements: dict[int, str] = {}
+    in_masses = False
+    for line in data_file.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Masses"):
+            in_masses = True
+            continue
+        if in_masses:
+            if not stripped:
+                if elements:
+                    break
+                continue
+            parts = stripped.split()
+            if not parts[0].isdigit():
+                break
+            if "#" not in stripped:
+                raise RelaxationError(
+                    f"Masses line without a type comment in {data_file.name}: "
+                    f"{stripped!r}"
+                )
+            fftype = stripped.split("#", 1)[1].split()[0]
+            match = _ELEMENT_OF_TYPE.match(fftype)
+            if match is None:
+                raise RelaxationError(f"Cannot read an element from {fftype!r}.")
+            elements[int(parts[0])] = match.group(1)
+    if not elements:
+        raise RelaxationError(f"No Masses block found in {data_file.name}.")
+    return elements
+
+
+def _match_displacements(
+    orig_frac: np.ndarray,
+    orig_species: list[str],
+    relaxed_frac: np.ndarray,
+    relaxed_species: list[str],
+    cell: np.ndarray,
+) -> np.ndarray:
+    """Fractional displacement of each original atom to its relaxed image.
+
+    Assignment is species-constrained, one-to-one, and minimum-image:
+    supercell replicas of the same source atom fold onto (nearly) the
+    same fractional position, so any replica is a valid match.
+
+    Parameters
+    ----------
+    orig_frac : np.ndarray
+        (n, 3) wrapped fractional coordinates of the original atoms.
+    orig_species, relaxed_species : list[str]
+        Element symbols of both sets.
+    relaxed_frac : np.ndarray
+        (m, 3) wrapped fractional coordinates of the relaxed atoms in
+        the primitive cell (m = n * replicas).
+    cell : np.ndarray
+        (3, 3) primitive cell matrix, used as the distance metric.
+
+    Returns
+    -------
+    np.ndarray
+        (n, 3) fractional displacements, minimum-image.
+    """
+    displacements = np.zeros_like(orig_frac)
+    relaxed_species_arr = np.array(relaxed_species)
+    for symbol in sorted(set(orig_species)):
+        rows = np.flatnonzero(np.array(orig_species) == symbol)
+        cols = np.flatnonzero(relaxed_species_arr == symbol)
+        if len(cols) < len(rows):
+            raise RelaxationError(
+                f"Relaxed structure has {len(cols)} {symbol} atoms for "
+                f"{len(rows)} originals; the atom mapping is inconsistent."
+            )
+        delta = relaxed_frac[cols][None, :, :] - orig_frac[rows][:, None, :]
+        delta -= np.round(delta)
+        cost = np.linalg.norm(delta @ cell, axis=2)
+        row_idx, col_idx = linear_sum_assignment(cost)
+        displacements[rows[row_idx]] = delta[row_idx, col_idx]
+    return displacements
+
+
+def relax_framework(
+    framework: Framework,
+    force_field: str = "UFF4MOF",
+    cutoff: float = 12.5,
+    verbose: bool = False,
+) -> Framework:
+    """Relax a framework's geometry and cell with LAMMPS.
+
+    Parameters
+    ----------
+    framework : Framework
+        The framework to relax; not modified.
+    force_field : str, optional
+        Force field passed to lammps-interface, by default "UFF4MOF".
+        Other options include "UFF" and "Dreiding".
+    cutoff : float, optional
+        Non-bonded cutoff in Angstrom, by default 12.5. Cells too
+        small for it are replicated into a supercell internally and
+        folded back afterwards.
+    verbose : bool, optional
+        Pass the lammps-interface and LAMMPS output through instead of
+        suppressing it.
+
+    Returns
+    -------
+    Framework
+        A new Framework with the same bond graph, relaxed coordinates
+        and cell, and the UFF energy per unit cell (kcal/mol) in
+        ``.energy``.
+
+    Raises
+    ------
+    RelaxationError
+        If the optional backends are missing, the structure contains
+        free molecules lammps-interface cannot handle unattended, or
+        the relaxed atoms cannot be mapped back onto the graph.
+    """
+    lammps, options_cls, simulation_cls, from_cif = _import_backends()
+    # lammps-interface derives every file name from the cif basename
+    safe_name = re.sub(r"[^A-Za-z0-9_-]", "_", framework.name) or "framework"
+    sink = io.StringIO()
+    quiet: contextlib.AbstractContextManager = (
+        contextlib.nullcontext() if verbose else contextlib.redirect_stdout(sink)
+    )
+    with tempfile.TemporaryDirectory(prefix="autografs_relax_") as tmp:
+        workdir = Path(tmp)
+        cif_path = workdir / f"{safe_name}.cif"
+        framework.write_cif(cif_path)
+        options = _make_options(options_cls, str(cif_path), force_field, cutoff)
+        try:
+            with quiet:
+                sim = simulation_cls(options)
+                cell, graph = from_cif(str(cif_path))
+                sim.set_cell(cell)
+                sim.set_graph(graph)
+                sim.split_graph()
+                sim.assign_force_fields()
+                sim.compute_simulation_size()
+                sim.merge_graphs()
+                sim.write_lammps_files(wd=str(workdir))
+        except EOFError as exc:
+            # compute_simulation_size prompts interactively when it
+            # detects free molecules; there is no API to answer it
+            raise RelaxationError(
+                f"lammps-interface found free molecules in "
+                f"{framework.name!r}; relax() only handles connected "
+                "frameworks."
+            ) from exc
+        supercell = np.array(sim.supercell, dtype=int)
+        type_elements = _parse_type_elements(workdir / f"data.{safe_name}")
+
+        try:
+            lmp = lammps.lammps(cmdargs=["-log", "none", "-screen", "none"])
+        except OSError as exc:
+            raise RelaxationError(
+                "The LAMMPS runtime failed to load. On Windows, the "
+                "LAMMPS wheel needs the Microsoft MPI runtime "
+                "(winget install Microsoft.MSMPI)."
+            ) from exc
+        try:
+            with quiet, contextlib.chdir(workdir):
+                lmp.file(f"in.{safe_name}")
+            # gather_atoms orders by atom id, matching the data file
+            natoms = lmp.get_natoms()
+            raw_x = lmp.gather_atoms("x", 1, 3)
+            raw_t = lmp.gather_atoms("type", 0, 1)
+            positions = np.array(raw_x[:], dtype=float).reshape(natoms, 3)
+            types = np.array(raw_t[:], dtype=int)
+            (xlo, ylo, zlo), (xhi, yhi, zhi), xy, yz, xz, *_ = lmp.extract_box()
+            energy = float(lmp.get_thermo("pe"))
+        finally:
+            lmp.close()
+
+    # LAMMPS convention: lattice vectors are the rows of a lower
+    # triangular matrix; the primitive cell is the supercell scaled
+    # down by the replication counts
+    super_matrix = np.array(
+        [
+            [xhi - xlo, 0.0, 0.0],
+            [xy, yhi - ylo, 0.0],
+            [xz, yz, zhi - zlo],
+        ]
+    )
+    prim_matrix = super_matrix / supercell[:, None]
+    relaxed_frac = (positions @ np.linalg.inv(prim_matrix)) % 1.0
+    relaxed_species = [type_elements[t] for t in types]
+
+    orig_cell = framework.cell
+    orig_frac = framework.cart_coords @ np.linalg.inv(orig_cell)
+    displacements = _match_displacements(
+        orig_frac % 1.0,
+        framework.symbols,
+        relaxed_frac,
+        relaxed_species,
+        prim_matrix,
+    )
+    moved = np.linalg.norm(displacements @ prim_matrix, axis=1)
+    logger.info(
+        f"Relaxed {framework.name!r} with {force_field}: energy "
+        f"{energy / supercell.prod():.1f} kcal/mol per cell, max atom "
+        f"displacement {moved.max():.2f} A."
+    )
+    # displacements apply to the unwrapped coordinates unchanged, so
+    # bonded atoms stay cartesian neighbors in the graph
+    new_frac = orig_frac + displacements
+    new_coords = new_frac @ prim_matrix
+
+    relaxed = networkx.Graph(cell=prim_matrix)
+    relaxed.add_edges_from(framework.graph.edges(data=True))
+    # cart_coords (and therefore new_coords) follow sorted node order
+    for row, node in enumerate(sorted(framework.graph)):
+        copied = dict(framework.graph.nodes[node])
+        copied["coord"] = new_coords[row]
+        relaxed.add_node(node, **copied)
+    from autografs.framework import Framework as FrameworkCls
+
+    result = FrameworkCls(relaxed, name=framework.name)
+    result.energy = energy / float(supercell.prod())
+    return result

--- a/tests/test_relax.py
+++ b/tests/test_relax.py
@@ -1,0 +1,146 @@
+"""
+Tests for the LAMMPS/UFF4MOF relaxation layer (autografs.relax).
+
+The mapping helpers are pure numpy and always run. The end-to-end
+relaxation needs the optional backends (pip install autografs[relax])
+plus a loadable LAMMPS runtime, and is exercised in CI's relax job;
+it skips cleanly anywhere the runtime is unavailable (e.g. Windows
+without the Microsoft MPI redistributable).
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+from autografs.exceptions import RelaxationError
+from autografs.relax import _match_displacements, _parse_type_elements
+
+FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "data", "topologies_fixture.json"
+)
+
+
+class TestMatchDisplacements:
+    def test_recovers_small_displacements(self):
+        rng = np.random.default_rng(7)
+        cell = np.diag([10.0, 10.0, 10.0])
+        orig = np.array([[0.1, 0.1, 0.1], [0.5, 0.5, 0.5], [0.9, 0.2, 0.7]])
+        species = ["C", "C", "O"]
+        shift = rng.uniform(-0.02, 0.02, orig.shape)
+        relaxed = (orig + shift) % 1.0
+        found = _match_displacements(orig, species, relaxed, species, cell)
+        np.testing.assert_allclose(found, shift, atol=1e-12)
+
+    def test_replicas_fold_onto_originals(self):
+        # 8 supercell replicas of each atom fold to the same fractional
+        # position; any replica is an acceptable match
+        cell = np.diag([10.0, 10.0, 10.0])
+        orig = np.array([[0.25, 0.25, 0.25]])
+        relaxed = np.tile(orig + 0.01, (8, 1)) % 1.0
+        found = _match_displacements(orig, ["C"], relaxed, ["C"] * 8, cell)
+        np.testing.assert_allclose(found, [[0.01, 0.01, 0.01]], atol=1e-12)
+
+    def test_minimum_image_across_boundary(self):
+        cell = np.diag([10.0, 10.0, 10.0])
+        orig = np.array([[0.99, 0.5, 0.5]])
+        relaxed = np.array([[0.01, 0.5, 0.5]])
+        found = _match_displacements(orig, ["C"], relaxed, ["C"], cell)
+        np.testing.assert_allclose(found, [[0.02, 0.0, 0.0]], atol=1e-12)
+
+    def test_species_constrained(self):
+        # the nearest atom is the wrong element; matching must skip it
+        cell = np.diag([10.0, 10.0, 10.0])
+        orig = np.array([[0.5, 0.5, 0.5]])
+        relaxed = np.array([[0.51, 0.5, 0.5], [0.6, 0.5, 0.5]])
+        found = _match_displacements(orig, ["C"], relaxed, ["O", "C"], cell)
+        np.testing.assert_allclose(found, [[0.1, 0.0, 0.0]], atol=1e-12)
+
+    def test_missing_species_raises(self):
+        cell = np.eye(3)
+        with pytest.raises(RelaxationError, match="0 C atoms"):
+            _match_displacements(
+                np.array([[0.5, 0.5, 0.5]]),
+                ["C"],
+                np.array([[0.5, 0.5, 0.5]]),
+                ["O"],
+                cell,
+            )
+
+
+class TestParseTypeElements:
+    def test_reads_masses_block(self, tmp_path):
+        data = tmp_path / "data.test"
+        data.write_text(
+            "test data file\n\n"
+            "2 atom types\n\n"
+            "Masses\n\n"
+            "1 12.0107 # C_R\n"
+            "2 65.38 # Zn4+2\n\n"
+            "Bond Coeffs\n\n"
+            "1 100.0 1.4\n"
+        )
+        assert _parse_type_elements(data) == {1: "C", 2: "Zn"}
+
+    def test_missing_block_raises(self, tmp_path):
+        data = tmp_path / "data.test"
+        data.write_text("no masses here\n")
+        with pytest.raises(RelaxationError, match="Masses"):
+            _parse_type_elements(data)
+
+
+def _lammps_runtime_available() -> bool:
+    """True when the optional backends import AND the runtime loads."""
+    try:
+        import lammps
+        import lammps_interface  # noqa: F401
+
+        lmp = lammps.lammps(cmdargs=["-log", "none", "-screen", "none"])
+        lmp.close()
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not _lammps_runtime_available(),
+    reason="LAMMPS backend not installed or runtime not loadable",
+)
+class TestRelaxIntegration:
+    @pytest.fixture(scope="class")
+    def mof5(self):
+        from autografs import Autografs
+
+        mofgen = Autografs(topofile=FIXTURE_PATH)
+        topology = mofgen.topologies["pcu"]
+        mappings = {}
+        for key in topology.mappings:
+            conn = len(key.atoms.indices_from_symbol("X"))
+            mappings[key] = "Zn_mof5_octahedral" if conn == 6 else "Benzene_linear"
+        return mofgen.build(topology, mappings=mappings)
+
+    def test_relax_mof5(self, mof5):
+        relaxed = mof5.relax()
+        # same graph: atom count, species, bonds untouched
+        assert len(relaxed) == len(mof5)
+        assert relaxed.symbols == mof5.symbols
+        assert sorted(relaxed.graph.edges()) == sorted(mof5.graph.edges())
+        # the input framework is untouched
+        assert mof5.energy is None
+        # energy recorded per unit cell
+        assert isinstance(relaxed.energy, float)
+        # UFF4MOF keeps MOF-5 cubic and near the experimental cell
+        abc = np.array(relaxed.lattice.abc)
+        np.testing.assert_allclose(abc, abc[0], rtol=0.02)
+        assert 12.0 < abc[0] < 14.0
+        # relaxation is a perturbation, not a rebuild
+        moved = np.linalg.norm(relaxed.cart_coords - mof5.cart_coords, axis=1)
+        assert moved.max() < 1.5
+        # still no overlapping atoms
+        assert relaxed.min_contact() > 1.0
+
+    def test_relaxed_framework_exports(self, mof5, tmp_path):
+        relaxed = mof5.relax()
+        path = relaxed.write_cif(tmp_path / "relaxed.cif")
+        assert path.exists()


### PR DESCRIPTION
## Summary
Implements the FF-relaxation half of v3_plan §3.6 via the agreed LAMMPS route. `Framework.relax()` optimizes geometry + cell with **UFF4MOF** (the same parameter set the rest of the pipeline speaks) and returns a new `Framework` with identical connectivity, relaxed coordinates/cell, and `.energy` (kcal/mol per unit cell).

**Pipeline:** write CIF → [lammps-interface](https://github.com/peteboyd/lammps_interface) types the structure and emits its alternating box-relax/FIRE minimization protocol → the LAMMPS python module runs it in-process → the relaxed state is mapped back onto the bond graph.

**The non-obvious part — supercell fold-back:** lammps-interface replicates cells too small for the 12.5 Å non-bonded cutoff (MOF-5 becomes 2×2×2). Starting from an exactly periodic configuration with a deterministic minimizer, the relaxation preserves translational symmetry, so the primitive cell is exactly the relaxed supercell divided by the replication counts, and every original atom is matched to its nearest relaxed image by species-constrained minimum-image `linear_sum_assignment` — no reliance on atom ordering anywhere. Displacements are applied to the unwrapped graph coordinates, so bonded atoms stay cartesian neighbors.

**Packaging:** optional extras `pip install "autografs[relax]"` (lammps-interface + LAMMPS pip wheels). On Windows the wheel needs the MS-MPI runtime; the load failure becomes a typed `RelaxationError` telling the user exactly that (`winget install Microsoft.MSMPI`). lammps-interface's interactive free-molecule prompt is converted to a `RelaxationError` as well.

## Verification
- Mapping helpers are pure numpy with direct unit tests (displacement recovery, replica folding, boundary min-image, species constraint).
- End-to-end MOF-5 relaxation test (graph invariance, cubic cell retained near 12.9 Å, bounded displacements, `min_contact` still clean) runs in a new dedicated **CI `relax` job** on ubuntu — this Windows dev machine can't load the LAMMPS wheel without an admin MS-MPI install, so CI is the execution validator; everything upstream of the LAMMPS launch was verified locally end-to-end.
- mypy clean, ruff clean, full fast suite green (LAMMPS tests skip cleanly where the runtime is absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)