### PR TITLE
fix: harvest() crashes on absolute glob patterns

### DIFF
--- a/src/autografs/harvest.py
+++ b/src/autografs/harvest.py
@@ -27,6 +27,7 @@ linkers are what feeds the builder.
 
 from __future__ import annotations
 
+import glob
 import logging
 import re
 from dataclasses import dataclass, field
@@ -169,7 +170,9 @@ def _iter_sources(sources: Source | Iterable[Source]) -> list[tuple[str, Source]
             files = sorted(p for p in path.iterdir() if p.suffix.lower() == ".cif")
             return [(p.stem, p) for p in files]
         if any(ch in str(sources) for ch in "*?[") and not path.exists():
-            matches = sorted(Path().glob(str(sources)))
+            # glob.glob, not Path().glob: pathlib refuses absolute
+            # patterns ("Non-relative patterns are unsupported")
+            matches = sorted(Path(match) for match in glob.glob(str(sources)))
             return [(p.stem, p) for p in matches]
         return [(path.stem, path)]
     # an iterable of sources

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -124,6 +124,35 @@ class TestHarvestInputs:
         assert "node_C6O13Zn4_6X" in result.fragments
 
 
+class TestIterSources:
+    """_iter_sources is pure path plumbing; no deconstruction runs."""
+
+    @pytest.fixture()
+    def cif_files(self, tmp_path):
+        for stem in ("alpha", "beta"):
+            (tmp_path / f"{stem}.cif").write_text("placeholder\n")
+        (tmp_path / "notes.txt").write_text("ignored\n")
+        return tmp_path
+
+    def test_absolute_glob_pattern(self, cif_files):
+        from autografs.harvest import _iter_sources
+
+        pairs = _iter_sources(str(cif_files / "*.cif"))
+        assert [label for label, _ in pairs] == ["alpha", "beta"]
+
+    def test_relative_glob_pattern(self, cif_files, monkeypatch):
+        from autografs.harvest import _iter_sources
+
+        monkeypatch.chdir(cif_files)
+        pairs = _iter_sources("*.cif")
+        assert [label for label, _ in pairs] == ["alpha", "beta"]
+
+    def test_glob_matching_nothing_is_empty(self, cif_files):
+        from autografs.harvest import _iter_sources
+
+        assert _iter_sources(str(cif_files / "*.xyz")) == []
+
+
 class TestHarvestRobustness:
     def test_unreadable_file_recorded_not_raised(self, mofgen, mof5, tmp_path):
         mof5.write_cif(tmp_path / "good.cif")


### PR DESCRIPTION
`_iter_sources` resolved glob strings with `Path().glob(...)`, which raises `NotImplementedError: Non-relative patterns are unsupported` for any absolute pattern — the natural input on Windows. Switched to stdlib `glob.glob`, which handles both, and added `_iter_sources` unit tests (absolute glob, relative glob, empty match).

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)