### PR TITLE
Framework save/load: persist the bond graph and provenance as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,16 @@ mof.view()                               # ASE viewer
 gulp_input = mof.to_gulp()               # UFF4MOF optimization input for GULP
 ```
 
+CIF export is for downstream tools; it loses the bond graph and the
+per-atom provenance that post-build editing needs. To keep a framework
+editable across sessions, save it to the versioned JSON format instead:
+
+```python
+mof.save("mof5.json.gz")                 # bond graph, tags, provenance, energy
+mof = Framework.load("mof5.json.gz")     # editable exactly like the original
+defective = mof.supercell(2).defects(fraction=0.1, seed=42)
+```
+
 ### UFF4MOF relaxation
 
 `relax` optimizes the geometry and cell with the UFF4MOF force field through

--- a/src/autografs/__init__.py
+++ b/src/autografs/__init__.py
@@ -55,6 +55,7 @@ __all__ = [
     "alignment",
     "fragment",
     "framework",
+    "framework_io",
     "topology",
     "topology_io",
     "builder",
@@ -72,6 +73,10 @@ __all__ = [
 
 import logging
 
+# bind every module listed in __all__ as a package attribute; relax's
+# optional LAMMPS backends are imported lazily inside its functions,
+# so importing the module itself is cheap and always safe
+from autografs import framework_io, relax
 from autografs.builder import Autografs
 from autografs.exceptions import (
     AlignmentError,

--- a/src/autografs/framework.py
+++ b/src/autografs/framework.py
@@ -247,6 +247,48 @@ class Framework:
         logger.info(f"Wrote {self!r} to {path}")
         return path
 
+    def save(self, path: str | Path) -> Path:
+        """Save the framework to a versioned JSON file.
+
+        Unlike CIF export, this persists everything a Framework is:
+        the bond graph with bond orders, UFF4MOF types, anchor tags,
+        and the per-atom slot/SBU provenance - so a framework saved in
+        one session can be reloaded with ``Framework.load`` and edited
+        (supercell, defects, functionalize, ...) in another.
+
+        Parameters
+        ----------
+        path : str or Path
+            Output path; gzip-compressed and compact when it ends in
+            ``.gz``, pretty-printed JSON otherwise.
+
+        Returns
+        -------
+        Path
+            The written path.
+        """
+        from autografs.framework_io import save_framework
+
+        return save_framework(self, path)
+
+    @classmethod
+    def load(cls, path: str | Path) -> Framework:
+        """Load a framework saved with ``save``.
+
+        Parameters
+        ----------
+        path : str or Path
+            Input path (.json or .json.gz).
+
+        Returns
+        -------
+        Framework
+            The loaded framework, editable exactly like the saved one.
+        """
+        from autografs.framework_io import load_framework
+
+        return load_framework(path)
+
     def to_ase(self) -> ase.Atoms:
         """The framework as an ASE Atoms object (wrapped, periodic)."""
         from ase import Atoms

--- a/src/autografs/framework_io.py
+++ b/src/autografs/framework_io.py
@@ -1,0 +1,199 @@
+"""
+Serialization of Framework objects to a versioned JSON format.
+
+CIF export loses everything that makes a built framework editable: the
+bond graph, the bond orders, the UFF4MOF types, the anchor tags, and
+the per-atom slot/SBU provenance that post-build editing (defects,
+functionalization, rotation) requires. This module persists the graph
+itself - plain data, safe to share, stable across pymatgen versions -
+so a framework can be saved in one session and edited in another:
+
+>>> mof.save("mof5.json.gz")
+>>> mof = Framework.load("mof5.json.gz")
+>>> defective = mof.supercell(2).defects(fraction=0.1, seed=42)
+
+Functions
+---------
+framework_to_dict / framework_from_dict
+    Convert a Framework to/from a JSON-compatible dict.
+save_framework / load_framework
+    Write/read one framework; gzip-compressed when the path ends
+    in .gz.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+from pathlib import Path
+
+import networkx
+import numpy as np
+
+from autografs.framework import Framework
+
+__all__ = [
+    "framework_to_dict",
+    "framework_from_dict",
+    "save_framework",
+    "load_framework",
+]
+
+logger = logging.getLogger(__name__)
+
+FORMAT_VERSION = 1
+
+
+def framework_to_dict(framework: Framework) -> dict:
+    """Convert a Framework into a JSON-compatible dict.
+
+    Parameters
+    ----------
+    framework : Framework
+        The framework to serialize.
+
+    Returns
+    -------
+    dict
+        Plain-data representation: name, energy, cell matrix, per-atom
+        columns (symbols, coords, tags, ufftypes, and slot/sbu
+        provenance when present), and the bond list with orders.
+
+    Raises
+    ------
+    ValueError
+        If the graph's node ids are not contiguous 0..n-1 (a violated
+        Framework invariant; every builder and editing path maintains
+        it).
+    """
+    graph = framework.graph
+    nodes = sorted(graph)
+    if nodes != list(range(len(nodes))):
+        raise ValueError(
+            "Framework node ids are not contiguous 0..n-1; the graph "
+            "violates the Framework invariant and cannot be serialized."
+        )
+    data: dict = {
+        "name": framework.name,
+        "energy": framework.energy,
+        "cell": np.asarray(framework.cell, dtype=float).tolist(),
+        "symbols": [graph.nodes[n]["symbol"] for n in nodes],
+        "coords": [
+            np.asarray(graph.nodes[n]["coord"], dtype=float).tolist() for n in nodes
+        ],
+        "tags": [int(graph.nodes[n]["tag"]) for n in nodes],
+        "ufftypes": [graph.nodes[n]["ufftype"] for n in nodes],
+        "bonds": sorted(
+            [min(u, v), max(u, v), float(d.get("bond_order", 1.0))]
+            for u, v, d in graph.edges(data=True)
+        ),
+    }
+    # slot/SBU provenance: written only when every atom carries it, so
+    # legacy graphs still save and loading keeps them legacy
+    if all("slot" in graph.nodes[n] for n in nodes):
+        data["slots"] = [int(graph.nodes[n]["slot"]) for n in nodes]
+        data["sbus"] = [graph.nodes[n]["sbu"] for n in nodes]
+    return data
+
+
+def framework_from_dict(data: dict) -> Framework:
+    """Reconstruct a Framework from its dict representation.
+
+    Parameters
+    ----------
+    data : dict
+        Output of framework_to_dict.
+
+    Returns
+    -------
+    Framework
+        The reconstructed framework, editable exactly like the one
+        that was saved (provenance included when it was present).
+    """
+    graph = networkx.Graph(cell=np.asarray(data["cell"], dtype=float))
+    slots = data.get("slots")
+    sbus = data.get("sbus")
+    columns = zip(
+        data["symbols"], data["coords"], data["tags"], data["ufftypes"], strict=True
+    )
+    for i, (symbol, coord, tag, ufftype) in enumerate(columns):
+        attributes: dict = {
+            "symbol": symbol,
+            "coord": np.asarray(coord, dtype=float),
+            "tag": int(tag),
+            "ufftype": ufftype,
+        }
+        if slots is not None and sbus is not None:
+            attributes["slot"] = int(slots[i])
+            attributes["sbu"] = sbus[i]
+        graph.add_node(i, **attributes)
+    for u, v, order in data["bonds"]:
+        graph.add_edge(int(u), int(v), bond_order=float(order))
+    framework = Framework(graph, name=data.get("name", "framework"))
+    framework.energy = data.get("energy")
+    return framework
+
+
+def save_framework(framework: Framework, path: str | Path) -> Path:
+    """Write a framework to a JSON file.
+
+    Parameters
+    ----------
+    framework : Framework
+        The framework to save.
+    path : str or Path
+        Output path. Written gzip-compressed and compact if it ends in
+        .gz; pretty-printed otherwise.
+
+    Returns
+    -------
+    Path
+        The written path.
+    """
+    path = Path(path)
+    payload = {
+        "format_version": FORMAT_VERSION,
+        "framework": framework_to_dict(framework),
+    }
+    if path.suffix == ".gz":
+        text = json.dumps(payload, separators=(",", ":"))
+        with gzip.open(path, "wt", encoding="utf-8") as handle:
+            handle.write(text)
+    else:
+        path.write_text(json.dumps(payload, indent=1), encoding="utf-8")
+    logger.info(f"Saved {framework!r} to {path}")
+    return path
+
+
+def load_framework(path: str | Path) -> Framework:
+    """Load a framework from a JSON file.
+
+    Parameters
+    ----------
+    path : str or Path
+        Input path. Read gzip-compressed if it ends in .gz.
+
+    Returns
+    -------
+    Framework
+        The loaded framework.
+
+    Raises
+    ------
+    ValueError
+        If the file declares an unsupported format version.
+    """
+    path = Path(path)
+    if path.suffix == ".gz":
+        with gzip.open(path, "rt", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    else:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    version = payload.get("format_version")
+    if version != FORMAT_VERSION:
+        raise ValueError(
+            f"Unsupported framework format version {version!r} in {path}; "
+            f"this build of AuToGraFS reads version {FORMAT_VERSION}."
+        )
+    return framework_from_dict(payload["framework"])

--- a/tests/test_framework_io.py
+++ b/tests/test_framework_io.py
@@ -1,0 +1,107 @@
+"""Round-trip tests for Framework JSON serialization (framework_io)."""
+
+import os
+
+import numpy as np
+import pytest
+
+from autografs.framework import Framework
+
+FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "data", "topologies_fixture.json"
+)
+
+
+@pytest.fixture(scope="module")
+def mofgen():
+    from autografs import Autografs
+
+    return Autografs(topofile=FIXTURE_PATH)
+
+
+@pytest.fixture(scope="module")
+def mof5(mofgen):
+    topology = mofgen.topologies["pcu"]
+    mappings = {}
+    for key in topology.mappings:
+        conn = len(key.atoms.indices_from_symbol("X"))
+        mappings[key] = {6: "Zn_mof5_octahedral", 2: "Benzene_linear"}[conn]
+    return mofgen.build(topology, mappings=mappings, refine_cell=True, max_rmsd=0.5)
+
+
+def assert_same_framework(a: Framework, b: Framework) -> None:
+    assert a.name == b.name
+    assert a.energy == b.energy
+    np.testing.assert_allclose(a.cell, b.cell)
+    assert a.symbols == b.symbols
+    np.testing.assert_allclose(a.cart_coords, b.cart_coords)
+    assert a.mmtypes == b.mmtypes
+    assert sorted(a.bonds) == sorted(b.bonds)
+    tags_a = [a.graph.nodes[n]["tag"] for n in sorted(a.graph)]
+    tags_b = [b.graph.nodes[n]["tag"] for n in sorted(b.graph)]
+    assert tags_a == tags_b
+    assert a.slots == b.slots
+
+
+class TestRoundTrip:
+    def test_json_round_trip(self, mof5, tmp_path):
+        path = mof5.save(tmp_path / "mof5.json")
+        loaded = Framework.load(path)
+        assert_same_framework(mof5, loaded)
+
+    def test_gzip_round_trip(self, mof5, tmp_path):
+        path = mof5.save(tmp_path / "mof5.json.gz")
+        loaded = Framework.load(path)
+        assert_same_framework(mof5, loaded)
+
+    def test_energy_survives(self, mof5, tmp_path):
+        mof5_copy = Framework.load(mof5.save(tmp_path / "a.json"))
+        mof5_copy.energy = -123.5
+        reloaded = Framework.load(mof5_copy.save(tmp_path / "b.json"))
+        assert reloaded.energy == -123.5
+
+    def test_loaded_framework_is_editable(self, mof5, tmp_path):
+        """The whole point: provenance survives, so post-build editing
+        works on a framework loaded in a later session."""
+        loaded = Framework.load(mof5.save(tmp_path / "mof5.json.gz"))
+        supercell = loaded.supercell(2)
+        assert len(supercell) == 8 * len(loaded)
+        linker = next(s for s, name in loaded.slots.items() if name == "Benzene_linear")
+        rotated = loaded.rotate(linker, np.pi / 6)
+        assert set(rotated.graph.edges()) == set(loaded.graph.edges())
+        defective = loaded.supercell(2).defects(
+            fraction=0.25, sbu="Benzene_linear", seed=1
+        )
+        assert len(defective.slots) < 8 * len(loaded.slots)
+
+    def test_stacked_and_edited_frameworks_round_trip(self, mofgen, tmp_path):
+        """Layer builds and post-stack graphs serialize too."""
+        topology = mofgen.topologies["hcb"]
+        mappings = {}
+        for key in topology.mappings:
+            conn = len(key.atoms.indices_from_symbol("X"))
+            mappings[key] = {3: "Boroxine_triangle", 2: "Benzene_linear"}[conn]
+        layer = mofgen.build(topology, mappings=mappings, max_rmsd=0.5)
+        stacked = layer.stack(mode="AB")
+        loaded = Framework.load(stacked.save(tmp_path / "cof.json.gz"))
+        assert_same_framework(stacked, loaded)
+
+
+class TestFormatGuards:
+    def test_wrong_version_raises(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text('{"format_version": 999, "framework": {}}')
+        with pytest.raises(ValueError, match="format version"):
+            Framework.load(bad)
+
+    def test_non_contiguous_ids_rejected(self, mof5):
+        import networkx
+
+        from autografs.framework_io import framework_to_dict
+
+        graph = networkx.Graph(cell=np.eye(3) * 10)
+        graph.add_node(0, symbol="C", coord=np.zeros(3), tag=0, ufftype="C_R")
+        graph.add_node(2, symbol="C", coord=np.ones(3), tag=0, ufftype="C_R")
+        broken = Framework(graph, name="broken")
+        with pytest.raises(ValueError, match="contiguous"):
+            framework_to_dict(broken)


### PR DESCRIPTION
Fixes #62.

New `autografs.framework_io` module (mirroring `topology_io`) plus `Framework.save(path)` / `Framework.load(path)`:

- versioned JSON format (v1), gzip-compressed when the path ends in `.gz`;
- persists everything a Framework is: name, energy, cell, per-atom symbols/coords/tags/UFF4MOF types, slot/SBU provenance (when present), and the bond list with orders;
- rejects graphs violating the contiguous-node-id invariant with a clear error, and unsupported format versions on load;
- round-trip tests cover plain/gzip paths, energy, stacked 2D frameworks, and — the point of the feature — that a *loaded* framework is fully editable (supercell, rotate, defects) in a later session.

README gains a short section distinguishing this from CIF export.

Drive-by consistency fix surfaced by the new module: `autografs.relax` was listed in the package `__all__` but only became a package attribute if something imported it first (test-order dependent). Both `relax` and `framework_io` are now imported in `__init__` — safe, since relax's optional LAMMPS backends load lazily inside its functions.

Full local suite, ruff, format, and mypy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)