### PR TITLE
chore: single-source the package version

### DIFF
--- a/src/autografs/__init__.py
+++ b/src/autografs/__init__.py
@@ -44,11 +44,18 @@ References
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _dist_version
+
 __author__ = "Damien Coupry"
 __credits__ = ["Prof. Matthew Addicoat"]
 __license__ = "MIT"
 __maintainer__ = "Damien Coupry"
-__version__ = "3.0.0"
+try:
+    # single source of truth: the version in pyproject.toml
+    __version__ = _dist_version("AuToGraFS")
+except PackageNotFoundError:  # a source tree that was never installed
+    __version__ = "0.0.0+uninstalled"
 __status__ = "production"
 __all__ = [
     "utils",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -15,18 +15,21 @@ class TestPackageImports:
 
         assert hasattr(autografs, "__version__")
 
-    def test_version_defined(self):
-        """Test that version is defined and valid."""
+    def test_version_matches_installed_metadata(self):
+        """__version__ is read from the installed distribution, so it
+        can never drift from pyproject.toml."""
+        from importlib.metadata import version
+
         from autografs import __version__
 
-        assert __version__ == "3.0.0"
         assert isinstance(__version__, str)
+        assert __version__ == version("AuToGraFS")
 
     def test_version_format(self):
         """Test version follows semantic versioning format."""
         from autografs import __version__
 
-        parts = __version__.split(".")
+        parts = __version__.split(".")[:3]
         assert len(parts) == 3
         assert all(part.isdigit() for part in parts)
 


### PR DESCRIPTION
`__version__` was hardcoded in `__init__.py` alongside `version = "3.0.0"` in pyproject.toml — agreeing today, guaranteed to desync on the first bump. It now reads `importlib.metadata.version("AuToGraFS")` with an `0.0.0+uninstalled` fallback for never-installed source trees; pyproject.toml is the single source of truth. Tests now assert `__version__` matches the installed metadata rather than pinning a literal.

Deliberately **not** bumping the version number here — whether the shipped deconstruction/harvest/COF/porosity work makes this 3.1 is a release decision for the maintainer (tracked in #112).

Fixes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)