### PR TITLE
Fragment editing fixes: flip centering, rotate guard, functionalize guard

### DIFF
--- a/src/autografs/fragment.py
+++ b/src/autografs/fragment.py
@@ -328,46 +328,59 @@ class Fragment:
     def rotate(self, theta: float) -> None:
         """
         Rotates in place the atoms in the Fragment.atoms object around the
-        axis provided by dummies by an angle of theta radians. This method will
-        fail if the number of dummies is not 2.
+        axis provided by dummies by an angle of theta radians.
 
         Parameters
         ----------
         theta : float
             angle of rotation in radians
-        """
-        dummies = self.extract_dummies()
-        if len(dummies) == 2:
-            sites = list(range(len(self.atoms)))
-            axis = dummies.cart_coords[0] - dummies.cart_coords[1]
-            anchor = dummies.cart_coords.mean(axis=0)
-            self.atoms.rotate_sites(
-                indices=sites, theta=theta, axis=axis, anchor=anchor
-            )
-            self._clear_geometry_caches()
-
-    def flip(self) -> None:
-        """
-        Flips in-place all the atoms in the Fragment.atoms object using a reflection
-        plane symmetry operation from the Fragment.symmetry object.
-
-        The method finds a reflection plane (mirror symmetry) from the point group
-        symmetry operations and applies it to all atomic coordinates.
 
         Raises
         ------
         ValueError
-            If no reflection plane is found in the symmetry operations.
+            If the number of dummies is not 2: only a linear (2-connected)
+            fragment has a well-defined rotation axis through its dummies.
         """
-        # Get symmetry operations from the PointGroupAnalyzer
+        dummies = self.extract_dummies()
+        if len(dummies) != 2:
+            raise ValueError(
+                f"Fragment {self.name!r} has {len(dummies)} connection "
+                "points; rotation around the dummy axis needs exactly 2."
+            )
+        sites = list(range(len(self.atoms)))
+        axis = dummies.cart_coords[0] - dummies.cart_coords[1]
+        anchor = dummies.cart_coords.mean(axis=0)
+        self.atoms.rotate_sites(indices=sites, theta=theta, axis=axis, anchor=anchor)
+        self._clear_geometry_caches()
+
+    def flip(self) -> None:
+        """
+        Flips in-place all the atoms in the Fragment.atoms object using an
+        improper symmetry operation (a mirror, or more generally any
+        determinant -1 operation) of the dummy arrangement.
+
+        The operation maps the dummy set onto itself, so the fragment
+        stays compatible with the same slots while its chirality is
+        inverted. Symmetry operations are expressed about the dummy
+        centroid (PointGroupAnalyzer centers its input), so they are
+        applied in that frame: an off-center fragment is mirrored in
+        place, not thrown across the origin.
+
+        Raises
+        ------
+        ValueError
+            If the dummy arrangement has no improper symmetry operation
+            (a chiral arrangement cannot be flipped onto itself).
+        """
+        center = self.extract_dummies().cart_coords.mean(axis=0)
         for op in self.symmetry.symmops:
             rot_matrix = op.rotation_matrix
-            # A reflection has det = -1 and trace can vary
-            # For a pure reflection: det(R) = -1
+            # det = -1: a reflection or other improper rotation
             if np.isclose(np.linalg.det(rot_matrix), -1.0):
