### PR TITLE
stack: warn on layer thicker than interlayer; document min_contact blind spot

### DIFF
--- a/src/autografs/framework.py
+++ b/src/autografs/framework.py
@@ -163,6 +163,12 @@ class Framework:
         in the graph are exempt (at every image - a bonded pair is
         never reported, even through a boundary).
 
+        Blind spot: because the exemption ignores the image, a bonded
+        pair whose atoms *also* approach each other through a different
+        periodic image (possible in a strongly collapsed cell) is not
+        reported either. Contacts between non-bonded pairs, including
+        self-image contacts, are always seen.
+
         Parameters
         ----------
         cutoff : float, optional
@@ -616,6 +622,15 @@ class Framework:
             raise StackingError(
                 f"Framework {self.name!r} spans {thickness:.2f} A along c "
                 f"(cell {pad_c:.2f} A); not a 2D layer."
+            )
+        # a puckered layer thicker than the spacing overlaps its own
+        # stacked images; legal (interdigitated stackings exist) but
+        # rarely intended, so say so instead of failing silently later
+        if thickness > interlayer:
+            logger.warning(
+                f"Layer {self.name!r} is {thickness:.2f} A thick but the "
+                f"interlayer spacing is {interlayer:.2f} A; stacked layers "
+                "will interpenetrate. Check the result with min_contact()."
             )
         if mode == "AA":
             if offset is not None:

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -267,6 +267,34 @@ class TestStacking:
         with pytest.raises(ValueError, match="positive"):
             layer.stack(interlayer=-1.0)
 
+    def test_thick_layer_warns_about_interpenetration(self, layer, caplog):
+        """A layer thicker than the interlayer spacing overlaps its own
+        stacked images; that must be said out loud, not left silent."""
+        import logging
+
+        import networkx
+
+        from autografs.framework import Framework
+
+        thick_graph = networkx.Graph(cell=np.diag([5.0, 5.0, 10.0]))
+        for i, z in enumerate([0.0, 2.0, 4.0]):
+            thick_graph.add_node(
+                i, symbol="C", coord=np.array([1.5 * i, 0.0, z]), tag=0, ufftype="C_R"
+            )
+        thick_graph.add_edge(0, 1, bond_order=1.0)
+        thick_graph.add_edge(1, 2, bond_order=1.0)
+        thick = Framework(thick_graph, name="puckered")
+        with caplog.at_level(logging.WARNING, logger="autografs.framework"):
+            thick.stack(mode="AA", interlayer=3.35)
+        assert any("interpenetrate" in rec.message for rec in caplog.records)
+
+    def test_flat_layer_does_not_warn(self, layer, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="autografs.framework"):
+            layer.stack(mode="AA", interlayer=3.35)
+        assert not any("interpenetrate" in rec.message for rec in caplog.records)
+
     def test_non_layered_input_rejected(self, mof5):
         from autografs.exceptions import StackingError
 


### PR DESCRIPTION
Fixes #54, fixes #55.

- **stack thickness** (#54): `Framework.stack` gated on thickness < half the slab padding but never compared the layer thickness to the requested `interlayer`. A 4 A-thick puckered layer stacked at 3.35 A passed silently and self-overlapped across images. Now logs a warning naming both numbers and pointing at `min_contact()` — a warning rather than an error because interdigitated stackings are legitimate. Tests cover both the warning and the no-warning flat case.
- **min_contact docs** (#55): documents the blind spot in the bonded-pair exemption — the exemption ignores the periodic image, so a bonded pair that *also* approaches itself through a different image (strongly collapsed cell) is not reported. Non-bonded and self-image contacts are always seen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)