### PR TITLE
Pythonicity cleanups

### DIFF
--- a/src/autografs/builder.py
+++ b/src/autografs/builder.py
@@ -502,7 +502,6 @@ class Autografs:
                 f"\t[x] loaded {len(added_sbu)} custom building units in {time.time() - t0:.0f} seconds."
             )
         self.sbu = sbu
-        return None
 
     def _setup_topologies(self, topofile: str | None = None) -> None:
         """Load topologies from a serialized library file.
@@ -544,7 +543,6 @@ class Autografs:
         # assignment, not dict.update(): the JSON loader returns a lazy
         # mapping, and update() would materialize every topology
         self.topologies = topologies
-        return None
 
     def list_topologies(
         self,

--- a/src/autografs/cli.py
+++ b/src/autografs/cli.py
@@ -55,6 +55,14 @@ MAX_SELECT_CHOICES = 15
 STRICT_MAX_RMSD = 0.5
 
 
+class _Cancelled:
+    """Sentinel type for a cancelled prompt, distinct from None
+    (which already means 'no gate' in the max-RMSD prompt)."""
+
+
+CANCELLED = _Cancelled()
+
+
 # ----------------------------------------------------------------------
 # pure helpers (unit-tested, no prompts)
 # ----------------------------------------------------------------------
@@ -121,15 +129,15 @@ class TopoInfo:
 def build_topology_index(topologies: Mapping[str, Topology]) -> list[TopoInfo]:
     """Metadata index of a topology library, for filtering prompts.
 
-    A LazyTopologyLibrary (see autografs.topology_io) keeps the parsed
-    JSON payload in ``_raw``; scanning that costs nothing, whereas
-    materializing ~2500 Topology objects takes ~10 s. Plain dicts
-    (legacy pickle libraries) are iterated as-is.
+    A LazyTopologyLibrary (see autografs.topology_io) exposes the
+    parsed JSON payload through ``raw_items()``; scanning that costs
+    nothing, whereas materializing ~2500 Topology objects takes ~10 s.
+    Plain dicts (legacy pickle libraries) are iterated as-is.
     """
-    raw = getattr(topologies, "_raw", None)
+    raw_items = getattr(topologies, "raw_items", None)
     infos = []
-    if raw is not None:
-        for name, data in raw.items():
+    if raw_items is not None:
+        for name, data in raw_items():
             conns = {slot["species"].count("X") for slot in data["slots"]}
             infos.append(
                 TopoInfo(name, bool(data.get("is_2d", False)), tuple(sorted(conns)))
@@ -192,8 +200,8 @@ def _pick_name(message: str, names: list[str]) -> str | None:
     return answer
 
 
-def _pick_max_rmsd() -> float | None | str:
-    """Prompt for the alignment gate; returns 'cancel' on Ctrl-C/ESC
+def _pick_max_rmsd() -> float | None | _Cancelled:
+    """Prompt for the alignment gate; returns CANCELLED on Ctrl-C/ESC
     (None already means 'no gate')."""
     pick = questionary.select(
         "Alignment quality gate (max RMSD)?",
@@ -204,7 +212,7 @@ def _pick_max_rmsd() -> float | None | str:
         ],
     ).ask()
     if pick is None:
-        return "cancel"
+        return CANCELLED
     if pick.startswith("No limit"):
         return None
     if pick.startswith(str(STRICT_MAX_RMSD)):
@@ -214,7 +222,7 @@ def _pick_max_rmsd() -> float | None | str:
         validate=_validate_positive_float,
     ).ask()
     if text is None:
-        return "cancel"
+        return CANCELLED
     return float(text)
 
 
@@ -356,7 +364,7 @@ def choose_build_options() -> tuple[bool, float | None] | None:
     if refine_cell is None:
         return None
     max_rmsd = _pick_max_rmsd()
-    if isinstance(max_rmsd, str):  # "cancel"
+    if isinstance(max_rmsd, _Cancelled):
         return None
     return refine_cell, max_rmsd
 
@@ -581,7 +589,7 @@ def batch_build(session: Session) -> None:
     if per_topology is None:
         return
     max_rmsd = _pick_max_rmsd()
-    if isinstance(max_rmsd, str):  # "cancel"
+    if isinstance(max_rmsd, _Cancelled):
         return
     outdir = questionary.text("Output directory:", default="frameworks").ask()
     if outdir is None:

--- a/src/autografs/fragment.py
+++ b/src/autografs/fragment.py
@@ -156,15 +156,12 @@ class Fragment:
             Crystallographic orbit id for topology slots.
         """
         self._symmetry = symmetry
-        self._pointgroup: str | None
-        if symmetry is not None:
-            self._pointgroup = symmetry.sch_symbol
-        else:
-            self._pointgroup = pointgroup
+        self._pointgroup: str | None = (
+            symmetry.sch_symbol if symmetry is not None else pointgroup
+        )
         self.atoms = atoms
         self.name = name
         self.equivalence_class = equivalence_class
-        return None
 
     @property
     def symmetry(self) -> PointGroupAnalyzer:
@@ -344,7 +341,6 @@ class Fragment:
                 indices=sites, theta=theta, axis=axis, anchor=anchor
             )
             self._clear_geometry_caches()
-        return None
 
     def flip(self) -> None:
         """
@@ -401,4 +397,3 @@ class Fragment:
                 idx -= 1
             self.atoms[idx].species = "X"
         self._clear_geometry_caches()
-        return None

