### PR TITLE
CLI wizard: post-build editing in the export menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ A guided session covers the whole workflow without writing a script:
   the combinations per topology, and write every resulting CIF to a directory.
 - 2D layer builds offer **COF stacking** (AA / AB / serrated / staggered,
   chosen interlayer spacing) before export.
+- The final menu is an **edit/export loop**: make a supercell, add statistical
+  defects, functionalize sites, rotate a placed linker, interpenetrate
+  (catenate), or relax with UFF4MOF — each edit feeds the next — then export.
 - Export formats: CIF, GULP input (UFF4MOF optimization), or straight into the
   ASE viewer.
 

--- a/src/autografs/cli.py
+++ b/src/autografs/cli.py
@@ -457,20 +457,208 @@ def maybe_stack(framework: Framework, topology: Topology) -> Framework:
     return stacked
 
 
+# ----------------------------------------------------------------------
+# post-build editing (pure helpers first, prompts below)
+# ----------------------------------------------------------------------
+
+
+def parse_multipliers(text: str) -> tuple[int, int, int]:
+    """Parse '2' or '2 2 1' (spaces or commas) into three positive ints."""
+    parts = [p for p in re.split(r"[,\s]+", text.strip()) if p]
+    if len(parts) == 1:
+        parts = parts * 3
+    if len(parts) != 3:
+        raise ValueError("give one multiplier or three (a b c)")
+    a, b, c = (int(p) for p in parts)
+    if min(a, b, c) < 1:
+        raise ValueError("multipliers must be >= 1")
+    return (a, b, c)
+
+
+def parse_indices(text: str) -> list[int]:
+    """Parse comma/space-separated atom indices into a sorted list."""
+    parts = [p for p in re.split(r"[,\s]+", text.strip()) if p]
+    if not parts:
+        raise ValueError("no indices given")
+    return sorted({int(p) for p in parts})
+
+
+def rotatable_slots(framework: Framework) -> list[int]:
+    """Placed SBUs with exactly two connection points (rotatable linkers)."""
+    anchors: dict[int, int] = {}
+    for _, data in framework.graph.nodes(data=True):
+        if data.get("tag", 0) > 0 and "slot" in data:
+            anchors[data["slot"]] = anchors.get(data["slot"], 0) + 1
+    return sorted(slot for slot, count in anchors.items() if count == 2)
+
+
+def _edit_supercell(framework: Framework) -> Framework | None:
+    text = questionary.text("Multipliers (one value or 'a b c'):", default="2").ask()
+    if text is None:
+        return None
+    try:
+        return framework.supercell(parse_multipliers(text))
+    except ValueError as exc:
+        console.print(f"[red]Supercell failed:[/red] {exc}")
+        return None
+
+
+def _edit_defects(framework: Framework) -> Framework | None:
+    names = sorted(set(framework.slots.values()))
+    if not names:
+        console.print("[yellow]No placed SBUs to remove.[/yellow]")
+        return None
+    target = questionary.select("Remove which SBU?", choices=["any"] + names).ask()
+    if target is None:
+        return None
+    fraction_text = questionary.text(
+        "Fraction to remove (0-1):",
+        default="0.1",
+        validate=_validate_positive_float,
+    ).ask()
+    if fraction_text is None:
+        return None
+    seed_text = questionary.text("Random seed (empty = unseeded):").ask()
+    if seed_text is None:
+        return None
+    try:
+        return framework.defects(
+            fraction=float(fraction_text),
+            sbu=None if target == "any" else target,
+            seed=int(seed_text) if seed_text.strip() else None,
+        )
+    except ValueError as exc:
+        console.print(f"[red]Defect generation failed:[/red] {exc}")
+        return None
+
+
+def _edit_functionalize(framework: Framework) -> Framework | None:
+    from pymatgen.core.structure import FunctionalGroups
+
+    symbol = questionary.text("Element to replace:", default="H").ask()
+    if symbol is None:
+        return None
+    sites = framework.functionalizable_sites(symbol=symbol.strip())
+    if not sites:
+        console.print(f"[yellow]No functionalizable {symbol} sites.[/yellow]")
+        return None
+    group = questionary.select(
+        f"Functional group for {len(sites)} candidate sites:",
+        choices=sorted(FunctionalGroups),
+    ).ask()
+    if group is None:
+        return None
+    which = questionary.select(
+        "Which sites?",
+        choices=[f"All {len(sites)} sites", "Enter site indices..."],
+    ).ask()
+    if which is None:
+        return None
+    chosen = sites
+    if which.startswith("Enter"):
+        text = questionary.text(f"Indices (candidates: {sites}):").ask()
+        if text is None:
+            return None
+        try:
+            chosen = parse_indices(text)
+        except ValueError as exc:
+            console.print(f"[red]Bad indices:[/red] {exc}")
+            return None
+    try:
+        return framework.functionalize(chosen, group)
+    except ValueError as exc:
+        console.print(f"[red]Functionalization failed:[/red] {exc}")
+        return None
+
+
+def _edit_rotate(framework: Framework) -> Framework | None:
+    candidates = rotatable_slots(framework)
+    if not candidates:
+        console.print("[yellow]No 2-connected placed SBU to rotate.[/yellow]")
+        return None
+    labels = {f"slot {s} ({framework.slots[s]})": s for s in candidates}
+    pick = questionary.select("Rotate which linker?", choices=list(labels)).ask()
+    if pick is None:
+        return None
+    angle_text = questionary.text(
+        "Angle in degrees:", default="90", validate=_validate_positive_float
+    ).ask()
+    if angle_text is None:
+        return None
+    try:
+        import math
+
+        return framework.rotate(labels[pick], math.radians(float(angle_text)))
+    except ValueError as exc:
+        console.print(f"[red]Rotation failed:[/red] {exc}")
+        return None
+
+
+def _edit_interpenetrate(framework: Framework) -> Framework | None:
+    n_text = questionary.text(
+        "Number of interlocked nets:", default="2", validate=_validate_positive_int
+    ).ask()
+    if n_text is None:
+        return None
+    try:
+        catenated = framework.interpenetrate(n=int(n_text))
+        contact = catenated.min_contact()
+        console.print(f"Closest contact in the catenated result: {contact:.2f} A")
+        return catenated
+    except ValueError as exc:
+        console.print(f"[red]Interpenetration failed:[/red] {exc}")
+        return None
+
+
+def _edit_relax(framework: Framework) -> Framework | None:
+    from autografs.exceptions import RelaxationError
+
+    try:
+        with console.status("Relaxing with UFF4MOF via LAMMPS..."):
+            relaxed = framework.relax()
+        console.print(
+            f"[green]Relaxed[/green] {relaxed!r} "
+            f"(energy {relaxed.energy:.1f} kcal/mol per cell)"
+        )
+        return relaxed
+    except RelaxationError as exc:
+        console.print(f"[red]Relaxation failed:[/red] {exc}")
+        return None
+
+
 def export_step(framework: Framework, default_name: str) -> None:
