### PR TITLE
Clear errors for bad XYZ input; explicit __all__ per module

### DIFF
--- a/src/autografs/alignment.py
+++ b/src/autografs/alignment.py
@@ -47,6 +47,15 @@ from autografs.exceptions import AlignmentError
 from autografs.fragment import Fragment
 from autografs.topology import Topology
 
+__all__ = [
+    "kabsch",
+    "match_directions",
+    "CellParametrization",
+    "SlotPlacement",
+    "BuildPlan",
+    "prepare_build",
+]
+
 logger = logging.getLogger(__name__)
 
 # Deterministic rotation multi-start for the direction matcher: the 24

--- a/src/autografs/builder.py
+++ b/src/autografs/builder.py
@@ -10,6 +10,11 @@ Classes
 Autografs
     Main framework maker class for generating structures.
 
+Functions
+---------
+build_framework
+    Library-independent build core, usable from worker processes.
+
 Examples
 --------
 >>> from autografs.builder import Autografs
@@ -42,6 +47,11 @@ from autografs.exceptions import AlignmentError, OverlapError
 from autografs.fragment import Fragment
 from autografs.framework import Framework
 from autografs.topology import Topology
+
+__all__ = [
+    "Autografs",
+    "build_framework",
+]
 
 logger = logging.getLogger(__name__)
 

--- a/src/autografs/editing.py
+++ b/src/autografs/editing.py
@@ -34,6 +34,15 @@ from pymatgen.core.structure import FunctionalGroups, Molecule
 import autografs.utils
 from autografs.framework import Framework
 
+__all__ = [
+    "rotate_sbu",
+    "flip_sbu",
+    "make_supercell",
+    "make_defects",
+    "functionalizable_sites",
+    "functionalize",
+]
+
 logger = logging.getLogger(__name__)
 
 # maximum out-of-plane deviation (Angstrom) for the anchors of a

--- a/src/autografs/fragment.py
+++ b/src/autografs/fragment.py
@@ -34,6 +34,10 @@ from scipy.spatial.distance import pdist
 if TYPE_CHECKING:
     pass
 
+__all__ = [
+    "Fragment",
+]
+
 logger = logging.getLogger(__name__)
 
 # Tolerance for point group symmetry detection on dummy arrangements

--- a/src/autografs/framework.py
+++ b/src/autografs/framework.py
@@ -38,6 +38,10 @@ if TYPE_CHECKING:
     import ase
     from pymatgen.core.structure import Molecule
 
+__all__ = [
+    "Framework",
+]
+
 logger = logging.getLogger(__name__)
 
 # graphite-like default; typical COF interlayer range is 3.3-3.6 A

--- a/src/autografs/topology.py
+++ b/src/autografs/topology.py
@@ -27,6 +27,10 @@ from pymatgen.core.structure import Molecule
 
 from autografs.fragment import Fragment
 
+__all__ = [
+    "Topology",
+]
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/autografs/topology_io.py
+++ b/src/autografs/topology_io.py
@@ -31,6 +31,14 @@ from pymatgen.core.structure import Molecule
 from autografs.fragment import Fragment
 from autografs.topology import Topology
 
+__all__ = [
+    "LazyTopologyLibrary",
+    "topology_to_dict",
+    "topology_from_dict",
+    "save_topologies",
+    "load_topologies",
+]
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/autografs/utils.py
+++ b/src/autografs/utils.py
@@ -50,6 +50,19 @@ from pymatgen.io.xyz import XYZ
 from autografs.data.uff4mof import UFF4MOF, UFFType
 from autografs.fragment import Fragment
 
+__all__ = [
+    "format_mappings",
+    "get_xyz_names",
+    "xyz_to_sbu",
+    "load_uff_lib",
+    "find_element_cutoffs",
+    "find_mmtypes",
+    "fragment_to_molgraph",
+    "fragments_to_networkx",
+    "view_graph",
+    "networkx_to_gulp",
+]
+
 logger = logging.getLogger(__name__)
 
 # Constants for molecular analysis
@@ -163,16 +176,34 @@ def xyz_to_sbu(path: str) -> dict[str, Fragment]:
     dict[str, Fragment]
         Dictionary mapping SBU names to Fragment objects.
 