-                # This is a reflection or improper rotation
-                # Apply the symmetry operation to all coordinates
-                new_coords = op.operate_multi(self.atoms.cart_coords)
+                # the symmop lives in the centered frame of the dummy
+                # arrangement; shift, operate, shift back
+                new_coords = op.operate_multi(self.atoms.cart_coords - center)
+                new_coords += center
                 self.atoms = Molecule(
                     self.atoms.species,
                     new_coords,
@@ -386,11 +399,23 @@ class Fragment:
         Parameters
         ----------
         index : int
-            The index of the atom to substitute
+            The index of the atom to substitute. Must not be a dummy
+            atom: dummies are the fragment's connection points.
         functional_group : str
             The name of the substitution
+
+        Raises
+        ------
+        ValueError
+            If index points at a dummy atom.
         """
         dummies_idx = self.atoms.indices_from_symbol("X")
+        if index in dummies_idx:
+            raise ValueError(
+                f"Atom {index} is a connection point (dummy); replacing it "
+                "would change the fragment's connectivity. Pick a terminal "
+                "real atom instead."
+            )
         self.atoms.replace_species({"X": "H"})
         fg = FunctionalGroups[functional_group]
         # the substitution deletes the atom at index, then appends

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -440,6 +440,17 @@ class TestFragmentRotate:
 
         np.testing.assert_array_almost_equal(coords_before, coords_after)
 
+    def test_rotate_wrong_dummy_count_raises(self):
+        """Rotation needs exactly 2 dummies; anything else must raise,
+        not silently no-op."""
+        mol = Molecule(
+            ["C", "X", "X", "X"],
+            [[0, 0, 0], [1, 0, 0], [-0.5, 0.87, 0], [-0.5, -0.87, 0]],
+        )
+        frag = Fragment(atoms=mol, name="trigonal")
+        with pytest.raises(ValueError, match="exactly 2"):
+            frag.rotate(theta=math.pi / 4)
+
 
 class TestFragmentFlip:
     """Test Fragment.flip method."""
@@ -466,6 +477,50 @@ class TestFragmentFlip:
         frag = Fragment(atoms=mol, symmetry=pg, name="chiral")
         with pytest.raises(ValueError, match="No reflection plane"):
             frag.flip()
+
+    def test_flip_off_center_preserves_dummies(self):
+        """The mirror must act about the dummy centroid: an off-center
+        fragment is flipped in place, its connection points fixed as a
+        set (regression: the symmop used to be applied about the
+        origin, throwing the fragment across space)."""
+        coords = [
+            [5.0, 5.0, 5.0],
+            [6.5, 5.0, 5.0],
+            [3.5, 5.0, 5.0],
+            [5.0, 6.0, 5.0],
+            [5.0, 4.0, 5.3],
+        ]
+        mol = Molecule(["C", "X", "X", "H", "H"], coords)
+        frag = Fragment(atoms=mol, name="offcenter")
+        dummies_before = frag.extract_dummies().cart_coords.copy()
+        frag.flip()
+        dummies_after = frag.extract_dummies().cart_coords
+        # the dummy set maps onto itself (possibly permuted)
+        for dummy in dummies_after:
+            nearest = np.linalg.norm(dummies_before - dummy, axis=1).min()
+            assert nearest < 1e-6
+        # and the fragment stayed in place
+        center_before = dummies_before.mean(axis=0)
+        center_after = dummies_after.mean(axis=0)
+        np.testing.assert_allclose(center_before, center_after, atol=1e-6)
+
+
+class TestFragmentFunctionalize:
+    """Test Fragment.functionalize guards."""
+
+    def test_functionalize_dummy_index_raises(self, linear_fragment):
+        """Replacing a connection point must raise, not silently corrupt
+        the dummy bookkeeping."""
+        dummy_idx = linear_fragment.atoms.indices_from_symbol("X")[0]
+        with pytest.raises(ValueError, match="connection point"):
+            linear_fragment.functionalize(dummy_idx, "methyl")
+
+    def test_functionalize_real_atom_works(self, linear_fragment):
+        """A terminal real atom is still substitutable."""
+        h_idx = linear_fragment.atoms.indices_from_symbol("H")[0]
+        n_dummies = len(linear_fragment.atoms.indices_from_symbol("X"))
+        linear_fragment.functionalize(h_idx, "methyl")
+        assert len(linear_fragment.atoms.indices_from_symbol("X")) == n_dummies
 
 
 # =============================================================================


### PR DESCRIPTION
Fixes #46, fixes #49, fixes #53.

- **flip** (#46): `PointGroupAnalyzer` expresses its symmetry operations in the centered frame of the analyzed molecule, but `flip` applied them to raw cartesian coordinates — mirroring off-center fragments about the *origin* and moving the connection points by twice the offset (~13 A in the repro). The operation is now applied about the dummy centroid, so the dummy set is preserved and the fragment is mirrored in place. Docstring now also states plainly that any determinant −1 operation qualifies (reflection or improper rotation).
- **rotate** (#49): raises `ValueError` when the dummy count is not 2 instead of silently no-oping; the docstring always claimed it would fail.
- **functionalize** (#53): raises `ValueError` when `index` points at a dummy atom; substituting a connection point silently corrupted the dummy reindexing.

New regression tests for all three (off-center flip, wrong-count rotate, dummy-index functionalize, plus a positive functionalize case). Full local suite, ruff, format, and mypy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)