-    """Export loop: CIF, GULP input, ASE viewer; repeats until Done."""
+    """Edit / export loop: post-build editing and exports until Done.
+
+    Every edit produces a new framework that the loop continues with;
+    a failed edit keeps the current one.
+    """
+    edits = {
+        "Make a supercell": _edit_supercell,
+        "Add statistical defects": _edit_defects,
+        "Functionalize sites": _edit_functionalize,
+        "Rotate a placed linker": _edit_rotate,
+        "Interpenetrate (catenate)": _edit_interpenetrate,
+        "Relax with UFF4MOF": _edit_relax,
+    }
     while True:
         action = questionary.select(
-            "Export:",
+            "Edit or export:",
             choices=[
                 "Write CIF",
                 "Write GULP input (UFF4MOF optimization)",
                 "Open in the ASE viewer",
+                *edits,
                 "Done",
             ],
         ).ask()
         if action is None or action == "Done":
             return
+        if action in edits:
+            edited = edits[action](framework)
+            if edited is not None:
+                framework = edited
+                console.print(f"[green]Now editing[/green] {framework!r}")
+            continue
         if action == "Write CIF":
             path = questionary.text("Output path:", default=default_name).ask()
             if not path:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,9 @@ from autografs.cli import (
     connectivity,
     default_output_name,
     main,
+    parse_indices,
+    parse_multipliers,
+    rotatable_slots,
     slot_label,
     slot_labels,
     sorted_slot_types,
@@ -105,6 +108,40 @@ class TestSlotTypeOrdering:
             int(label.split(" - ")[1].split()[0]) for label in labels.values()
         )
         assert n_labeled == len(topology)
+
+
+class TestEditingHelpers:
+    """Pure helpers behind the edit/export menu."""
+
+    def test_parse_multipliers_single_value(self):
+        assert parse_multipliers("2") == (2, 2, 2)
+
+    def test_parse_multipliers_three_values(self):
+        assert parse_multipliers("2, 1 3") == (2, 1, 3)
+
+    def test_parse_multipliers_rejects_garbage(self):
+        with pytest.raises(ValueError):
+            parse_multipliers("2 2")
+        with pytest.raises(ValueError):
+            parse_multipliers("0")
+        with pytest.raises(ValueError):
+            parse_indices("")
+
+    def test_parse_indices(self):
+        assert parse_indices("3, 1 2, 3") == [1, 2, 3]
+
+    def test_rotatable_slots_are_the_linkers(self, mofgen):
+        topology = mofgen.topologies["pcu"]
+        mappings = {}
+        for key in topology.mappings:
+            conn = len(key.atoms.indices_from_symbol("X"))
+            mappings[key] = {6: "Zn_mof5_octahedral", 2: "Benzene_linear"}[conn]
+        mof5 = mofgen.build(topology, mappings=mappings, refine_cell=False)
+        linkers = rotatable_slots(mof5)
+        assert linkers
+        assert all(mof5.slots[s] == "Benzene_linear" for s in linkers)
+        node = next(s for s, n in mof5.slots.items() if n == "Zn_mof5_octahedral")
+        assert node not in linkers
 
 
 class TestEntryPoint:


### PR DESCRIPTION
Fixes #65.

The wizard's final step becomes an **edit/export loop** exposing the whole post-build editing API to non-scripting users:

- **Make a supercell** — one multiplier or `a b c`;
- **Add statistical defects** — SBU filter, fraction, optional seed;
- **Functionalize sites** — element filter, group picker from pymatgen's `FunctionalGroups`, all sites or explicit indices;
- **Rotate a placed linker** — offers only the 2-connected placed SBUs, angle in degrees;
- **Interpenetrate (catenate)** — n nets with the auto offset, reporting the resulting closest contact;
- **Relax with UFF4MOF** — graceful message when the `[relax]` extra is missing.

Every edit returns a new framework the loop continues with (announced via its repr); a failed edit keeps the current one; the CIF/GULP/viewer export actions are unchanged.

Parsing and slot-picking live in pure, unit-tested helpers (`parse_multipliers`, `parse_indices`, `rotatable_slots`) — consistent with how the CLI is tested (prompt flows are manual-test territory, per the existing test module docstring). README's wizard section documents the new loop.

Full CLI test set, ruff, format, and mypy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)