### PR TITLE
scale_slots: clear cached slot geometry after rescaling

### DIFF
--- a/src/autografs/topology.py
+++ b/src/autografs/topology.py
@@ -190,6 +190,10 @@ class Topology:
                 scaled_coords,
                 site_properties=slot.atoms.site_properties,
             )
+            # deepcopy carries the cached_property values of the source
+            # slot in __dict__; after anisotropic scaling those cached
+            # arm directions are wrong for the new geometry
+            scaled_slot._clear_geometry_caches()
             scaled_slots.append(scaled_slot)
         self.slots = np.array(scaled_slots, dtype=object)
         self.cell = scaled_cell

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -628,6 +628,23 @@ class TestTopologyScaleSlots:
         new_abc = simple_topology.cell.abc
         np.testing.assert_array_almost_equal(new_abc, (1.0, 1.0, 1.0))
 
+    def test_anisotropic_scale_refreshes_cached_geometry(self):
+        """Regression: deepcopy carried the pre-scaling arm_units cache
+        onto the scaled slots, so compatibility checks after an
+        anisotropic scale answered for the wrong shape."""
+        mol = Molecule(["C", "X", "X"], [[0, 0, 0], [1, 1, 0], [-1, -1, 0]])
+        mol.add_site_property("tags", [0, 1, 2])
+        topo = Topology(
+            name="diag", slots=[Fragment(atoms=mol, name="slot")], cell=np.eye(3) * 10
+        )
+        _ = topo.slots[0].arm_units  # populate the cache, as the sieve does
+        topo.scale_slots(scales=(30.0, 10.0, 10.0))
+        slot = topo.slots[0]
+        dummies = slot.extract_dummies().cart_coords
+        arm = dummies[0] - dummies.mean(axis=0)
+        expected = arm / np.linalg.norm(arm)
+        np.testing.assert_allclose(slot.arm_units[0], expected, atol=1e-9)
+
 
 # =============================================================================
 # Hypothesis Property-Based Tests


### PR DESCRIPTION
Fixes #48.

`copy.deepcopy` carries the `functools.cached_property` values (`arm_units`, `_shape_signature`, `max_dummy_distance`) of the source slot in the instance `__dict__`, so slots scaled by `Topology.scale_slots` kept answering with their pre-scaling geometry. After an anisotropic scale, `get_compatible_slots` / `has_compatible_symmetry` matched against the wrong arm directions (measured: cached `[0.707, 0.707, 0]` vs true `[0.949, 0.316, 0]`).

The fix clears the caches on each scaled slot after its atoms are replaced. Regression test populates the cache the way the sieve does, scales anisotropically, and checks `arm_units` against directions recomputed from the scaled dummies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)