+    Raises
+    ------
+    FileNotFoundError
+        If ``path`` does not exist.
+    ValueError
+        If the file is not valid XYZ (bad atom counts, unparseable
+        coordinates, or mismatched structure/comment counts).
+
     Examples
     --------
     >>> sbus = xyz_to_sbu("custom_sbus.xyz")
     >>> print(sbus.keys())  # dict_keys(['SBU_1', 'SBU_2', ...])
     """
-    xyz = XYZ.from_file(path)
+    try:
+        xyz = XYZ.from_file(path)
+    except (IndexError, ValueError) as exc:
+        # pymatgen surfaces malformed content as bare IndexError/ValueError
+        raise ValueError(f"Malformed XYZ file '{path}': {exc}") from exc
     names = get_xyz_names(path)
+    molecules = xyz.all_molecules
+    if len(molecules) != len(names):
+        raise ValueError(
+            f"Malformed XYZ file '{path}': parsed {len(molecules)} "
+            f"structure(s) but found {len(names)} comment line(s)"
+        )
     return {
         name: Fragment(atoms=molecule, name=name)
-        for molecule, name in zip(xyz.all_molecules, names, strict=True)
+        for molecule, name in zip(molecules, names, strict=True)
     }
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -203,6 +203,26 @@ class TestXyzToSbu:
         # the symbol is still available on demand
         assert sbus["Test_Linear"].pointgroup == "D*h"
 
+    def test_nonexistent_path_raises(self, tmp_path):
+        """A missing file raises FileNotFoundError."""
+        missing = tmp_path / "does_not_exist.xyz"
+        with pytest.raises(FileNotFoundError):
+            utils.xyz_to_sbu(str(missing))
+
+    def test_bad_atom_count_raises_value_error(self, tmp_path):
+        """A structure declaring more atoms than it has is malformed."""
+        bad = tmp_path / "bad_count.xyz"
+        bad.write_text("5\nname=Bad\nC 0.0 0.0 0.0\nH 1.0 0.0 0.0\n")
+        with pytest.raises(ValueError, match="Malformed XYZ file"):
+            utils.xyz_to_sbu(str(bad))
+
+    def test_garbage_content_raises_value_error(self, tmp_path):
+        """Non-XYZ garbage content raises a clear ValueError."""
+        garbage = tmp_path / "garbage.xyz"
+        garbage.write_text("this is not\nan xyz file\nat all garbage garbage\n")
+        with pytest.raises(ValueError, match="Malformed XYZ file"):
+            utils.xyz_to_sbu(str(garbage))
+
 
 # =============================================================================
 # load_uff_lib Tests


### PR DESCRIPTION
## Summary

Resolves the two remaining open issues.

**Error-condition tests for XYZ input (#25)**
- `autografs.utils.xyz_to_sbu` previously leaked pymatgen internals on malformed input: a bare `IndexError: list index out of range` for a wrong atom count, and a cryptic `ValueError: zip() argument 2 is longer than argument 1` for garbage content. It now raises `ValueError` with a clear `Malformed XYZ file '<path>': ...` message in both cases (parse failures are wrapped; a structure-count/comment-count mismatch is detected explicitly). A nonexistent path still raises the standard `FileNotFoundError`. The docstring gained a Raises section.
- New tests in `tests/test_utils.py` (`TestXyzToSbu`) cover the missing-file, bad-atom-count, and garbage-content cases using `tmp_path`.

**Explicit `__all__` exports (#24)**
- Added `__all__` to `builder`, `fragment`, `topology`, `topology_io`, `utils`, `framework`, `editing`, and `alignment`, matching the public API each module's docstring documents (and the package-level `__all__`). Private helpers (`_format_runs`, `_relabel`, `_build_task`, ...) are not exported. `builder`'s docstring now also lists the public `build_framework` function.

## Verification

- `pytest`: 305 passed, 8 skipped (slow tests auto-skipped, LAMMPS backend absent)
- `ruff check src tests scripts`: all checks passed
- `ruff format --check src tests scripts`: 36 files already formatted
- `mypy src/autografs`: no issues found in 16 source files

Closes #24
Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)