### PR TITLE
Interpenetration builder: n-fold catenated frameworks

### DIFF
--- a/src/autografs/editing.py
+++ b/src/autografs/editing.py
@@ -245,6 +245,107 @@ def flip_sbu(framework: Framework, slot: int) -> Framework:
 
 
 # ----------------------------------------------------------------------
+# interpenetration / catenation
+# ----------------------------------------------------------------------
+
+# high-symmetry displacement candidates tried by offset="auto": body
+# center first (the classic dia-c / pcu-c catenation vector), then
+# face and edge centers
+_CATENATION_CANDIDATES: tuple[tuple[float, float, float], ...] = (
+    (0.5, 0.5, 0.5),
+    (0.5, 0.5, 0.0),
+    (0.5, 0.0, 0.5),
+    (0.0, 0.5, 0.5),
+    (0.5, 0.0, 0.0),
+    (0.0, 0.5, 0.0),
+    (0.0, 0.0, 0.5),
+)
+
+
+def _min_internet_contact(framework: Framework, n_atoms: int, cutoff: float) -> float:
+    """Smallest distance between atoms of different interpenetrated nets.
+
+    Copies are blocks of n_atoms consecutive node ids, so the net of
+    an atom is its id // n_atoms.
+    """
+    import math
+
+    centers, points, _, distances = framework.structure.get_neighbor_list(r=cutoff)
+    if len(distances) == 0:
+        return math.inf
+    different_net = (centers // n_atoms) != (points // n_atoms)
+    if not different_net.any():
+        return math.inf
+    return float(distances[different_net].min())
+
+
+def interpenetrate(
+    framework: Framework,
+    n: int = 2,
+    offset: tuple[float, float, float] | str = "auto",
+) -> Framework:
+    """Generate an n-fold interpenetrated (catenated) framework.
+
+    See Framework.interpenetrate for the user-facing documentation.
+    """
+    if n < 2:
+        raise ValueError(f"Interpenetration needs n >= 2 nets, got {n}.")
+    if isinstance(offset, str):
+        if offset != "auto":
+            raise ValueError(
+                f"offset must be a fractional 3-vector or 'auto', got {offset!r}."
+            )
+        candidates = _CATENATION_CANDIDATES
+    else:
+        candidates = (tuple(float(x) for x in offset),)  # type: ignore[assignment]
+        if len(candidates[0]) != 3:
+            raise ValueError(
+                f"offset must have three fractional components, got {offset!r}."
+            )
+    n_atoms = len(framework.graph)
+    best: tuple[float, Framework] | None = None
+    for candidate in candidates:
+        catenated = _displaced_copies(framework, n, candidate)
+        contact = _min_internet_contact(catenated, n_atoms, cutoff=6.0)
+        if best is None or contact > best[0]:
+            best = (contact, catenated)
+    assert best is not None  # candidates is never empty
+    contact, catenated = best
+    logger.info(
+        f"Interpenetrated {framework.name!r} {n}-fold; closest inter-net "
+        f"contact {contact:.2f} A."
+    )
+    return catenated
+
+
+def _displaced_copies(
+    framework: Framework, n: int, offset: tuple[float, float, float]
+) -> Framework:
+    """n copies of the framework, copy k displaced by k * offset."""
+    cell = framework.cell
+    graph = framework.graph
+    n_atoms = len(graph)
+    combined = networkx.Graph(cell=cell.copy())
+    tag_base = max((d["tag"] for _, d in graph.nodes(data=True)), default=0)
+    slot_base = (
+        max((d.get("slot", 0) for _, d in graph.nodes(data=True)), default=0) + 1
+    )
+    for k in range(n):
+        shift = (k * np.asarray(offset, dtype=float)) @ cell
+        for node, data in graph.nodes(data=True):
+            copied = dict(data)
+            copied["coord"] = np.asarray(data["coord"], dtype=float) + shift
+            if copied["tag"] > 0:
+                copied["tag"] += k * tag_base
+            if "slot" in copied:
+                copied["slot"] += k * slot_base
+            combined.add_node(node + k * n_atoms, **copied)
+        for i, j, data in graph.edges(data=True):
+            combined.add_edge(i + k * n_atoms, j + k * n_atoms, **dict(data))
+    return Framework(combined, name=f"{framework.name}_cat{n}")
+
+
+# ----------------------------------------------------------------------
 # supercells
 # ----------------------------------------------------------------------
 

--- a/src/autografs/framework.py
+++ b/src/autografs/framework.py
@@ -504,6 +504,47 @@ class Framework:
 
         return flip_sbu(self, slot=slot)
 
+    def interpenetrate(
+        self,
+        n: int = 2,
+        offset: tuple[float, float, float] | str = "auto",
+    ) -> Framework:
+        """Generate an n-fold interpenetrated (catenated) framework.
+
+        Places n displaced copies of this framework in the same cell -
+        the classic catenation of open nets (IRMOF-9/-11, dia-c,
+        pcu-c). Copy k is displaced by ``k * offset`` (fractional);
+        copies are van-der-Waals interlocked, never bonded, and their
+        tags and slot ids stay unique so every placed SBU remains
+        addressable.
+
+        Parameters
+        ----------
+        n : int, optional
+            Number of interpenetrated nets, by default 2.
+        offset : tuple[float, float, float] or "auto", optional
+            Fractional displacement between successive nets. "auto"
+            (default) tries the high-symmetry candidates (body center
+            first, then face and edge centers) and keeps the one whose
+            closest inter-net contact is largest.
+
+        Returns
+        -------
+        Framework
+            A new Framework; this one is unchanged. Check the result
+            with ``min_contact()`` - a dense parent framework cannot
+            host another net without clashes.
+
+        Examples
+        --------
+        >>> catenated = mof.interpenetrate()                  # auto offset
+        >>> catenated = mof.interpenetrate(2, (0.5, 0.5, 0.5))
+        >>> catenated.min_contact()
+        """
+        from autografs.editing import interpenetrate
+
+        return interpenetrate(self, n=n, offset=offset)
+
     def supercell(self, scale: int | tuple[int, int, int]) -> Framework:
         """Replicate the framework into a supercell.
 

--- a/tests/test_editing.py
+++ b/tests/test_editing.py
@@ -154,6 +154,63 @@ class TestFlip:
             mof5.flip(node_slot(mof5))
 
 
+class TestInterpenetrate:
+    def test_explicit_offset_geometry(self, mof5):
+        catenated = mof5.interpenetrate(2, (0.5, 0.5, 0.5))
+        n = len(mof5)
+        assert len(catenated) == 2 * n
+        assert catenated.graph.number_of_edges() == 2 * mof5.graph.number_of_edges()
+        assert len(catenated.slots) == 2 * len(mof5.slots)
+        np.testing.assert_allclose(catenated.cell, mof5.cell)
+        shift = np.array([0.5, 0.5, 0.5]) @ mof5.cell
+        for i in range(n):
+            np.testing.assert_allclose(
+                catenated.graph.nodes[i + n]["coord"],
+                mof5.graph.nodes[i]["coord"] + shift,
+            )
+
+    def test_no_internet_bonds(self, mof5):
+        catenated = mof5.interpenetrate(2, (0.5, 0.5, 0.5))
+        n = len(mof5)
+        for i, j in catenated.graph.edges():
+            assert i // n == j // n
+
+    def test_tags_stay_pairwise_and_disjoint_between_nets(self, mof5):
+        from collections import Counter
+
+        catenated = mof5.interpenetrate(2, (0.5, 0.5, 0.5))
+        counts = Counter(
+            d["tag"] for _, d in catenated.graph.nodes(data=True) if d["tag"] > 0
+        )
+        # every anchor pair stays a pair, and the second net's tags do
+        # not collide with the first's
+        assert counts and set(counts.values()) == {2}
+        original = Counter(
+            d["tag"] for _, d in mof5.graph.nodes(data=True) if d["tag"] > 0
+        )
+        assert len(counts) == 2 * len(original)
+
+    def test_auto_picks_a_roomy_offset(self, mof5):
+        """MOF-5's pore center hosts a second net with real clearance."""
+        catenated = mof5.interpenetrate()
+        assert len(catenated) == 2 * len(mof5)
+        # the interlocked nets must not clash
+        assert catenated.min_contact() > 1.0
+
+    def test_threefold(self, mof5):
+        catenated = mof5.interpenetrate(3, (1 / 3, 1 / 3, 1 / 3))
+        assert len(catenated) == 3 * len(mof5)
+        assert len(set(catenated.slots)) == 3 * len(mof5.slots)
+
+    def test_bad_arguments_rejected(self, mof5):
+        with pytest.raises(ValueError, match="n >= 2"):
+            mof5.interpenetrate(1)
+        with pytest.raises(ValueError, match="fractional 3-vector"):
+            mof5.interpenetrate(2, "diagonal")
+        with pytest.raises(ValueError, match="three fractional"):
+            mof5.interpenetrate(2, (0.5, 0.5))
+
+
 class TestSupercell:
     def test_counts_and_cell(self, mof5):
         supercell = mof5.supercell(2)


### PR DESCRIPTION
Fixes #68.

`Framework.interpenetrate(n=2, offset="auto")` generates catenated frameworks:

- copy k of the framework is displaced by `k * offset` (fractional) in the same cell;
- `offset="auto"` tries the high-symmetry candidates (body center first — the classic dia-c/pcu-c vector — then face and edge centers) and keeps the one maximizing the closest **inter-net** contact, measured between atoms of different nets only (the intra-net minimum is constant and would mask the comparison);
- nets are van-der-Waals interlocked, never bonded; per-copy tag and slot-id offsets keep every anchor pair and placed SBU uniquely addressable — the same bookkeeping `supercell` and `stack` use;
- the docstring points users at `min_contact()` for the final clash check, since a dense parent cannot host a second net.

Tests: exact geometry of the displaced copy, no inter-net bonds, pairwise tags disjoint between nets, auto mode yields clash-free 2-fold MOF-5 (pore center has real clearance), 3-fold catenation, and argument validation.

Full editing test set, ruff, format, and mypy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)