### PR TITLE
utils fixes: run formatting, GULP ordering/determinism, cutoff pairs

### DIFF
--- a/src/autografs/utils.py
+++ b/src/autografs/utils.py
@@ -70,11 +70,11 @@ BOND_CUTOFF = 10.0  # Maximum cutoff distance for bond detection
 
 
 def format_indices(iterable: Iterable[int]) -> str:
+    """Format a consecutive run of indices as "first-last" (or "only")."""
     lst = list(iterable)
     if len(lst) > 1:
-        return f"{lst[0]}-{lst[1]}"
-    else:
-        return f"{lst[0]}"
+        return f"{lst[0]}-{lst[-1]}"
+    return f"{lst[0]}"
 
 
 def _format_runs(indices: list[int]) -> str:
@@ -294,7 +294,10 @@ def find_element_cutoffs(
         prefix = entry.symbol[:2]
         max_radius[prefix] = max(max_radius.get(prefix, 0.0), entry.radius)
     cuts = {}
-    for e0, e1 in itertools.product(uff_symbs, uff_symbs):
+    # element pairs, not atom pairs: uff_symbs is per-atom, and pairing
+    # atoms would make this quadratic in atom count for identical output
+    elements = sorted(set(uff_symbs))
+    for e0, e1 in itertools.product(elements, elements):
         cuts[(e0.strip("_"), e1.strip("_"))] = max_radius[e0] + max_radius[e1]
     return cuts
 
@@ -504,7 +507,10 @@ def view_graph(graph: networkx.Graph) -> None:
     from ase.visualize import view
 
     at = Atoms(cell=graph.graph["cell"], pbc=(True, True, True))
-    for _, d in graph.nodes(data=True):
+    # sorted node id order, like every Framework view: insertion order
+    # is not guaranteed to match node ids after graph editing
+    for node in sorted(graph):
+        d = graph.nodes[node]
         at.append(Atom(d["symbol"], d["coord"]))
     view(at)
 
@@ -549,12 +555,15 @@ def networkx_to_gulp(
     lines.append(f"{cell[2][0]:>.3f} {cell[2][1]:>.3f} {cell[2][2]:>.3f}")
     lines.append("cartesian")
 
-    # Build atom type mapping
-    mmset = list(set([(d["symbol"], d["ufftype"]) for _, d in graph.nodes(data=True)]))
+    # Build atom type mapping; sorted so the species labels (C0, C1...)
+    # are reproducible run to run instead of following set hash order
+    mmset = sorted({(d["symbol"], d["ufftype"]) for _, d in graph.nodes(data=True)})
     mmdict = {u: f"{s}{i}" for i, (s, u) in enumerate(mmset)}
 
-    # Atomic coordinates
-    for _, d in graph.nodes(data=True):
+    # Atomic coordinates, in sorted node id order: the connect records
+    # below refer to atoms by node id + 1, so line i must be node i
+    for node in sorted(graph):
+        d = graph.nodes[node]
         x, y, z = d["coord"]
         s = mmdict[d["ufftype"]]
         lines.append(f"{s:<4} core {x:>15.8f} {y:>15.8f} {z:>15.8f}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,6 +90,10 @@ class TestFormatIndices:
         result = utils.format_indices([1, 2])
         assert result == "1-2"
 
+    def test_run_of_three_or_more(self):
+        """The run must end at the LAST index, not the second."""
+        assert utils.format_indices([0, 1, 2, 3]) == "0-3"
+
     def test_empty_iterable(self):
         """Test with empty iterable."""
         # This will raise an IndexError - documenting current behavior
@@ -116,8 +120,17 @@ class TestFormatMappings:
         """Test that consecutive indices are grouped."""
         mappings = {0: "SBU_A", 1: "SBU_A", 2: "SBU_A"}
         result = utils.format_mappings(mappings)
-        assert "SBU_A" in result
-        # Should group 0, 1, 2
+        assert result == "SBU_A : 0-2"
+
+    def test_long_run_shows_last_index(self):
+        """Regression: {0..3} used to render as '0-1'."""
+        mappings = {0: "A", 1: "A", 2: "A", 3: "A"}
+        assert utils.format_mappings(mappings) == "A : 0-3"
+
+    def test_run_and_singleton(self):
+        """A run followed by a gap keeps both parts."""
+        mappings = {0: "A", 1: "A", 2: "A", 5: "A"}
+        assert utils.format_mappings(mappings) == "A : 0-2,5"
 
     def test_multiple_sbus(self):
         """Test multiple SBUs in mapping."""
@@ -416,6 +429,43 @@ class TestNetworkxToGulp:
 
         result = utils.networkx_to_gulp(G, name="test", write_to_file=False)
         assert "library uff4mof" in result
+
+    def test_atom_lines_follow_sorted_node_ids(self):
+        """connect records address atoms by node id + 1, so the atom
+        lines must follow sorted node ids even when the graph was built
+        in another insertion order."""
+        import networkx
+
+        G = networkx.Graph(cell=np.eye(3) * 10)
+        # inserted out of id order on purpose
+        G.add_node(1, symbol="H", coord=[9.0, 0.0, 0.0], tag=0, ufftype="H_")
+        G.add_node(0, symbol="C", coord=[1.0, 0.0, 0.0], tag=0, ufftype="C_R")
+        G.add_edge(0, 1, bond_order=1.0)
+
+        result = utils.networkx_to_gulp(G, name="test", write_to_file=False)
+        core_lines = [ln for ln in result.splitlines() if " core " in ln]
+        assert "1.00000000" in core_lines[0]  # node 0 first
+        assert "9.00000000" in core_lines[1]  # node 1 second
+
+    def test_species_labels_are_deterministic(self):
+        """Labels number the (symbol, ufftype) pairs in sorted order,
+        not set iteration order, so output is reproducible."""
+        import networkx
+
+        G = networkx.Graph(cell=np.eye(3) * 10)
+        G.add_node(0, symbol="C", coord=[0, 0, 0], tag=0, ufftype="C_R")
+        G.add_node(1, symbol="C", coord=[1, 0, 0], tag=0, ufftype="C_3")
+        G.add_node(2, symbol="O", coord=[2, 0, 0], tag=0, ufftype="O_2")
+
+        result = utils.networkx_to_gulp(G, name="test", write_to_file=False)
+        lines = result.splitlines()
+        mapping = {}
+        for line in lines[lines.index("species") + 1 :]:
+            if not line.strip():
+                break
+            label, ufftype = line.split()
+            mapping[ufftype] = label
+        assert mapping == {"C_3": "C0", "C_R": "C1", "O_2": "O2"}
 
     def test_bond_order_single(self):
         """Test single bond formatting."""


### PR DESCRIPTION
Fixes #47, fixes #56, fixes #58.

- **format_indices** (#47): a consecutive run now prints first-*last* instead of first-*second* — `format_mappings({0..3: "A"})` rendered as `"A : 0-1"`. User-facing in build logs and in the slot-picker error message of `editing._slot_nodes`. Regression tests cover runs of 3+, exact grouped output, and run+singleton.
- **GULP/view ordering + determinism** (#56): `networkx_to_gulp` and `view_graph` now iterate nodes in sorted id order (the `connect` records address atoms by node id + 1, so atom line i must be node i — insertion order made that an implicit invariant); species labels number the sorted (symbol, ufftype) pairs so output is byte-reproducible instead of following set hash order.
- **find_element_cutoffs** (#58): iterates element pairs instead of atom pairs — identical output, no longer quadratic in atom count (it runs per fragment per build).

Full local suite, ruff, format, and mypy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)