### PR TITLE
CGD parsing robustness: explicit errors for malformed entries

### DIFF
--- a/src/autografs/cgd.py
+++ b/src/autografs/cgd.py
@@ -134,6 +134,12 @@ def topology_from_string(
     name: str | None = None
     is_2d = False
     plane_group: str | None = None
+    # entries missing a GROUP or CELL line must fail as ValueError so
+    # read_cgd_data counts them as parse errors instead of crashing on
+    # an unbound local
+    lattice: Lattice | None = None
+    groupname: str | None = None
+    spacegroup: SpaceGroup | None = None
     for tokens in lines:
         # keys are matched case-insensitively: a few RCSR entries
         # write 'Name' instead of 'NAME'
@@ -186,6 +192,10 @@ def topology_from_string(
             elements += [dummy_element, dummy_element]
     if name is None:
         raise ValueError("CGD entry without a NAME line.")
+    if lattice is None:
+        raise ValueError(f"CGD entry {name} without a CELL line.")
+    if not xyz:
+        raise ValueError(f"CGD entry {name} without NODE or EDGE lines.")
     coords = np.stack(xyz, axis=0)
     if is_2d:
         # node coordinates need to be padded to 3D
@@ -200,6 +210,8 @@ def topology_from_string(
     else:
         if is_2d:
             raise ValueError(f"2D CELL without a plane group in entry {name}.")
+        if groupname is None or spacegroup is None:
+            raise ValueError(f"CGD entry {name} without a GROUP line.")
         # generate the crystal. Pass the normalized symbol string: it
         # keeps the setting suffix, which both SpaceGroup(...).symbol
         # and the group's int number would silently drop (reverting
@@ -304,8 +316,9 @@ def read_cgd_data(cgd: str, max_sites: int = MAX_FRAGMENT_SITES) -> dict[str, To
     parse_error_counter = 0
     extraction_errors: dict[str, str] = {}
     group_lookup = build_group_lookup()
-    # split the file by topology
-    split_cgd = [t.strip().strip("CRYSTAL") for t in cgd.split("END")]
+    # split the file by topology; removeprefix, NOT strip: strip("CRYSTAL")
+    # would eat any leading/trailing C/R/Y/S/T/A/L characters
+    split_cgd = [t.strip().removeprefix("CRYSTAL") for t in cgd.split("END")]
     for cgd_string in tqdm(split_cgd, desc="Creating topologies"):
         if not cgd_string:
             continue

--- a/tests/test_cgd.py
+++ b/tests/test_cgd.py
@@ -1,0 +1,77 @@
+"""Tests for CGD parsing robustness (malformed and adversarial entries)."""
+
+import pytest
+
+from autografs.cgd import build_group_lookup, read_cgd_data, topology_from_string
+
+# 3D group but no CELL line: must fail as ValueError (counted as a
+# parse error), not UnboundLocalError (which crashed the whole run)
+MISSING_CELL_CGD = """CRYSTAL
+  NAME nocell
+  GROUP Pm-3m
+  NODE 1 6  0.00000 0.00000 0.00000
+  EDGE  0.00000 0.00000 0.00000   0.50000 0.00000 0.00000
+END
+"""
+
+# CELL but no GROUP line at all
+MISSING_GROUP_CGD = """CRYSTAL
+  NAME nogroup
+  CELL 1.00000 1.00000 1.00000 90.0000 90.0000 90.0000
+  NODE 1 6  0.00000 0.00000 0.00000
+  EDGE  0.00000 0.00000 0.00000   0.50000 0.00000 0.00000
+END
+"""
+
+# no NODE or EDGE lines: np.stack would raise a confusing error
+EMPTY_SITES_CGD = """CRYSTAL
+  NAME nosites
+  GROUP p4mm
+  CELL 1.00000 1.00000 90.0000
+END
+"""
+
+# the entry's last content line ends with letters from {C,R,Y,S,T,A,L}:
+# a str.strip("CRYSTAL") split silently ate them (METAL -> ME)
+TRAILING_LETTERS_CGD = """CRYSTAL
+  GROUP p4mm
+  CELL 1.00000 1.00000 90.0000
+  NODE 1 4  0.00000 0.00000
+  EDGE  0.00000 0.00000   0.00000 1.00000
+  EDGE  0.00000 0.00000   1.00000 0.00000
+  NAME METAL
+END
+"""
+
+
+def _entry(cgd: str) -> str:
+    """One entry as read_cgd_data hands it to topology_from_string."""
+    return cgd.split("END")[0].strip().removeprefix("CRYSTAL")
+
+
+class TestMalformedEntries:
+    def test_missing_cell_raises_value_error(self):
+        with pytest.raises(ValueError, match="CELL"):
+            topology_from_string(_entry(MISSING_CELL_CGD), build_group_lookup())
+
+    def test_missing_group_raises_value_error(self):
+        with pytest.raises(ValueError, match="GROUP"):
+            topology_from_string(_entry(MISSING_GROUP_CGD), build_group_lookup())
+
+    def test_missing_sites_raises_value_error(self):
+        with pytest.raises(ValueError, match="NODE or EDGE"):
+            topology_from_string(_entry(EMPTY_SITES_CGD), build_group_lookup())
+
+    def test_malformed_entries_are_counted_not_fatal(self):
+        """One bad entry must not abort the conversion of the rest."""
+        topologies = read_cgd_data(
+            MISSING_CELL_CGD + MISSING_GROUP_CGD + EMPTY_SITES_CGD
+        )
+        assert topologies == {}
+
+
+class TestEntrySplitting:
+    def test_trailing_crystal_letters_survive(self):
+        """Entry text ending in C/R/Y/S/T/A/L letters is not eaten."""
+        topologies = read_cgd_data(TRAILING_LETTERS_CGD)
+        assert set(topologies) == {"METAL"}


### PR DESCRIPTION
Fixes #50, fixes #51.

- `topology_from_string`: entries missing a CELL, GROUP, or any NODE/EDGE line now raise `ValueError`, which `read_cgd_data` counts as a parse error. Previously they raised `UnboundLocalError`, which escaped the `except (KeyError, ValueError, IndexError)` accounting and aborted the entire conversion run on one malformed entry.
- `read_cgd_data`: split entries with `removeprefix("CRYSTAL")` instead of `strip("CRYSTAL")` — the latter character-strips any leading/trailing C/R/Y/S/T/A/L letters, silently corrupting entries whose text ends in those letters (regression test: an entry named METAL used to lose "TAL").
- New `tests/test_cgd.py` covering all failure modes plus the splitting regression.

Verified locally: new tests + existing plane-group/CGD tests pass; ruff, format, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)