### PR TITLE
Porosity descriptors: density, void fraction, LCD, PLD

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,11 @@ mof.mmtypes            # UFF4MOF atom types, node order
 mof.min_contact()      # closest non-bonded contact (all images)
 mof.slots              # {slot index: SBU name} for every placed unit
 
+mof.density                     # g/cm3 (MOF-5: ~0.6)
+mof.void_fraction()             # geometric; probe_radius=1.2 for a He probe
+mof.largest_cavity_diameter()   # LCD, Angstrom (MOF-5: ~15)
+mof.pore_limiting_diameter()    # PLD, Angstrom (MOF-5: ~8) - the channel bottleneck
+
 mof.write_cif("out.cif", symprec=None)   # symprec symmetrizes if set
 atoms = mof.to_ase()                     # periodic ase.Atoms
 mof.view()                               # ASE viewer

--- a/src/autografs/__init__.py
+++ b/src/autografs/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     "fragment",
     "framework",
     "framework_io",
+    "porosity",
     "topology",
     "topology_io",
     "builder",
@@ -76,7 +77,7 @@ import logging
 # bind every module listed in __all__ as a package attribute; relax's
 # optional LAMMPS backends are imported lazily inside its functions,
 # so importing the module itself is cheap and always safe
-from autografs import framework_io, relax
+from autografs import framework_io, porosity, relax
 from autografs.builder import Autografs
 from autografs.exceptions import (
     AlignmentError,

--- a/src/autografs/framework.py
+++ b/src/autografs/framework.py
@@ -199,6 +199,75 @@ class Framework:
         return float(distances[unbonded].min())
 
     # ------------------------------------------------------------------
+    # porosity descriptors (implementations in autografs.porosity)
+    # ------------------------------------------------------------------
+
+    @property
+    def density(self) -> float:
+        """Crystal density in g/cm3."""
+        return float(self.structure.density)
+
+    def void_fraction(self, probe_radius: float = 0.0, spacing: float = 0.4) -> float:
+        """Fraction of the cell volume where a probe sphere fits.
+
+        Parameters
+        ----------
+        probe_radius : float, optional
+            Probe radius in Angstrom; 0.0 (default) gives the
+            geometric void fraction outside the vdW surfaces. 1.2
+            approximates a helium probe, 1.86 nitrogen.
+        spacing : float, optional
+            Grid resolution in Angstrom; smaller is more accurate and
+            slower.
+
+        Returns
+        -------
+        float
+            Accessible-volume fraction, in [0, 1].
+        """
+        from autografs.porosity import void_fraction
+
+        return void_fraction(self, probe_radius=probe_radius, spacing=spacing)
+
+    def largest_cavity_diameter(self, spacing: float = 0.4) -> float:
+        """Diameter of the largest sphere fitting in the structure (LCD).
+
+        Parameters
+        ----------
+        spacing : float, optional
+            Grid resolution in Angstrom.
+
+        Returns
+        -------
+        float
+            The LCD in Angstrom; 0.0 for a dense structure.
+        """
+        from autografs.porosity import largest_cavity_diameter
+
+        return largest_cavity_diameter(self, spacing=spacing)
+
+    def pore_limiting_diameter(self, spacing: float = 0.4) -> float:
+        """Diameter of the largest sphere that can percolate through (PLD).
+
+        The limiting bottleneck of the pore network: the widest probe
+        that can travel through the periodic structure in any
+        direction. Always <= the largest cavity diameter.
+
+        Parameters
+        ----------
+        spacing : float, optional
+            Grid resolution in Angstrom.
+
+        Returns
+        -------
+        float
+            The PLD in Angstrom; 0.0 when no channel percolates.
+        """
+        from autografs.porosity import pore_limiting_diameter
+
+        return pore_limiting_diameter(self, spacing=spacing)
+
+    # ------------------------------------------------------------------
     # crystallographic exports
     # ------------------------------------------------------------------
 

--- a/src/autografs/porosity.py
+++ b/src/autografs/porosity.py
@@ -1,0 +1,239 @@
+"""
+Geometric porosity descriptors for built frameworks.
+
+For a generator of porous materials, the first questions about any
+output are geometric: how dense is it, how much empty space does it
+hold, how big is its largest cavity, and what is the widest probe that
+can actually travel through it? This module answers them with a
+periodic distance grid - ranking-quality numbers from pure geometry,
+not a replacement for Zeo++-grade analysis.
+
+All functions work on the vdW-surface convention: the distance field
+d(p) is the distance from point p to the nearest atom's van der Waals
+surface (negative inside an atom). A probe of radius r fits at p when
+d(p) >= r.
+
+- ``void_fraction``: fraction of the cell where a probe fits.
+- ``largest_cavity_diameter`` (LCD): diameter of the largest sphere
+  that fits anywhere in the structure.
+- ``pore_limiting_diameter`` (PLD): diameter of the largest sphere
+  that can percolate through the periodic structure - found by binary
+  search over the grid with a wrap-detecting union-find.
+
+Resolution is controlled by ``spacing`` (grid step in Angstrom):
+smaller is more accurate and slower; the 0.4 A default resolves
+typical MOF pores to a few tenths of an Angstrom.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+from pymatgen.analysis.local_env import CovalentRadius
+from pymatgen.core.periodic_table import Element
+from scipy.spatial import cKDTree
+
+if TYPE_CHECKING:
+    from autografs.framework import Framework
+
+__all__ = [
+    "void_fraction",
+    "largest_cavity_diameter",
+    "pore_limiting_diameter",
+]
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SPACING = 0.4
+
+# elements without a tabulated vdW radius fall back to their covalent
+# radius plus this pad (a typical covalent-to-vdW gap)
+_VDW_FALLBACK_PAD = 0.8
+
+
+def _vdw_radius(symbol: str) -> float:
+    radius = Element(symbol).van_der_waals_radius
+    if radius:
+        return float(radius)
+    return float(CovalentRadius.radius.get(symbol, 1.2) + _VDW_FALLBACK_PAD)
+
+
+def _distance_grid(
+    framework: Framework, spacing: float
+) -> tuple[np.ndarray, tuple[int, int, int]]:
+    """Distance from each grid point to the nearest vdW surface.
+
+    Returns the (n1*n2*n3,) distance array (negative inside atoms) and
+    the grid dimensions. Periodicity is handled by replicating atoms
+    into the 27 neighboring images; one KD-tree per element keeps the
+    per-element vdW offset exact.
+    """
+    cell = framework.cell
+    a, b, c = framework.lattice.abc
+    dims = (
+        max(2, math.ceil(a / spacing)),
+        max(2, math.ceil(b / spacing)),
+        max(2, math.ceil(c / spacing)),
+    )
+    axes = [(np.arange(n) + 0.5) / n for n in dims]
+    frac = np.stack(np.meshgrid(*axes, indexing="ij"), axis=-1).reshape(-1, 3)
+    points = frac @ cell
+
+    atom_frac = framework.cart_coords @ np.linalg.inv(cell) % 1.0
+    shifts = np.array(
+        [[i, j, k] for i in (-1, 0, 1) for j in (-1, 0, 1) for k in (-1, 0, 1)],
+        dtype=float,
+    )
+    symbols = np.array(framework.symbols)
+    distances = np.full(len(points), np.inf)
+    for symbol in sorted(set(symbols)):
+        element_frac = atom_frac[symbols == symbol]
+        images = (element_frac[None, :, :] + shifts[:, None, :]).reshape(-1, 3)
+        tree = cKDTree(images @ cell)
+        raw, _ = tree.query(points)
+        distances = np.minimum(distances, raw - _vdw_radius(symbol))
+    return distances, dims
+
+
+def void_fraction(
+    framework: Framework,
+    probe_radius: float = 0.0,
+    spacing: float = DEFAULT_SPACING,
+) -> float:
+    """Fraction of the cell volume where a probe sphere fits.
+
+    Parameters
+    ----------
+    framework : Framework
+        The framework to analyze.
+    probe_radius : float, optional
+        Probe radius in Angstrom; 0.0 (default) gives the geometric
+        void fraction outside the vdW surfaces. 1.2 approximates a
+        helium probe, 1.86 nitrogen.
+    spacing : float, optional
+        Grid resolution in Angstrom.
+
+    Returns
+    -------
+    float
+        Accessible-volume fraction, in [0, 1].
+    """
+    distances, _ = _distance_grid(framework, spacing)
+    return float(np.count_nonzero(distances >= probe_radius) / len(distances))
+
+
+def largest_cavity_diameter(
+    framework: Framework, spacing: float = DEFAULT_SPACING
+) -> float:
+    """Diameter of the largest sphere fitting anywhere in the cell (LCD).
+
+    Returns
+    -------
+    float
+        The LCD in Angstrom; 0.0 when no grid point lies outside the
+        vdW surfaces (a dense structure).
+    """
+    distances, _ = _distance_grid(framework, spacing)
+    best = float(distances.max())
+    return max(0.0, 2.0 * best)
+
+
+def pore_limiting_diameter(
+    framework: Framework, spacing: float = DEFAULT_SPACING
+) -> float:
+    """Diameter of the largest sphere that can travel through the net (PLD).
+
+    Binary-searches the probe radius: at each radius, the grid points
+    with enough clearance form a graph (periodic 6-neighbor
+    connectivity), and a wrap-detecting union-find checks whether any
+    open component connects to its own periodic image - the definition
+    of a percolating channel, in any direction.
+
+    Returns
+    -------
+    float
+        The PLD in Angstrom; 0.0 when not even a point probe
+        percolates (a closed-pore or dense structure).
+    """
+    distances, dims = _distance_grid(framework, spacing)
+    hi = float(distances.max())
+    if hi <= 0.0 or not _percolates(distances >= 0.0, dims):
+        return 0.0
+    lo = 0.0
+    # bisect until the radius bracket is far below the grid resolution
+    while hi - lo > spacing / 8.0:
+        mid = 0.5 * (lo + hi)
+        if _percolates(distances >= mid, dims):
+            lo = mid
+        else:
+            hi = mid
+    return 2.0 * lo
+
+
+def _percolates(open_mask: np.ndarray, dims: tuple[int, int, int]) -> bool:
+    """Whether the open grid cells contain a periodically wrapping path.
+
+    Union-find over the open cells, tracking each node's wrap count to
+    its root (one integer per lattice axis). Joining two cells that
+    already share a root through an edge whose wrap disagrees with the
+    recorded counts means the component connects to its own periodic
+    image - a percolating channel. Plain Python ints throughout: this
+    runs ~10^5 times per bisection step and numpy scalars would
+    dominate the cost.
+    """
+    n1, n2, n3 = dims
+    open_grid = open_mask.reshape(n1, n2, n3)
+    size = open_grid.size
+    parent = list(range(size))
+    wraps: list[tuple[int, int, int]] = [(0, 0, 0)] * size
+
+    def find(node: int) -> tuple[int, tuple[int, int, int]]:
+        # accumulate the wrap count along the chain to the root
+        root = node
+        w0 = w1 = w2 = 0
+        while parent[root] != root:
+            r0, r1, r2 = wraps[root]
+            w0, w1, w2 = w0 + r0, w1 + r1, w2 + r2
+            root = parent[root]
+        # path compression, keeping every wrap count consistent
+        current = node
+        a0, a1, a2 = w0, w1, w2
+        while parent[current] != root:
+            following = parent[current]
+            s0, s1, s2 = wraps[current]
+            parent[current] = root
+            wraps[current] = (a0, a1, a2)
+            a0, a1, a2 = a0 - s0, a1 - s1, a2 - s2
+            current = following
+        return root, (w0, w1, w2)
+
+    index = np.arange(size).reshape(n1, n2, n3)
+    unit_steps = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+    for axis in range(3):
+        neighbor = np.roll(index, -1, axis=axis)
+        crossing = np.zeros_like(open_grid, dtype=bool)
+        crossing[(slice(None),) * axis + (-1,)] = True
+        both_open = open_grid & open_grid.reshape(-1)[neighbor]
+        edges = zip(
+            index[both_open].tolist(),
+            neighbor[both_open].tolist(),
+            crossing[both_open].tolist(),
+            strict=True,
+        )
+        step_if_crossing = unit_steps[axis]
+        for a, b, crosses in edges:
+            step = step_if_crossing if crosses else (0, 0, 0)
+            root_a, (a0, a1, a2) = find(a)
+            root_b, (b0, b1, b2) = find(b)
+            delta = (a0 + step[0] - b0, a1 + step[1] - b1, a2 + step[2] - b2)
+            if root_a == root_b:
+                if delta != (0, 0, 0):
+                    return True
+                continue
+            # attach root_b under root_a with the consistent wrap count
+            parent[root_b] = root_a
+            wraps[root_b] = delta
+    return False

--- a/tests/test_porosity.py
+++ b/tests/test_porosity.py
@@ -1,0 +1,101 @@
+"""Tests for the geometric porosity descriptors.
+
+MOF-5 (built from the committed fixture) is the reference: its
+experimental descriptors are well known (density ~0.6 g/cm3, LCD
+~15 A, PLD ~8 A), so coarse-grid values must land in generous windows
+around them and obey the exact identities (PLD <= LCD, void fraction
+monotone in probe radius).
+"""
+
+import os
+
+import networkx
+import numpy as np
+import pytest
+
+from autografs.framework import Framework
+
+FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "data", "topologies_fixture.json"
+)
+
+# coarse grid: fast, and the assertion windows account for it
+SPACING = 0.5
+
+
+@pytest.fixture(scope="module")
+def mofgen():
+    from autografs import Autografs
+
+    return Autografs(topofile=FIXTURE_PATH)
+
+
+@pytest.fixture(scope="module")
+def mof5(mofgen):
+    topology = mofgen.topologies["pcu"]
+    mappings = {}
+    for key in topology.mappings:
+        conn = len(key.atoms.indices_from_symbol("X"))
+        mappings[key] = {6: "Zn_mof5_octahedral", 2: "Benzene_linear"}[conn]
+    return mofgen.build(topology, mappings=mappings, refine_cell=True, max_rmsd=0.5)
+
+
+@pytest.fixture(scope="module")
+def dense():
+    """A dense fcc-like metal: no pores at all."""
+    cell = np.eye(3) * 3.6
+    graph = networkx.Graph(cell=cell)
+    positions = [[0, 0, 0], [1.8, 1.8, 0], [1.8, 0, 1.8], [0, 1.8, 1.8]]
+    for i, coord in enumerate(positions):
+        graph.add_node(
+            i, symbol="Cu", coord=np.array(coord, dtype=float), tag=0, ufftype="Cu3+1"
+        )
+    for i in range(3):
+        graph.add_edge(i, i + 1, bond_order=1.0)
+    return Framework(graph, name="fcc_copper")
+
+
+class TestDensity:
+    def test_mof5_density(self, mof5):
+        # experimental MOF-5: ~0.59-0.62 g/cm3
+        assert 0.45 < mof5.density < 0.8
+
+    def test_dense_metal_density(self, dense):
+        # fcc copper: ~8.9 g/cm3
+        assert 7.0 < dense.density < 11.0
+
+
+class TestVoidFraction:
+    def test_mof5_is_mostly_empty(self, mof5):
+        vf = mof5.void_fraction(spacing=SPACING)
+        assert 0.5 < vf < 0.95
+
+    def test_monotone_in_probe_radius(self, mof5):
+        geometric = mof5.void_fraction(probe_radius=0.0, spacing=SPACING)
+        helium = mof5.void_fraction(probe_radius=1.2, spacing=SPACING)
+        nitrogen = mof5.void_fraction(probe_radius=1.86, spacing=SPACING)
+        assert geometric > helium > nitrogen > 0.0
+
+    def test_dense_metal_has_no_void(self, dense):
+        assert dense.void_fraction(spacing=0.3) < 0.05
+
+
+class TestPoreDiameters:
+    def test_mof5_lcd(self, mof5):
+        # literature LCD for MOF-5: ~15.1 A
+        lcd = mof5.largest_cavity_diameter(spacing=SPACING)
+        assert 11.0 < lcd < 18.0
+
+    def test_mof5_pld(self, mof5):
+        # literature PLD for MOF-5: ~7.8-8.0 A
+        pld = mof5.pore_limiting_diameter(spacing=SPACING)
+        assert 5.5 < pld < 10.5
+
+    def test_pld_never_exceeds_lcd(self, mof5):
+        lcd = mof5.largest_cavity_diameter(spacing=SPACING)
+        pld = mof5.pore_limiting_diameter(spacing=SPACING)
+        assert pld <= lcd
+
+    def test_dense_metal_has_no_pores(self, dense):
+        assert dense.largest_cavity_diameter(spacing=0.3) == 0.0
+        assert dense.pore_limiting_diameter(spacing=0.3) == 0.0


### PR DESCRIPTION
Fixes #66.

New `autografs.porosity` module with thin `Framework` delegates — the primary selection criteria for a porous-materials generator:

- `Framework.density` — g/cm3 via the pymatgen structure.
- `Framework.void_fraction(probe_radius=0.0, spacing=0.4)` — fraction of the cell where a probe sphere fits (0.0 = geometric void; 1.2 ≈ He, 1.86 ≈ N2).
- `Framework.largest_cavity_diameter()` (LCD) — largest included sphere.
- `Framework.pore_limiting_diameter()` (PLD) — largest sphere that can *travel through* the periodic structure, found by bisecting the probe radius with a wrap-detecting union-find over the open grid cells (a component that connects to its own periodic image is a percolating channel, in any direction).

Implementation notes:
- periodic distance field via one KD-tree per element over the 27 neighboring images, so per-element vdW offsets are exact;
- elements without a tabulated vdW radius fall back to covalent + 0.8 A;
- documented as ranking-quality geometry, not a Zeo++ replacement.

Tests bracket MOF-5's known values on a coarse grid (density ~0.6 g/cm3, LCD ~15 A, PLD ~8 A), assert the exact identities (PLD <= LCD, void fraction monotone in probe radius), and check a dense fcc metal reports zero porosity.

README's API tour gains the four one-liners.

Note: this branch may need a trivial rebase after #82 (both touch `__init__.py` and the same README section).

Full local suite, ruff, format, and mypy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)