### PR TITLE
build_all: opt-in structural deduplication of the results

### DIFF
--- a/src/autografs/builder.py
+++ b/src/autografs/builder.py
@@ -202,6 +202,36 @@ def _batched(iterable: Iterable, size: int):
         yield chunk
 
 
+def _deduplicate_frameworks(frameworks: list[Framework]) -> list[Framework]:
+    """Keep the first representative of each equivalence class.
+
+    Structures are pre-binned by reduced formula (different formulas
+    can never match), then compared within a bin with pymatgen's
+    StructureMatcher at its default tolerances. First occurrence wins,
+    so the result order is a stable subsequence of the input.
+    """
+    from pymatgen.analysis.structure_matcher import StructureMatcher
+
+    matcher = StructureMatcher()
+    kept: list[Framework] = []
+    kept_by_formula: dict[str, list[int]] = {}
+    for framework in frameworks:
+        formula = framework.structure.composition.reduced_formula
+        indices = kept_by_formula.setdefault(formula, [])
+        if any(
+            matcher.fit(kept[index].structure, framework.structure) for index in indices
+        ):
+            continue
+        indices.append(len(kept))
+        kept.append(framework)
+    if len(kept) < len(frameworks):
+        logger.info(
+            f"\t[x] Removed {len(frameworks) - len(kept)} structurally "
+            "equivalent duplicates."
+        )
+    return kept
+
+
 def _iter_combinations(
     options: list[list[str]],
     max_count: int | None,
@@ -304,6 +334,7 @@ class Autografs:
         max_per_topology: int | None = None,
         seed: int | None = None,
         n_jobs: int = 1,
+        deduplicate: bool = False,
     ) -> list[Framework]:
         """
         Builds all available structures based on the SBU and Topologies libraries
@@ -338,6 +369,13 @@ class Autografs:
             spawn start method re-imports the package (pymatgen
             included) in every worker, so a few seconds of warmup
             precede the first results.
+        deduplicate : bool, optional
+            Drop structurally equivalent duplicates from the result
+            (different SBU combinations can converge to the same
+            crystal). Matching uses pymatgen's StructureMatcher, keeps
+            the first representative of each equivalence class, and is
+            off by default: it is quadratic per composition group, and
+            the raw enumeration is sometimes the point.
 
         Returns
         -------
@@ -415,6 +453,8 @@ class Autografs:
             logger.info(
                 f"\t[x] Rate of error: {1.0 - len(frameworks) / attempted:2.2%}."
             )
+        if deduplicate:
+            frameworks = _deduplicate_frameworks(frameworks)
         return frameworks
 
     def build(

--- a/tests/test_fixture_builds.py
+++ b/tests/test_fixture_builds.py
@@ -210,6 +210,41 @@ class TestGoldenBuilds:
         parallel = mofgen.build_all(n_jobs=2, **kwargs)
         assert [fw.formula for fw in serial] == [fw.formula for fw in parallel]
 
+    def test_deduplicate_helper_drops_equivalent_structures(self, mofgen):
+        """Equivalent crystals collapse to their first representative."""
+        from autografs.builder import _deduplicate_frameworks
+
+        topology = mofgen.topologies["pcu"]
+        mappings = {}
+        for key in topology.mappings:
+            conn = len(key.atoms.indices_from_symbol("X"))
+            mappings[key] = {6: "Zn_mof5_octahedral", 2: "Benzene_linear"}[conn]
+        mof = mofgen.build(topology, mappings=mappings, refine_cell=False)
+        twin = mofgen.build(topology, mappings=mappings, refine_cell=False)
+        hcb = mofgen.topologies["hcb"]
+        layer_mappings = {}
+        for key in hcb.mappings:
+            conn = len(key.atoms.indices_from_symbol("X"))
+            layer_mappings[key] = {3: "Boroxine_triangle", 2: "Benzene_linear"}[conn]
+        layer = mofgen.build(hcb, mappings=layer_mappings, max_rmsd=0.5)
+
+        kept = _deduplicate_frameworks([mof, twin, layer])
+        assert kept == [mof, layer]  # first occurrence wins, order stable
+
+    def test_build_all_deduplicate_flag(self, mofgen):
+        kwargs = dict(
+            topology_subset=["pcu"],
+            max_per_topology=3,
+            seed=42,
+            refine_cell=False,
+        )
+        raw = mofgen.build_all(**kwargs)
+        deduped = mofgen.build_all(deduplicate=True, **kwargs)
+        assert 0 < len(deduped) <= len(raw)
+        # the deduplicated list is a stable subsequence of the raw one
+        it = iter(fw.formula for fw in raw)
+        assert all(any(f == g for g in it) for f in (fw.formula for fw in deduped))
+
     def test_cof1_like_build(self, mofgen):
         """hcb + boroxine + benzene = the COF-1 prototype layer.
 


### PR DESCRIPTION
Fixes #69.

`build_all(deduplicate=True)` drops structurally equivalent duplicates from the result list:

- pre-binned by reduced formula (different formulas can never match), then compared within a bin with `pymatgen.analysis.structure_matcher.StructureMatcher` at default tolerances;
- first occurrence wins, so the output is a stable subsequence of the raw enumeration;
- the removed count is logged;
- off by default: matching is quadratic per composition group, and the raw enumeration is sometimes what the user wants.

Tests cover the helper directly (two identical MOF-5 builds + one hcb layer collapse to two, order preserved) and the flag end-to-end on the pcu fixture.

Full local fixture-build suite, ruff, format, and mypy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)