### PR TITLE
fix: build_all diagnostics, subset validation, signed CLI rotation angles

### DIFF
--- a/src/autografs/builder.py
+++ b/src/autografs/builder.py
@@ -187,7 +187,15 @@ def _build_one(
             max_rmsd=max_rmsd,
             min_distance=min_distance,
         )
-    except (AssertionError, AlignmentError, OverlapError, ValueError):
+    except (AlignmentError, OverlapError):
+        # the quality gates rejecting a combination is the expected
+        # outcome of an enumeration sweep; nothing to report
+        return None
+    except (AssertionError, ValueError):
+        # unexpected failure types: still skip the combination (a sweep
+        # must not abort), but leave a diagnosable trace instead of
+        # only inflating the error-rate statistic
+        logger.debug(f"Unexpected failure building on {topology.name!r}", exc_info=True)
         return None
 
 
@@ -774,6 +782,9 @@ class Autografs:
         >>> print(sorted(by_connectivity))  # [1, 2, 3, 4, ...]
         """
         if subset is not None:
+            unknown = set(subset) - self.sbu.keys()
+            if unknown:
+                raise ValueError(f"Unknown SBUs in subset: {sorted(unknown)}")
             sbus = [self.sbu[k] for k in subset]
         else:
             sbus = list(self.sbu.values())

--- a/src/autografs/cli.py
+++ b/src/autografs/cli.py
@@ -173,6 +173,14 @@ def topology_summary_table(topology: Topology) -> Table:
 # ----------------------------------------------------------------------
 
 
+def _validate_float(text: str) -> bool | str:
+    try:
+        float(text)
+    except ValueError:
+        return "Enter a number"
+    return True
+
+
 def _validate_positive_float(text: str) -> bool | str:
     try:
         value = float(text)
@@ -581,7 +589,7 @@ def _edit_rotate(framework: Framework) -> Framework | None:
     if pick is None:
         return None
     angle_text = questionary.text(
-        "Angle in degrees:", default="90", validate=_validate_positive_float
+        "Angle in degrees:", default="90", validate=_validate_float
     ).ask()
     if angle_text is None:
         return None

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -6,6 +6,7 @@ and building functionality. Some tests require the full data files
 and are marked accordingly.
 """
 
+import logging
 import os
 import tempfile
 
@@ -425,6 +426,53 @@ class TestListBuildingUnits:
             for name in names:
                 sbu = mofgen.sbu[name]
                 assert len(sbu.atoms.indices_from_symbol("X")) == conn
+
+    def test_unknown_subset_raises(self, synthetic_mofgen):
+        """Unknown SBU names in subset fail loudly, like list_topologies."""
+        with pytest.raises(ValueError, match="no_such_sbu"):
+            synthetic_mofgen.list_building_units(subset=["no_such_sbu"])
+
+
+class TestBuildOneDiagnostics:
+    """_build_one keeps sweeps alive but must not hide real bugs."""
+
+    def test_expected_gate_failures_are_silent(self, caplog, monkeypatch):
+        import autografs.builder as builder_module
+        from autografs.exceptions import AlignmentError
+
+        def raise_gate(*args, **kwargs):
+            raise AlignmentError("shape mismatch")
+
+        monkeypatch.setattr(builder_module, "build_framework", raise_gate)
+        with caplog.at_level(logging.DEBUG, logger="autografs.builder"):
+            result = builder_module._build_one(
+                topology=type("T", (), {"name": "fake"})(),
+                mappings={},
+                refine_cell=False,
+                max_rmsd=None,
+                min_distance=None,
+            )
+        assert result is None
+        assert caplog.records == []
+
+    def test_unexpected_failures_leave_a_trace(self, caplog, monkeypatch):
+        import autografs.builder as builder_module
+
+        def raise_bug(*args, **kwargs):
+            raise ValueError("a genuine pipeline bug")
+
+        monkeypatch.setattr(builder_module, "build_framework", raise_bug)
+        with caplog.at_level(logging.DEBUG, logger="autografs.builder"):
+            result = builder_module._build_one(
+                topology=type("T", (), {"name": "fake"})(),
+                mappings={},
+                refine_cell=False,
+                max_rmsd=None,
+                min_distance=None,
+            )
+        assert result is None
+        assert any("fake" in record.message for record in caplog.records)
+        assert any(record.exc_info for record in caplog.records)
 
 
 # =============================================================================

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -130,6 +130,14 @@ class TestEditingHelpers:
     def test_parse_indices(self):
         assert parse_indices("3, 1 2, 3") == [1, 2, 3]
 
+    def test_rotation_angle_accepts_negative(self):
+        """Rotation angles are signed; the prompt must accept -90."""
+        from autografs.cli import _validate_float
+
+        assert _validate_float("-90") is True
+        assert _validate_float("90") is True
+        assert _validate_float("spin") != True  # noqa: E712 - questionary contract
+
     def test_rotatable_slots_are_the_linkers(self, mofgen):
         topology = mofgen.topologies["pcu"]
         mappings = {}


### PR DESCRIPTION
Three small fixes from the bug-hunt list:

- **#104**: `_build_one` kept sweeps alive by swallowing `ValueError`/`AssertionError` along with the expected gate failures — a genuine pipeline bug surfaced only as an inflated "rate of error" statistic. Gate rejections stay silent; unexpected exception types now log a debug-level traceback naming the topology. Tested both paths with caplog.
- **#105**: `list_building_units(subset=...)` raised a bare `KeyError` on unknown SBU names; it now validates like `list_topologies` does.
- **#106**: the CLI rotation prompt validated angles as *positive* floats, so `-90` could not be typed. New `_validate_float` accepts any finite number.

Fixes #104
Fixes #105
Fixes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)