--- a/src/autografs/topology.py
+++ b/src/autografs/topology.py
@@ -73,7 +73,10 @@ class Topology:
             the name given to the topology (RCSR symbol in defaults)
         slots : list[Fragment]
             the list of Fragment objects describing the orientation and
-            connectivity of slots in the topology.
+            connectivity of slots in the topology. The fragments are
+            stored as-is (not copied); when equivalence_classes is
+            given, their ``equivalence_class`` attribute is set in
+            place.
         cell : np.ndarray
             The information on periodicity in matrix form (3x3)
         equivalence_classes : list[int] or None, optional
@@ -118,7 +121,6 @@ class Topology:
         for i, slot_type in enumerate(slots):
             mappings.setdefault(slot_type, []).append(i)
         self.mappings = mappings
-        return None
 
     def __len__(self):
         return len(self.slots)
@@ -187,4 +189,3 @@ class Topology:
             scaled_slots.append(scaled_slot)
         self.slots = np.array(scaled_slots, dtype=object)
         self.cell = scaled_cell
-        return None

--- a/src/autografs/topology_io.py
+++ b/src/autografs/topology_io.py
@@ -24,6 +24,7 @@ import json
 import logging
 from collections.abc import Iterator, Mapping
 from pathlib import Path
+from typing import cast
 
 import numpy as np
 from pymatgen.core.structure import Molecule
@@ -68,6 +69,15 @@ class LazyTopologyLibrary(Mapping):
             f"LazyTopologyLibrary({len(self._raw)} topologies, "
             f"{len(self._cache)} materialized)"
         )
+
+    def raw_items(self) -> Iterator[tuple[str, dict]]:
+        """(name, raw JSON payload) pairs, materializing nothing.
+
+        The payload is the plain-data dict of topology_to_dict; callers
+        can scan cheap metadata (slot species, is_2d, ...) across the
+        whole library without paying Topology reconstruction.
+        """
+        return iter(self._raw.items())
 
 
 FORMAT_VERSION = 1
@@ -148,8 +158,8 @@ def topology_from_dict(name: str, data: dict) -> Topology:
         )
         equivalence_classes.append(slot_data.get("equivalence_class"))
     known_classes = (
-        [c for c in equivalence_classes if c is not None]
-        if all(c is not None for c in equivalence_classes)
+        cast(list[int], equivalence_classes)
+        if None not in equivalence_classes
         else None
     )
     return Topology(

--- a/src/autografs/utils.py
+++ b/src/autografs/utils.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 import functools
 import itertools
 import logging
-import re
 from collections import defaultdict
 from collections.abc import Iterable
 from itertools import count, groupby
@@ -125,20 +124,41 @@ def get_xyz_names(path: str) -> list[str]:
     >>> names = get_xyz_names("sbus.xyz")
     >>> print(names)  # ['Benzene_linear', 'Zn_paddlewheel', ...]
     """
+
+    def is_count(line: str) -> bool:
+        return line.strip().isdigit()
+
     names = []
-    white_space = r"[ \t\r\f\v]"
-    natoms_line = white_space + r"*\d+" + white_space + r"*\n"
     with open(path) as xyz_file:
-        data = re.split(natoms_line, xyz_file.read())
-        comment_lines = [
-            list(y)[0] for x, y in itertools.groupby(data, lambda z: z == "") if not x
-        ]
-        for cl in comment_lines:
-            if "name=" in cl:
-                name = cl.split("name=")[1].split(" ")[0]
-                names.append(name)
-            else:
-                names.append("Unnamed")
+        lines = xyz_file.readlines()
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if not stripped:
+            i += 1
+            continue
+        if not is_count(lines[i]):
+            raise ValueError(
+                f"Malformed XYZ file {path}: expected an atom count on "
+                f"line {i + 1}, got {stripped!r}."
+            )
+        # a count line directly followed by another count line (or EOF)
+        # is a stray with no molecule behind it; pymatgen's XYZ reader
+        # skips those, so the name walk must too to stay in step
+        if i + 1 >= len(lines) or is_count(lines[i + 1]):
+            i += 1
+            continue
+        comment = lines[i + 1]
+        name = next(
+            (
+                token.removeprefix("name=")
+                for token in comment.split()
+                if token.startswith("name=")
+            ),
+            "Unnamed",
+        )
+        names.append(name)
+        i += 2 + int(stripped)
     return names
 
 


### PR DESCRIPTION
Style/idiom cleanups from the codebase review — no behavior changes intended, with one deliberate exception noted below.

- Drop explicit `return None` from void methods (`Fragment`, `Topology`, `Autografs` setup); collapse the `Fragment` pointgroup init to a ternary.
- Rewrite `get_xyz_names` as a plain line walk instead of an unanchored regex split. Deliberate change: truly malformed files now raise a clear `ValueError` instead of silently misparsing. Stray count lines (one exists in `defaults.xyz` at line 1185) are skipped exactly as pymatgen's XYZ reader skips them, so the name/molecule `zip(strict=True)` stays in step.
- `topology_io`: simplify the equivalence-class reconstruction (`None not in ...` + `cast`); add `LazyTopologyLibrary.raw_items()` so the CLI no longer reaches into the private `_raw` attribute.
- `cli`: replace the `"cancel"` string sentinel with a typed `CANCELLED` sentinel object.
- Document that `Topology.__init__` stores slot fragments as-is and sets `equivalence_class` on them in place.

Verified locally: `ruff check`, `ruff format --check`, `mypy`, and the full fast test suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)