### PR TITLE
Net verification: check that a built framework realizes its blueprint

### DIFF
--- a/src/autografs/__init__.py
+++ b/src/autografs/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     "fragment",
     "framework",
     "framework_io",
+    "net",
     "porosity",
     "topology",
     "topology_io",
@@ -67,6 +68,7 @@ __all__ = [
     "AutografsError",
     "Fragment",
     "Framework",
+    "NetMismatchError",
     "OverlapError",
     "RelaxationError",
     "Topology",
@@ -77,11 +79,12 @@ import logging
 # bind every module listed in __all__ as a package attribute; relax's
 # optional LAMMPS backends are imported lazily inside its functions,
 # so importing the module itself is cheap and always safe
-from autografs import framework_io, porosity, relax
+from autografs import framework_io, net, porosity, relax
 from autografs.builder import Autografs
 from autografs.exceptions import (
     AlignmentError,
     AutografsError,
+    NetMismatchError,
     OverlapError,
     RelaxationError,
 )

--- a/src/autografs/builder.py
+++ b/src/autografs/builder.py
@@ -71,6 +71,7 @@ def build_framework(
     verbose: bool = False,
     max_rmsd: float | None = None,
     min_distance: float | None = None,
+    verify_net: bool = False,
 ) -> Framework:
     """Build one framework from validated slot-index mappings.
 
@@ -95,6 +96,8 @@ def build_framework(
         Directional shape-mismatch gate; see Autografs.build.
     min_distance : float or None, optional
         Post-build overlap gate; see Autografs.build.
+    verify_net : bool, optional
+        Topological gate; see Autografs.build.
 
     Returns
     -------
@@ -155,6 +158,8 @@ def build_framework(
                 f"min_distance={min_distance:.2f} A, on topology "
                 f"{topology.name}: overlapping or interpenetrating output."
             )
+    if verify_net:
+        framework.verify_net(topology)
     return framework
 
 
@@ -465,6 +470,7 @@ class Autografs:
         verbose: bool = False,
         max_rmsd: float | None = None,
         min_distance: float | None = None,
+        verify_net: bool = False,
     ) -> Framework:
         """
         Generates a framework from a mapping of SBU to topology slots.
@@ -494,6 +500,13 @@ class Autografs:
             included. If any pair is closer, OverlapError is raised
             instead of returning an overlapping or interpenetrating
             structure. None (default) disables the screening.
+        verify_net : bool, optional
+            If True, verify that the output realizes the requested
+            topology by comparing labeled quotient graphs (see
+            Framework.verify_net); NetMismatchError is raised on a
+            mismatch. Catches mis-paired anchors and wrong periodic
+            images, which the geometric gates cannot see. False by
+            default.
 
         Returns
         -------
@@ -510,6 +523,9 @@ class Autografs:
         OverlapError
             If min_distance is set and any non-bonded contact in the
             output is closer than it.
+        NetMismatchError
+            If verify_net is set and the output does not realize the
+            blueprint's net.
         ValueError
             If the mappings leave topology slots unfilled.
         """
@@ -529,6 +545,7 @@ class Autografs:
             verbose=verbose,
             max_rmsd=max_rmsd,
             min_distance=min_distance,
+            verify_net=verify_net,
         )
 
     def _validate_mappings(

--- a/src/autografs/exceptions.py
+++ b/src/autografs/exceptions.py
@@ -30,6 +30,12 @@ class OverlapError(AutografsError):
     output)."""
 
 
+class NetMismatchError(AutografsError):
+    """Raised when a built framework's quotient graph does not realize
+    the blueprint topology (mis-paired anchors or a bond through the
+    wrong periodic image)."""
+
+
 class RelaxationError(AutografsError):
     """Raised when the optional LAMMPS relaxation backend is missing
     or a framework cannot be relaxed."""

--- a/src/autografs/framework.py
+++ b/src/autografs/framework.py
@@ -38,6 +38,8 @@ if TYPE_CHECKING:
     import ase
     from pymatgen.core.structure import Molecule
 
+    from autografs.topology import Topology
+
 __all__ = [
     "Framework",
 ]
@@ -197,6 +199,34 @@ class Framework:
         if not unbonded.any():
             return math.inf
         return float(distances[unbonded].min())
+
+    def verify_net(self, topology: Topology) -> None:
+        """Check that this as-built framework realizes its blueprint.
+
+        Compares the labeled quotient graphs (one node per slot, one
+        edge per inter-SBU bond with its periodic image voltage) as
+        exact multisets - the check that catches mis-paired anchors or
+        a bond through the wrong image, which the geometric gates
+        cannot see. Also available at build time via
+        ``build(..., verify_net=True)``.
+
+        Only meaningful for as-built frameworks: supercells, stacks
+        and defective frameworks intentionally change the quotient
+        graph.
+
+        Parameters
+        ----------
+        topology : Topology
+            The blueprint this framework was built on.
+
+        Raises
+        ------
+        NetMismatchError
+            If the framework does not realize the blueprint's net.
+        """
+        from autografs.net import verify_net
+
+        verify_net(self, topology)
 
     # ------------------------------------------------------------------
     # porosity descriptors (implementations in autografs.porosity)

--- a/src/autografs/net.py
+++ b/src/autografs/net.py
@@ -1,0 +1,235 @@
+"""
+Net verification: does a built framework realize its blueprint?
+
+The build gates check geometry (``max_rmsd``) and overlap
+(``min_distance``), but neither verifies that the output actually
+realizes the requested topology - mis-paired tags or a bond through
+the wrong periodic image would pass both while building a different
+net. This module closes that gap by comparing labeled quotient graphs.
+
+Both a Topology and a built Framework reduce to the same object: one
+node per slot, and one edge per inter-slot bond carrying an integer
+*voltage* (the periodic image offset between the two slots' home-cell
+representatives). Because every built atom records which blueprint
+slot it fills (the ``slot`` provenance attribute), the two quotient
+graphs share their node labels, and verification is an exact multiset
+comparison of canonicalized edges - no graph isomorphism search.
+
+>>> mof = mofgen.build(topology, mappings, verify_net=True)   # gated
+>>> mof.verify_net(topology)                                  # explicit
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from autografs.exceptions import NetMismatchError
+
+if TYPE_CHECKING:
+    from autografs.framework import Framework
+    from autografs.topology import Topology
+
+__all__ = [
+    "topology_quotient_edges",
+    "framework_quotient_edges",
+    "verify_net",
+]
+
+logger = logging.getLogger(__name__)
+
+# fractional coordinates are rounded to this many decimals before the
+# integer/fractional split, so a center sitting a float-noise away
+# from a cell boundary wraps identically on both sides
+_WRAP_DECIMALS = 6
+
+Edge = tuple[int, int, tuple[int, int, int]]
+
+
+def _split_image(frac: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Split fractional coords into integer image and wrapped remainder."""
+    stabilized = np.round(np.asarray(frac, dtype=float), _WRAP_DECIMALS)
+    image = np.floor(stabilized)
+    return image.astype(int), stabilized - image
+
+
+def _canonical(slot_a: int, slot_b: int, voltage: np.ndarray) -> Edge:
+    """Direction-independent form of one quotient edge.
+
+    An edge from a to b with voltage v equals the edge from b to a
+    with voltage -v; self-edges (a slot bonded to its own image)
+    canonicalize the voltage sign lexicographically.
+    """
+    v0, v1, v2 = (int(x) for x in voltage)
+    v = (v0, v1, v2)
+    negated = (-v0, -v1, -v2)
+    if slot_a < slot_b:
+        return (slot_a, slot_b, v)
+    if slot_b < slot_a:
+        return (slot_b, slot_a, negated)
+    return (slot_a, slot_a, max(v, negated))
+
+
+def _require_provenance(framework: Framework) -> None:
+    if any("slot" not in data for _, data in framework.graph.nodes(data=True)):
+        raise NetMismatchError(
+            "The framework graph carries no slot provenance; net "
+            "verification needs the per-atom 'slot' attributes recorded "
+            "at build time."
+        )
+
+
+def _topology_slot_images(topology: Topology) -> dict[int, np.ndarray]:
+    """Home-cell image of every blueprint slot's dummy centroid.
+
+    These are the shared gauge for both quotient graphs: the builder
+    places each SBU with its dummy centroid exactly at the blueprint
+    slot center, so using the blueprint's integer/fractional split on
+    both sides removes the per-node gauge freedom that would otherwise
+    let float noise at a cell boundary flip a voltage.
+    """
+    inv_cell = np.linalg.inv(topology.cell.matrix)
+    images: dict[int, np.ndarray] = {}
+    for slot_index, slot in enumerate(topology.slots):
+        dummy_idx = [
+            i for i, site in enumerate(slot.atoms) if site.specie.symbol == "X"
+        ]
+        dummy_frac = np.asarray(slot.atoms.cart_coords)[dummy_idx] @ inv_cell
+        images[slot_index], _ = _split_image(dummy_frac.mean(axis=0))
+    return images
+
+
+def topology_quotient_edges(topology: Topology) -> Counter[Edge]:
+    """The blueprint's labeled quotient graph as an edge multiset.
+
+    Nodes are slot indices; one edge per shared blueprint dummy (the
+    same tag on two slots), with the voltage worked out from the
+    dummies' coincident positions and the slots' home-cell images.
+    """
+    inv_cell = np.linalg.inv(topology.cell.matrix)
+    images = _topology_slot_images(topology)
+    tag_sites: dict[int, list[tuple[int, np.ndarray]]] = {}
+    for slot_index, slot in enumerate(topology.slots):
+        dummy_idx = [
+            i for i, site in enumerate(slot.atoms) if site.specie.symbol == "X"
+        ]
+        dummy_frac = np.asarray(slot.atoms.cart_coords)[dummy_idx] @ inv_cell
+        for i, dummy in zip(dummy_idx, dummy_frac, strict=True):
+            tag = int(slot.atoms[i].properties["tags"])
+            tag_sites.setdefault(tag, []).append((slot_index, dummy))
+    edges: Counter[Edge] = Counter()
+    for tag in sorted(tag_sites):
+        entries = tag_sites[tag]
+        if len(entries) < 2:
+            continue
+        # >2 slots on one tag is malformed input; prepare_build warns
+        # and bonds the first two, so the quotient must mirror that
+        (slot_a, frac_a), (slot_b, frac_b) = entries[:2]
+        shift = np.round(frac_a - frac_b).astype(int)
+        voltage = images[slot_b] + shift - images[slot_a]
+        edges[_canonical(slot_a, slot_b, voltage)] += 1
+    return edges
+
+
+def framework_quotient_edges(
+    framework: Framework, images: dict[int, np.ndarray] | None = None
+) -> Counter[Edge]:
+    """The built framework's labeled quotient graph as an edge multiset.
+
+    Nodes are the ``slot`` provenance ids; one edge per inter-slot
+    bond, with the voltage recovered from the bond's minimum-image
+    crossing and the slots' home-cell images (coordinates are
+    unwrapped cartesian, so both are exact integer roundings).
+
+    Parameters
+    ----------
+    framework : Framework
+        The built framework.
+    images : dict[int, np.ndarray] or None, optional
+        Home-cell image per slot id. verify_net passes the blueprint's
+        (see _topology_slot_images) so both sides share one gauge;
+        when omitted, images are derived from each placed SBU's atom
+        centroid - fine standalone, but a centroid within float noise
+        of a cell boundary may wrap differently than the blueprint's.
+    """
+    graph = framework.graph
+    _require_provenance(framework)
+    inv_cell = np.linalg.inv(framework.cell)
+    if images is None:
+        by_slot: dict[int, list[int]] = {}
+        for node, data in graph.nodes(data=True):
+            by_slot.setdefault(data["slot"], []).append(node)
+        images = {}
+        for slot, nodes in by_slot.items():
+            center = np.mean(
+                [np.asarray(graph.nodes[n]["coord"], dtype=float) for n in nodes],
+                axis=0,
+            )
+            images[slot], _ = _split_image(center @ inv_cell)
+    edges: Counter[Edge] = Counter()
+    for u, v in graph.edges():
+        slot_u = graph.nodes[u]["slot"]
+        slot_v = graph.nodes[v]["slot"]
+        if slot_u == slot_v:
+            continue
+        delta = np.asarray(graph.nodes[u]["coord"], dtype=float) - np.asarray(
+            graph.nodes[v]["coord"], dtype=float
+        )
+        shift = np.round(delta @ inv_cell).astype(int)
+        edges[_canonical(slot_u, slot_v, images[slot_v] + shift - images[slot_u])] += 1
+    return edges
+
+
+def verify_net(framework: Framework, topology: Topology) -> None:
+    """Check that a built framework realizes its blueprint topology.
+
+    Compares the labeled quotient graphs (slots + inter-slot bonds
+    with periodic image voltages) as exact edge multisets - possible
+    because the build records which blueprint slot every atom fills.
+    Only meaningful for as-built frameworks: supercells, stacks and
+    defective frameworks intentionally change the quotient graph.
+
+    Parameters
+    ----------
+    framework : Framework
+        The built framework (untouched by post-build editing).
+    topology : Topology
+        The blueprint it was built on.
+
+    Raises
+    ------
+    NetMismatchError
+        If the slot sets or the bonded quotient edges differ - the
+        framework does not realize the blueprint's net.
+    """
+    _require_provenance(framework)
+    built_slots = set(framework.slots)
+    blueprint_slots = set(range(len(topology)))
+    if built_slots != blueprint_slots:
+        raise NetMismatchError(
+            f"Framework {framework.name!r} fills slots "
+            f"{sorted(built_slots)} but topology {topology.name!r} has "
+            f"slots {sorted(blueprint_slots)}."
+        )
+    blueprint = topology_quotient_edges(topology)
+    # both quotient graphs use the blueprint's slot images: one shared
+    # gauge, so equal nets compare equal edge-for-edge (see
+    # _topology_slot_images)
+    built = framework_quotient_edges(framework, images=_topology_slot_images(topology))
+    if built == blueprint:
+        return
+    missing = blueprint - built
+    extra = built - blueprint
+    details = []
+    if missing:
+        details.append(f"missing inter-SBU bonds: {sorted(missing.elements())}")
+    if extra:
+        details.append(f"unexpected inter-SBU bonds: {sorted(extra.elements())}")
+    raise NetMismatchError(
+        f"Framework {framework.name!r} does not realize topology "
+        f"{topology.name!r} ({'; '.join(details)}). Edges are "
+        "(slot_a, slot_b, periodic image voltage)."
+    )

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -1,0 +1,110 @@
+"""Tests for the net verification gate (autografs.net)."""
+
+import os
+
+import networkx
+import numpy as np
+import pytest
+
+from autografs.exceptions import NetMismatchError
+from autografs.framework import Framework
+
+FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "data", "topologies_fixture.json"
+)
+
+
+@pytest.fixture(scope="module")
+def mofgen():
+    from autografs import Autografs
+
+    return Autografs(topofile=FIXTURE_PATH)
+
+
+def mappings_by_connectivity(topology, choices):
+    mappings = {}
+    for key in topology.mappings:
+        conn = len(key.atoms.indices_from_symbol("X"))
+        mappings[key] = choices[conn]
+    return mappings
+
+
+@pytest.fixture(scope="module")
+def mof5(mofgen):
+    topology = mofgen.topologies["pcu"]
+    mappings = mappings_by_connectivity(
+        topology, {6: "Zn_mof5_octahedral", 2: "Benzene_linear"}
+    )
+    return mofgen.build(topology, mappings=mappings, refine_cell=True, max_rmsd=0.5)
+
+
+class TestVerifyNet:
+    def test_as_built_framework_verifies(self, mofgen, mof5):
+        mof5.verify_net(mofgen.topologies["pcu"])  # must not raise
+
+    def test_2d_layer_verifies(self, mofgen):
+        topology = mofgen.topologies["hcb"]
+        mappings = mappings_by_connectivity(
+            topology, {3: "Boroxine_triangle", 2: "Benzene_linear"}
+        )
+        layer = mofgen.build(topology, mappings=mappings, max_rmsd=0.5)
+        layer.verify_net(topology)  # must not raise
+
+    def test_build_gate_passes(self, mofgen):
+        topology = mofgen.topologies["pcu"]
+        mappings = mappings_by_connectivity(
+            topology, {6: "Zn_mof5_octahedral", 2: "Benzene_linear"}
+        )
+        framework = mofgen.build(topology, mappings=mappings, verify_net=True)
+        assert len(framework) == 53
+
+    def test_wrong_topology_rejected(self, mofgen, mof5):
+        with pytest.raises(NetMismatchError, match="slots"):
+            mof5.verify_net(mofgen.topologies["dia"])
+
+    def test_missing_bond_detected(self, mofgen, mof5):
+        """Deleting one inter-SBU bond must break verification."""
+        broken = networkx.Graph(**mof5.graph.graph)
+        broken.add_nodes_from(mof5.graph.nodes(data=True))
+        broken.add_edges_from(mof5.graph.edges(data=True))
+        inter = next(
+            (u, v)
+            for u, v in broken.edges()
+            if broken.nodes[u]["slot"] != broken.nodes[v]["slot"]
+        )
+        broken.remove_edge(*inter)
+        with pytest.raises(NetMismatchError, match="missing inter-SBU"):
+            Framework(broken, name="broken").verify_net(mofgen.topologies["pcu"])
+
+    def test_wrong_image_detected(self, mofgen, mof5):
+        """Rewiring a boundary-crossing bond to the in-cell image (the
+        classic wrong-image failure) must break verification even
+        though node count, edge count, and degrees all stay right."""
+        rewired = networkx.Graph(**mof5.graph.graph)
+        rewired.add_nodes_from((n, dict(d)) for n, d in mof5.graph.nodes(data=True))
+        rewired.add_edges_from(mof5.graph.edges(data=True))
+        inv_cell = np.linalg.inv(mof5.cell)
+        # find a bond crossing the boundary and pull its far endpoint
+        # (and only it) into the home image
+        for u, v in rewired.edges():
+            if rewired.nodes[u]["slot"] == rewired.nodes[v]["slot"]:
+                continue
+            delta = np.asarray(rewired.nodes[u]["coord"]) - np.asarray(
+                rewired.nodes[v]["coord"]
+            )
+            shift = np.round(delta @ inv_cell)
+            if np.any(shift != 0):
+                coord = np.asarray(rewired.nodes[v]["coord"], dtype=float)
+                rewired.nodes[v]["coord"] = coord + shift @ mof5.cell
+                break
+        else:
+            pytest.fail("no boundary-crossing inter-SBU bond found")
+        with pytest.raises(NetMismatchError):
+            Framework(rewired, name="rewired").verify_net(mofgen.topologies["pcu"])
+
+    def test_no_provenance_rejected(self, mofgen):
+        graph = networkx.Graph(cell=np.eye(3) * 10)
+        graph.add_node(0, symbol="C", coord=np.zeros(3), tag=0, ufftype="C_R")
+        bare = Framework(graph, name="bare")
+        with pytest.raises(NetMismatchError, match="provenance"):
+            bare.verify_net(mofgen.topologies["pcu"])


