### PR TITLE
identify_net: surface the matching tier; weak-keyed signature cache

### DIFF
--- a/docs/deconstruction.md
+++ b/docs/deconstruction.md
@@ -37,7 +37,11 @@ coordination sequences, computed on the quotient graph with capping
 ligands pruned): an almost-unique invariant matched in two tiers,
 first with ditopic linkers counted as vertices (separating a net from
 its edge-decorated derivatives), then against the underlying
-2-coordination-suppressed net. Multiple candidates are returned as a
+2-coordination-suppressed net. The returned list carries the tier on
+its `.tier` attribute (`"exact"`, `"contracted"`, or `None`) — worth
+checking before trusting a result, since a contracted-tier match is
+blind to edge decoration; the per-subframework entries in
+`subframework_nets` carry it too. Multiple candidates are returned as a
 list rather than silently picking one.
 
 Interpenetrated (catenated) structures are handled: each periodic

--- a/src/autografs/cli.py
+++ b/src/autografs/cli.py
@@ -845,6 +845,9 @@ def deconstruct_wizard(session: Session) -> None:
         return
 
     net = ", ".join(result.net_candidates) if result.net_candidates else "unidentified"
+    tiers = {nets.tier for nets in result.subframework_nets if nets}
+    if result.net_candidates and "contracted" in tiers:
+        net += "  (contracted-tier match)"
     if result.n_periodic_components > 1:
         net += f"  ({result.n_periodic_components}-fold interpenetrated)"
     console.print(f"\n[bold]Net:[/bold] {net}")

--- a/src/autografs/deconstruct.py
+++ b/src/autografs/deconstruct.py
@@ -67,7 +67,7 @@ from autografs.fragment import Fragment
 # _canonical and _split_image are net's gauge conventions; the unit
 # quotient graph below must share them exactly, so it uses the same
 # helpers rather than re-deriving them
