### PR TITLE
release: 3.1.0 — attach dist to GitHub releases, tag/version guard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,18 @@ jobs:
       - name: Check package
         run: twine check dist/*
 
+      # guard against tagging the wrong commit: a vX.Y.Z release must
+      # ship exactly the version pyproject.toml declares
+      - name: Verify the release tag matches the package version
+        if: github.event_name == 'release'
+        run: |
+          version=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          tag="${{ github.event.release.tag_name }}"
+          if [ "v${version}" != "${tag}" ]; then
+            echo "Release tag ${tag} does not match package version v${version}."
+            exit 1
+          fi
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -69,6 +81,30 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+
+  # attach the wheel and sdist to the GitHub release itself: workflow
+  # artifacts expire and need a login, release assets are permanent
+  # and public
+  github-release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'release'
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Attach wheel and sdist to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >
+          gh release upload "${{ github.event.release.tag_name }}"
+          dist/* --clobber --repo "${{ github.repository }}"
 
   publish-pypi:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "AuToGraFS"
-version = "3.0.0"
+version = "3.1.0"
 description = "Automatic Topological Generator for Framework Structures"
 readme = "README.md"
 license = {text = "MIT"}
@@ -24,12 +24,14 @@ keywords = [
     "computational chemistry"
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Chemistry",
     "Topic :: Scientific/Engineering :: Physics",
 ]


### PR DESCRIPTION
Prepares the 3.1.0 release (the release half of #112):

- **Version 3.1.0** in pyproject.toml — the single source since #118; `__version__` follows automatically. Covers everything since 3.0.0: deconstruction (metal-oxo + COF branch-point paths), batch harvesting, catenation, COF stacking, porosity descriptors, Framework save/load, net verification/identification, the CLI deconstruct wizard, and the bug-hunt fixes.
- **Classifiers**: `Development Status :: 5 - Production/Stable`, and Python 3.12/3.13 added (both already in the CI test matrix).
- **publish.yml**:
  - new `github-release` job attaches the built wheel + sdist to the GitHub release itself (workflow artifacts expire after 90 days and need a login; release assets are permanent and public);
  - the build job now verifies a `vX.Y.Z` release tag matches pyproject.toml's version, failing fast on a mis-tagged commit.

After merge the plan is: `gh release create v3.1.0 --generate-notes` → the publish workflow builds, attaches assets, and publishes to PyPI via trusted publishing (environment `pypi`, OIDC — no tokens stored).

⚠️ **PyPI prerequisite**: [pypi.org/project/AuToGraFS](https://pypi.org/project/AuToGraFS/) currently tops out at 2.3.2 and has no trusted publisher configured for this repo as far as the workflow history shows (publish.yml has never run). Before or after the release, the project owner needs to add a trusted publisher on PyPI (project settings → Publishing): owner `DCoupry`, repository `autografs`, workflow `publish.yml`, environment `pypi`. If the release fires before that's in place, only the `publish-pypi` job fails — re-run it (or `workflow_dispatch` with target `pypi`) once configured.

Part of #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)