### PR DESCRIPTION
Fixes #67.

The geometric gates (`max_rmsd`, `min_distance`) cannot see the one failure class that matters most: a framework whose bonds are mis-paired or run through the wrong periodic image builds a *different net* while passing both. New `autografs.net` module closes the gap:

- **Labeled quotient graphs**: both a `Topology` and a built `Framework` reduce to one node per slot and one edge per inter-slot bond carrying an integer *voltage* (periodic image offset). Because builds record which blueprint slot every atom fills, the two graphs share node labels and verification is an **exact multiset comparison** of canonicalized edges — no graph isomorphism search.
- **Shared gauge**: voltages are only defined up to a per-node image choice, so both sides use the blueprint's slot images (the builder places each SBU's dummy centroid exactly at the blueprint slot center). Without this, a slot centroid sitting float-noise from a cell boundary wraps differently on the two sides and falsely flips a voltage — caught by the hcb layer test during development.
- **API**: `Framework.verify_net(topology)` (raises `NetMismatchError` naming the missing/unexpected edges) and the opt-in build gate `build(..., verify_net=True)`. Documented as meaningful for as-built frameworks only — supercells, stacks, and defects intentionally change the quotient graph.

Tests: MOF-5/pcu and a 2D hcb layer verify clean; wrong topology, a deleted inter-SBU bond, and the classic wrong-image rewiring (same node count, edge count, and degrees — invisible to weaker checks) are all rejected; missing provenance fails with a clear message.

Full local suite, ruff, format, and mypy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)