### PR TITLE
Sieve prefilter: sqrt(n) margin; bound the match-RMSD cache

### DIFF
--- a/src/autografs/fragment.py
+++ b/src/autografs/fragment.py
@@ -57,13 +57,16 @@ SYMMETRY_TOLERANCE = 0.1
 COMPATIBILITY_MAX_RMSD = 0.35
 
 
-@functools.cache
+@functools.lru_cache(maxsize=65536)
 def _match_rmsd_cached(this_bytes: bytes, that_bytes: bytes, size: int) -> float:
     """Memoized directional match RMSD between two arm-unit sets.
 
     Keyed on rounded coordinate bytes: the same star shapes recur
     across the topology library (every Oh 6-c vertex, every linear
     edge...), so the full matcher runs once per distinct shape pair.
+    Bounded (unlike functools.cache) so a long session sieving many
+    user-supplied SBUs cannot grow it without limit; 65536 entries
+    comfortably hold the shipped library's distinct shape pairs.
     """
     # local import: alignment imports Fragment for construction, so
     # fragment cannot import it at module level
@@ -306,9 +309,16 @@ class Fragment:
         if len(this_units) <= 2:
             return True
         # cheap rotation/permutation-invariant prefilter: grossly
-        # different pairwise-angle multisets cannot match
+        # different pairwise-angle multisets cannot match. The margin
+        # must scale with sqrt(n): a directional RMSD of r over n arms
+        # can concentrate a residual of r*sqrt(n) on a single arm, and
+        # a sorted-signature entry moves by at most the sum of the two
+        # residuals it involves, so 2*r*sqrt(n) bounds the gap a true
+        # match can produce. The previous flat 4*r bound was only safe
+        # for n <= 4 and could over-reject high-connectivity stars.
+        n_arms = len(this_units)
         gap = float(np.abs(self._shape_signature - other._shape_signature).max())
-        if gap > 4.0 * max_rmsd:
+        if gap > 2.0 * max_rmsd * float(np.sqrt(n_arms)):
             return False
         return (
             _match_rmsd_cached(

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -318,6 +318,40 @@ class TestFragmentSymmetryCompatibility:
         assert frag_tri.has_compatible_symmetry(frag_t)
         assert not frag_tri.has_compatible_symmetry(frag_t, max_rmsd=0.1)
 
+    def test_prefilter_never_overrules_matcher_at_high_connectivity(self):
+        """The signature prefilter is an optimization only: whenever the
+        full matcher accepts a pair, the prefilter must too. RMSD
+        averages over n arms while the signature gap does not, so the
+        margin has to scale with sqrt(n) - a flat margin over-rejected
+        high-connectivity stars with one badly fitting arm."""
+        from autografs.alignment import match_directions
+        from autografs.fragment import COMPATIBILITY_MAX_RMSD
+
+        rng = np.random.default_rng(42)
+        accepted = 0
+        for n in (17, 20, 24):
+            for _ in range(10):
+                base = rng.normal(size=(n, 3))
+                base /= np.linalg.norm(base, axis=1, keepdims=True)
+                other = base.copy()
+                # push one arm hard: residual concentrated on a single
+                # arm is the worst case for a flat prefilter margin
+                k = int(rng.integers(n))
+                other[k] = other[k] + rng.normal(scale=0.8, size=3)
+                other[k] /= np.linalg.norm(other[k])
+                frag_a = self._fragment_from_dummy_coords(
+                    (base * 1.5).tolist(), "star_a"
+                )
+                frag_b = self._fragment_from_dummy_coords(
+                    (other * 1.5).tolist(), "star_b"
+                )
+                _, _, rmsd = match_directions(frag_a.arm_units, frag_b.arm_units)
+                if rmsd <= COMPATIBILITY_MAX_RMSD:
+                    accepted += 1
+                    assert frag_a.has_compatible_symmetry(frag_b)
+        # the sample must actually exercise matcher-accepted pairs
+        assert accepted >= 10
+
 
 class TestFragmentLazySymmetry:
     """Fragment can be built without a precomputed PointGroupAnalyzer."""


### PR DESCRIPTION
Fixes #52, fixes #60.

- **Prefilter margin** (#52): the pairwise-dot signature prefilter in `has_compatible_symmetry` compared the max signature gap against a flat `4 * max_rmsd`. Directional RMSD averages over n arms, so a pair with one badly fitting arm can carry a residual of `r*sqrt(n)` while its RMSD stays at `r`; each sorted-signature entry moves by at most the sum of the two residuals it involves, so `2*r*sqrt(n)` bounds the gap a true match can produce. The flat margin was only provably safe for n <= 4 and could over-reject high-connectivity stars — exactly the 24-c nets the 0.35 threshold was tuned to cover. The margin now scales with sqrt(n).

  Note on testability: I could not construct a *realizable* false rejection (centroid-relative arms sum to zero, which fights the adversarial cluster geometry the bound allows), so this is a prophylactic fix guided by the bound. The new seeded test enforces the invariant directly — over random high-connectivity star pairs with one strongly perturbed arm, the prefilter never overrules a matcher-accepted pair — and guards any future margin change.

- **Cache bound** (#60): `_match_rmsd_cached` moves from unbounded `functools.cache` to `lru_cache(maxsize=65536)` — comfortably above the shipped library's distinct shape pairs, but no longer able to grow without limit in a long session sieving user SBUs.

The looser prefilter only costs prefilter selectivity at high n; rejected-shape decisions now fall through to the full matcher, whose results are cached.

Full local suite, ruff, format, and mypy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)