### PR TITLE
build_all: exhaustive enumeration (max_per_topology=-1) + up-front combination count

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -82,6 +82,10 @@ frameworks = mofgen.build_all(
 Failed builds are counted and skipped, not raised. Multinodal nets have
 combinatorially many SBU choices; when the full product exceeds
 `max_per_topology`, a seeded sample of distinct combinations is built instead.
+Passing `max_per_topology=-1` (or `None`, the default) disables the cap and
+enumerates exhaustively. Either way the total combination count over all
+buildable topologies is logged before the first build starts, so an
+exhaustive run can be cost-estimated — and aborted — while still cheap.
 
 ## Working with the result
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,7 +29,8 @@ A guided session covers the whole workflow without writing a script:
 - **Browse building units** — composition, connectivity, dummy point group,
   and how many nets the SBU fits.
 - **Batch build** — a front-end for `build_all`: pick a topology subset, cap
-  the combinations per topology, and write every resulting CIF to a directory.
+  the combinations per topology (-1 disables the cap), and write every
+  resulting CIF to a directory.
 - 2D layer builds offer **COF stacking** (AA / AB / serrated / staggered,
   chosen interlayer spacing) before export.
 - The final menu is an **edit/export loop**: make a supercell, add statistical

--- a/src/autografs/builder.py
+++ b/src/autografs/builder.py
@@ -374,7 +374,10 @@ class Autografs:
             Cap on the SBU combinations attempted per topology. The
             full product over slot types explodes combinatorially on
             multinodal nets; when it exceeds the cap, a seeded random
-            sample of distinct combinations is built instead.
+            sample of distinct combinations is built instead. -1 (or
+            None, the default) disables the cap and enumerates
+            exhaustively; the total combination count is logged before
+            building starts so the cost is visible up front.
         seed : int or None, optional
             Seed for the sampling generator; a fixed seed makes the
             sampled enumeration reproducible.
@@ -398,31 +401,61 @@ class Autografs:
         list[Framework]
             the frameworks produced by the building method
         """
+        if max_per_topology is not None and max_per_topology < 1:
+            if max_per_topology != -1:
+                raise ValueError(
+                    "max_per_topology must be a positive integer, or -1/None "
+                    f"for no cap, got {max_per_topology}"
+                )
+            max_per_topology = None
         logger.info("Building All Available Structures! This will take some time.")
         logger.info("============================================================")
         rng = np.random.default_rng(seed)
         frameworks: list[Framework] = []
         attempted = 0
+        # sieve pass first, so the full enumeration size is known (and
+        # logged) before the first build starts: exhaustive runs can be
+        # cost-estimated and aborted while still cheap
+        plans: list[tuple[str, list[Fragment | int], list[list[str]]]] = []
+        total = 0
+        sampled = 0
+        sieve_pbar = tqdm(self.list_topologies(subset=topology_subset))
+        for topology_name in sieve_pbar:
+            sieve_pbar.set_description(f"Sieving topology {topology_name:<5}")
+            topology = self.topologies[topology_name]
+            sbu_dict = self.list_building_units(
+                sieve=topology_name, verbose=False, subset=sbu_subset
+            )
+            # slot types with no compatible SBU are absent from the
+            # dict entirely, so completeness needs an explicit check
+            if len(sbu_dict) != len(topology.mappings):
+                continue
+            if not all(sbu_dict.values()):
+                continue
+            slot_types = list(sbu_dict.keys())
+            options = [sbu_dict[slot_type] for slot_type in slot_types]
+            count = math.prod(len(choices) for choices in options)
+            total += count
+            if max_per_topology is not None and count > max_per_topology:
+                sampled += 1
+            plans.append((topology_name, slot_types, options))
+        logger.info(
+            f"\t[x] {total} SBU combinations over {len(plans)} buildable topologies."
+        )
+        if sampled:
+            logger.info(
+                f"\t[x] Sampling {sampled} topologies down to "
+                f"{max_per_topology} combinations each."
+            )
         executor = ProcessPoolExecutor(max_workers=n_jobs) if n_jobs > 1 else None
         # cap on submitted-but-unfinished chunks: bounds the validated
         # mappings (deep-copied fragments) alive at any moment
         max_pending = 2 * n_jobs
         try:
-            topology_pbar = tqdm(self.list_topologies(subset=topology_subset))
-            for topology_name in topology_pbar:
+            topology_pbar = tqdm(plans)
+            for topology_name, slot_types, options in topology_pbar:
                 topology_pbar.set_description(f"Processing topology {topology_name:<5}")
                 topology = self.topologies[topology_name]
-                sbu_dict = self.list_building_units(
-                    sieve=topology_name, verbose=False, subset=sbu_subset
-                )
-                # slot types with no compatible SBU are absent from the
-                # dict entirely, so completeness needs an explicit check
-                if len(sbu_dict) != len(topology.mappings):
-                    continue
-                if not all(sbu_dict.values()):
-                    continue
-                slot_types = list(sbu_dict.keys())
-                options = [sbu_dict[slot_type] for slot_type in slot_types]
                 # combination name-tuples are cheap to hold; the heavy
                 # deep-copied fragment mappings are produced lazily
                 choices = list(_iter_combinations(options, max_per_topology, rng))

--- a/src/autografs/cli.py
+++ b/src/autografs/cli.py
@@ -197,6 +197,14 @@ def _validate_positive_int(text: str) -> bool | str:
     return value > 0 or "Enter a positive integer"
 
 
+def _validate_combination_cap(text: str) -> bool | str:
+    try:
+        value = int(text)
+    except ValueError:
+        return "Enter an integer"
+    return value > 0 or value == -1 or "Enter a positive integer, or -1 for no cap"
+
+
 def _pick_name(message: str, names: list[str]) -> str | None:
     """Type-to-search prompt over a list of names; None on cancel."""
     answer: str | None = questionary.autocomplete(
@@ -778,9 +786,9 @@ def batch_build(session: Session) -> None:
             console.print(f"[red]Unknown topologies:[/red] {', '.join(unknown)}")
             return
     per_topology = questionary.text(
-        "Max SBU combinations per topology:",
+        "Max SBU combinations per topology (-1 = no cap):",
         default="5",
-        validate=_validate_positive_int,
+        validate=_validate_combination_cap,
     ).ask()
     if per_topology is None:
         return

--- a/tests/test_fixture_builds.py
+++ b/tests/test_fixture_builds.py
@@ -8,6 +8,7 @@ compatibility, alignment, cell optimization - without the full
 topology database.
 """
 
+import logging
 import os
 
 import numpy as np
@@ -196,6 +197,25 @@ class TestGoldenBuilds:
         # a different seed picks a different sample (pcu has 58 combos)
         third = mofgen.build_all(**{**kwargs, "seed": 7})
         assert len(third) <= 3
+
+    def test_build_all_exhaustive_no_cap(self, mofgen, caplog):
+        """max_per_topology=-1 disables sampling and logs the total count."""
+        kwargs = dict(
+            topology_subset=["pcu"],
+            sbu_subset=["Zn_mof5_octahedral", "Benzene_linear"],
+            refine_cell=False,
+        )
+        with caplog.at_level(logging.INFO, logger="autografs.builder"):
+            uncapped = mofgen.build_all(max_per_topology=-1, **kwargs)
+        default = mofgen.build_all(max_per_topology=None, **kwargs)
+        assert [fw.formula for fw in uncapped] == [fw.formula for fw in default]
+        assert any("SBU combinations" in r.message for r in caplog.records)
+
+    def test_build_all_rejects_invalid_cap(self, mofgen):
+        """0 and negative caps other than -1 are errors, not silent no-ops."""
+        for bad in (0, -2):
+            with pytest.raises(ValueError, match="max_per_topology"):
+                mofgen.build_all(topology_subset=["pcu"], max_per_topology=bad)
 
     @pytest.mark.slow
     def test_build_all_parallel_matches_serial(self, mofgen):


### PR DESCRIPTION
Closes #120.

- `max_per_topology=-1` is an explicit no-cap alias (same as the default `None`); `0` and other negative values now raise `ValueError` instead of silently building nothing
- the topology sieve now runs as a planning pass before the first build: the total combination count over all buildable topologies (and how many topologies will be sampled) is logged up front, so exhaustive runs can be cost-estimated and aborted early
- sampling semantics and RNG determinism are unchanged: same topology order, same seed sequence, and the sieve still runs exactly once per topology (it just runs earlier)
- CLI batch-build prompt accepts `-1 = no cap` with a dedicated validator
- docs (`building.md`, `cli.md`) updated; two new tests (exhaustive == default, invalid caps raise)

Full suite: 422 passed, 8 skipped (slow) locally; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)