-from autografs.net import Edge, _canonical, _split_image, identify_net
+from autografs.net import Edge, NetMatches, _canonical, _split_image, identify_net
 from autografs.utils import (
     BOND_CUTOFF,
     BOND_TOLERANCE,
@@ -154,11 +154,15 @@ class Deconstruction:
     n_periodic_components : int
         Number of catenated (interpenetrated) subframeworks - the fold
         of the interpenetration (1 for a non-catenated framework).
-    subframework_nets : list[list[str]]
+    subframework_nets : list[NetMatches]
         Net candidates for each periodic subframework independently,
         one list per component. For genuine n-fold interpenetration
         every entry is the same net; differing entries flag distinct
-        interpenetrating nets.
+        interpenetrating nets. Each entry is an
+        autografs.net.NetMatches whose ``tier`` attribute records
+        whether the match was exact or contraction-blind
+        ("contracted": correct underlying net, but blind to how its
+        edges are subdivided).
     guest_formulas : list[str]
         Compositions of the removed 0-periodic components.
     """
@@ -169,7 +173,7 @@ class Deconstruction:
     quotient_edges: Counter[Edge]
     net_candidates: list[str] = field(default_factory=list)
     n_periodic_components: int = 1
-    subframework_nets: list[list[str]] = field(default_factory=list)
+    subframework_nets: list[NetMatches] = field(default_factory=list)
     guest_formulas: list[str] = field(default_factory=list)
 
     @property
@@ -793,7 +797,7 @@ def deconstruct(
     quotient_edges = unit_quotient()
 
     # identify each interpenetrated subframework independently
-    subframework_nets: list[list[str]] = []
+    subframework_nets: list[NetMatches] = []
     if topologies is not None:
         subframework_nets = [
             identify_net(unit_quotient(component), topologies)

--- a/src/autografs/net.py
+++ b/src/autografs/net.py
@@ -39,18 +39,18 @@ rather than silent errors.
 
 from __future__ import annotations
 
-import functools
 import logging
 import math
 from collections import Counter, defaultdict
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
+from weakref import WeakKeyDictionary
 
 import numpy as np
 
 from autografs.exceptions import NetMismatchError
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterable, Mapping
 
     from autografs.framework import Framework
     from autografs.topology import Topology
@@ -62,6 +62,7 @@ __all__ = [
     "coordination_sequences",
     "net_signature",
     "identify_net",
+    "NetMatches",
 ]
 
 logger = logging.getLogger(__name__)
@@ -434,19 +435,27 @@ def net_signature(
     return tuple(sorted((seq, mult // divisor) for seq, mult in counts.items()))
 
 
-@functools.lru_cache(maxsize=8192)
+# Topology neither defines __eq__ nor __hash__, so the cache is keyed
+# by object identity - correct because LazyTopologyLibrary caches
+# materialized topologies for the session. Weak keys let entries die
+# with their Topology, so a long session cycling custom libraries does
+# not pin every library it ever identified against.
+_SIGNATURE_CACHE: WeakKeyDictionary[Topology, dict[tuple[int, bool], Signature]] = (
+    WeakKeyDictionary()
+)
+
+
 def _topology_signature_cached(
     topology: Topology, shells: int, contract: bool
 ) -> Signature:
-    """Signature of a library topology, cached per Topology object.
-
-    Topology neither defines __eq__ nor __hash__, so the cache is
-    keyed by object identity - correct because LazyTopologyLibrary
-    caches materialized topologies for the session.
-    """
-    return net_signature(
-        topology_quotient_edges(topology), shells=shells, contract=contract
-    )
+    """Signature of a library topology, cached per Topology object."""
+    cached = _SIGNATURE_CACHE.setdefault(topology, {})
+    key = (shells, contract)
+    if key not in cached:
+        cached[key] = net_signature(
+            topology_quotient_edges(topology), shells=shells, contract=contract
+        )
+    return cached[key]
 
 
 def _degree_profile(degrees: list[int]) -> tuple[tuple[int, int], ...]:
@@ -465,11 +474,35 @@ def _degree_profile(degrees: list[int]) -> tuple[tuple[int, int], ...]:
     return tuple(sorted((degree, mult // divisor) for degree, mult in counts.items()))
 
 
+class NetMatches(list):
+    """Sorted matching net names, with the matching tier attached.
+
+    Behaves as a plain ``list[str]`` (existing callers are unaffected);
+    ``tier`` records how identify_net matched: "exact" when the
+    uncontracted signatures agreed (the net itself, distinct from its
+    edge-decorated derivatives), "contracted" when only the
+    contraction-blind fallback matched (the underlying net, however
+    its edges are subdivided), None when nothing matched. List
+    operations (slicing, concatenation) return plain lists and drop
+    the attribute.
+    """
+
+    tier: Literal["exact", "contracted"] | None
+
+    def __init__(
+        self,
+        names: Iterable[str] = (),
+        tier: Literal["exact", "contracted"] | None = None,
+    ) -> None:
+        super().__init__(names)
+        self.tier = tier
+
+
 def identify_net(
     edges: Counter[Edge],
     topologies: Mapping[str, Topology],
     shells: int = SIGNATURE_SHELLS,
-) -> list[str]:
+) -> NetMatches:
     """Names of the library nets matching a quotient graph's signature.
 
     Candidates are prefiltered on the reduced degree multiset of their
@@ -492,14 +525,18 @@ def identify_net(
 
     Returns
     -------
-    list[str]
+    NetMatches
         Sorted names of the matching nets - usually one, empty when
         nothing in the library matches, several only if the library
-        holds nets that share all coordination sequences.
+        holds nets that share all coordination sequences. The result
+        is a plain list of names carrying a ``tier`` attribute
+        ("exact", "contracted", or None) that records which tier
+        matched - worth checking before trusting a deconstruction:
+        a contracted-tier answer is blind to edge decoration.
     """
     contracted = net_signature(edges, shells=shells, contract=True)
     if not contracted:
-        return []
+        return NetMatches()
     # the first coordination shell of a vertex is its degree; the
     # profile is contraction-invariant, so it prefilters both tiers
     target_profile = _degree_profile(
@@ -531,9 +568,12 @@ def identify_net(
         if _topology_signature_cached(topologies[name], shells, False) == exact
     )
     if exact_matches:
-        return exact_matches
-    return sorted(
+        logger.debug(f"identify_net: exact-tier match: {exact_matches}")
+        return NetMatches(exact_matches, tier="exact")
+    fallback = sorted(
         name
         for name in candidates
         if _topology_signature_cached(topologies[name], shells, True) == contracted
     )
+    logger.debug(f"identify_net: contracted-tier match: {fallback or 'none'}")
+    return NetMatches(fallback, tier="contracted" if fallback else None)

--- a/tests/test_deconstruct.py
+++ b/tests/test_deconstruct.py
@@ -115,7 +115,49 @@ class TestIdentifyNet:
                 (1, 2, (-1, 0, 1)): 1,
             }
         )
-        assert identify_net(nbo_like, mofgen.topologies) == []
+        matches = identify_net(nbo_like, mofgen.topologies)
+        assert matches == []
+        assert matches.tier is None
+
+    def test_exact_tier_surfaced(self, mofgen):
+        """A blueprint quotient matches its own net on the exact tier."""
+        edges = topology_quotient_edges(mofgen.topologies["pcu"])
+        matches = identify_net(edges, mofgen.topologies)
+        assert matches == ["pcu"]
+        assert matches.tier == "exact"
+
+    def test_contracted_tier_surfaced(self, mofgen):
+        """The bare pcu quotient (no edge centers) misses the exact
+        tier - the blueprint counts its 2-coordinated edge centers as
+        vertices - and falls back to the contraction-blind match."""
+        bare: Counter = Counter(
+            {
+                (0, 0, (1, 0, 0)): 1,
+                (0, 0, (0, 1, 0)): 1,
+                (0, 0, (0, 0, 1)): 1,
+            }
+        )
+        matches = identify_net(bare, mofgen.topologies)
+        assert matches == ["pcu"]
+        assert matches.tier == "contracted"
+
+    def test_signature_cache_releases_topologies(self, mofgen):
+        """The per-topology signature cache must not pin dead libraries."""
+        import copy
+        import gc
+
+        from autografs.net import _SIGNATURE_CACHE
+
+        topology = copy.deepcopy(mofgen.topologies["pcu"])
+        before = len(_SIGNATURE_CACHE)
+        matches = identify_net(
+            topology_quotient_edges(topology), {"pcu_copy": topology}
+        )
+        assert matches == ["pcu_copy"]
+        assert len(_SIGNATURE_CACHE) == before + 1
+        del topology
+        gc.collect()
+        assert len(_SIGNATURE_CACHE) == before
 
 
 class TestDeconstructMOF5:


### PR DESCRIPTION
Closes #113.

- `identify_net` returns `NetMatches` — a `list[str]` subclass with a `.tier` attribute (`"exact"` / `"contracted"` / `None`). Fully backward compatible: it is a plain list to every existing caller, and equality/iteration are unchanged.
- `Deconstruction.subframework_nets` is now typed `list[NetMatches]`, so per-component tiers ride along automatically; the CLI deconstruction summary appends "(contracted-tier match)" when the consensus rests on the coarser tier.
- Debug log line on both tiers.
- The `_topology_signature_cached` `lru_cache(8192)` (process-lifetime strong refs, flagged in the issue) is replaced by a `WeakKeyDictionary` keyed on Topology identity — entries die with their Topology, so harvest sessions cycling custom libraries no longer pin memory. A test asserts the release via `gc.collect()`.
- New tests: exact tier on a blueprint quotient, contracted tier on the bare pcu quotient, `tier is None` on no-match, cache release.

Full suite: 425 passed, 8 skipped (slow) locally; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)