### PR TITLE
Benchmark drivers: net-ID accuracy vs external labels, build/identify throughput (#130)

### DIFF
--- a/scripts/benchmarks/netid.py
+++ b/scripts/benchmarks/netid.py
@@ -1,0 +1,119 @@
+"""Net-identification accuracy benchmark against external labels.
+
+Runs deconstruction-based net identification over a corpus and compares
+the candidates against reference topology assignments (e.g. ARC-MOF's
+CrystalNets.jl labels), reporting agreement split by matching tier.
+
+The labels file is JSON: ``{"structure.cif": "pcu", ...}`` — values may
+also be lists when the reference itself is ambiguous. A structure
+agrees when the reference label (any of them) is among our candidates.
+
+Outcomes per structure:
+- ``agree`` / ``disagree``     identified, label present
+- ``unidentified``             deconstructed, no library net matched
+- ``unlabelled``               no reference label for this structure
+- ``deconstruction_failed``    with the error message
+
+Usage:
+    python scripts/benchmarks/netid.py corpus_dir --labels labels.json -o netid.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from collections import Counter
+from pathlib import Path
+
+from autografs import Autografs
+from autografs.exceptions import AutografsError
+
+
+def identify_one(mofgen: Autografs, source, labels: dict) -> dict:
+    """Identify one structure and score it against its label."""
+    record: dict = {"outcome": None, "net": None, "tier": None, "error": None}
+    name = Path(str(source)).name
+    reference = labels.get(name)
+    if isinstance(reference, str):
+        reference = [reference]
+    t0 = time.perf_counter()
+    try:
+        result = mofgen.deconstruct(source)
+    except (AutografsError, ValueError, KeyError, IndexError) as exc:
+        record["outcome"] = "deconstruction_failed"
+        record["error"] = f"{type(exc).__name__}: {exc}"
+        record["seconds"] = time.perf_counter() - t0
+        return record
+    record["seconds"] = time.perf_counter() - t0
+    record["net"] = list(result.net_candidates)
+    if result.net_candidates:
+        record["tier"] = result.subframework_nets[0].tier
+    record["fold"] = result.n_periodic_components
+    if reference is None:
+        record["outcome"] = "unlabelled"
+    elif not result.net_candidates:
+        record["outcome"] = "unidentified"
+        record["label"] = reference
+    else:
+        record["label"] = reference
+        agrees = bool(set(reference) & set(result.net_candidates))
+        record["outcome"] = "agree" if agrees else "disagree"
+    return record
+
+
+def run(corpus: list[Path], mofgen: Autografs, labels: dict) -> dict:
+    """Score the whole corpus; returns the results payload."""
+    records = {}
+    for path in sorted(corpus):
+        records[path.name] = identify_one(mofgen, str(path), labels)
+        print(f"  {path.name:<40} {records[path.name]['outcome']}")
+    outcomes = Counter(record["outcome"] for record in records.values())
+    by_tier: Counter[str] = Counter()
+    for record in records.values():
+        if record["outcome"] in ("agree", "disagree"):
+            by_tier[f"{record['outcome']}_{record['tier']}"] += 1
+    scored = outcomes["agree"] + outcomes["disagree"]
+    return {
+        "benchmark": "netid",
+        "n_structures": len(records),
+        "outcomes": dict(sorted(outcomes.items())),
+        "agreement_by_tier": dict(sorted(by_tier.items())),
+        "agreement_rate": (outcomes["agree"] / scored) if scored else None,
+        "structures": records,
+    }
+
+
+def _collect(spec: str) -> list[Path]:
+    path = Path(spec)
+    if path.is_dir():
+        return sorted(path.glob("*.cif"))
+    if any(char in spec for char in "*?["):
+        return sorted(Path(spec).parent.glob(Path(spec).name))
+    return [path]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("corpus", help="directory, glob, or single CIF")
+    parser.add_argument("--labels", required=True, help="JSON name -> net(s)")
+    parser.add_argument("-o", "--output", default="netid.json")
+    parser.add_argument("--topofile", default=None, help="topology library override")
+    args = parser.parse_args()
+
+    corpus = _collect(args.corpus)
+    if not corpus:
+        raise SystemExit(f"no structures matched {args.corpus!r}")
+    labels = json.loads(Path(args.labels).read_text(encoding="utf-8"))
+    mofgen = Autografs(topofile=args.topofile)
+    payload = run(corpus, mofgen, labels)
+    Path(args.output).write_text(json.dumps(payload, indent=1, default=str))
+    print(f"\n{payload['n_structures']} structures -> {args.output}")
+    rate = payload["agreement_rate"]
+    print(f"  agreement: {f'{rate:.1%}' if rate is not None else 'n/a'}")
+    for outcome, count in payload["outcomes"].items():
+        print(f"  {outcome:<24} {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/throughput.py
+++ b/scripts/benchmarks/throughput.py
@@ -1,0 +1,96 @@
+"""Build and identification throughput benchmark.
+
+For each requested topology: build it once from the first compatible
+SBU combination in the library (timed over repeats, median reported),
+then time net identification of the built framework. Deterministic:
+first-in-sorted-order SBUs, no sampling.
+
+Usage:
+    python scripts/benchmarks/throughput.py --topologies pcu,dia,srs -o throughput.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from pathlib import Path
+
+from autografs import Autografs
+from autografs.exceptions import AutografsError
+from autografs.net import framework_quotient_edges, identify_net
+
+
+def time_one(mofgen: Autografs, name: str, repeats: int) -> dict:
+    """Median build and identify wall times for one topology."""
+    record: dict = {"error": None}
+    if name not in mofgen.topologies:
+        record["error"] = "unknown topology"
+        return record
+    topology = mofgen.topologies[name]
+    available = mofgen.list_building_units(sieve=name, verbose=False)
+    if len(available) != len(topology.mappings) or not all(available.values()):
+        record["error"] = "no compatible SBU combination"
+        return record
+    mappings = {
+        slot_type: sorted(options)[0] for slot_type, options in available.items()
+    }
+    record["sbus"] = sorted(set(mappings.values()))
+    try:
+        build_times = []
+        for _ in range(repeats):
+            t0 = time.perf_counter()
+            framework = mofgen.build(topology, mappings=dict(mappings))
+            build_times.append(time.perf_counter() - t0)
+        identify_times = []
+        for _ in range(repeats):
+            t0 = time.perf_counter()
+            candidates = identify_net(
+                framework_quotient_edges(framework), mofgen.topologies
+            )
+            identify_times.append(time.perf_counter() - t0)
+    except AutografsError as exc:
+        record["error"] = f"{type(exc).__name__}: {exc}"
+        return record
+    record["n_atoms"] = len(framework)
+    record["build_seconds"] = statistics.median(build_times)
+    record["identify_seconds"] = statistics.median(identify_times)
+    record["identified_as"] = list(candidates)
+    return record
+
+
+def run(mofgen: Autografs, topologies: list[str], repeats: int) -> dict:
+    """Time every requested topology; returns the results payload."""
+    records = {}
+    for name in topologies:
+        records[name] = time_one(mofgen, name, repeats)
+        timing = records[name].get("build_seconds")
+        note = f"{timing:.2f}s" if timing is not None else records[name]["error"]
+        print(f"  {name:<8} {note}")
+    return {
+        "benchmark": "throughput",
+        "repeats": repeats,
+        "topologies": records,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--topologies", required=True, help="comma-separated topology names"
+    )
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("-o", "--output", default="throughput.json")
+    parser.add_argument("--topofile", default=None, help="topology library override")
+    args = parser.parse_args()
+
+    names = [name.strip() for name in args.topologies.split(",") if name.strip()]
+    mofgen = Autografs(topofile=args.topofile)
+    payload = run(mofgen, names, args.repeats)
+    Path(args.output).write_text(json.dumps(payload, indent=1, default=str))
+    print(f"\n{len(names)} topologies -> {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_benchmark_drivers.py
+++ b/tests/test_benchmark_drivers.py
@@ -1,0 +1,90 @@
+"""Smoke tests for the netid and throughput drivers (scripts/benchmarks).
+
+The drivers are scripts, not package modules; they are imported via a
+path insertion so CI catches breakage of the library APIs they lean on.
+(The round-trip driver has its own smoke test alongside its PR.)
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+SCRIPTS = os.path.join(os.path.dirname(__file__), "..", "scripts", "benchmarks")
+FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "data", "topologies_fixture.json"
+)
+
+
+def _load(name):
+    sys.path.insert(0, SCRIPTS)
+    try:
+        return __import__(name)
+    finally:
+        sys.path.pop(0)
+
+
+@pytest.fixture(scope="module")
+def mofgen():
+    from autografs import Autografs
+
+    return Autografs(topofile=FIXTURE_PATH)
+
+
+@pytest.fixture(scope="module")
+def mof5_cif(mofgen, tmp_path_factory):
+    topology = mofgen.topologies["pcu"]
+    mappings = {}
+    for key in topology.mappings:
+        conn = len(key.atoms.indices_from_symbol("X"))
+        mappings[key] = {6: "Zn_mof5_octahedral", 2: "Benzene_linear"}[conn]
+    mof = mofgen.build(topology, mappings=mappings, max_rmsd=0.5)
+    path = tmp_path_factory.mktemp("corpus") / "mof5.cif"
+    mof.write_cif(path)
+    return path
+
+
+class TestNetId:
+    def test_agreement_scored_by_tier(self, mofgen, mof5_cif):
+        netid = _load("netid")
+        labels = {"mof5.cif": "pcu"}
+        payload = netid.run([mof5_cif], mofgen, labels)
+        assert payload["outcomes"] == {"agree": 1}
+        assert payload["agreement_rate"] == 1.0
+        record = payload["structures"]["mof5.cif"]
+        assert record["net"] == ["pcu"]
+        assert record["tier"] in ("exact", "contracted")
+        assert payload["agreement_by_tier"] == {f"agree_{record['tier']}": 1}
+
+    def test_disagreement_and_missing_label(self, mofgen, mof5_cif):
+        netid = _load("netid")
+        payload = netid.run([mof5_cif], mofgen, {"mof5.cif": "dia"})
+        assert payload["outcomes"] == {"disagree": 1}
+        assert payload["agreement_rate"] == 0.0
+        payload = netid.run([mof5_cif], mofgen, {})
+        assert payload["outcomes"] == {"unlabelled": 1}
+        assert payload["agreement_rate"] is None
+
+    def test_labels_may_be_lists(self, mofgen, mof5_cif):
+        netid = _load("netid")
+        payload = netid.run([mof5_cif], mofgen, {"mof5.cif": ["dia", "pcu"]})
+        assert payload["outcomes"] == {"agree": 1}
+
+
+class TestThroughput:
+    def test_timings_are_positive_and_identified(self, mofgen):
+        throughput = _load("throughput")
+        payload = throughput.run(mofgen, ["pcu"], repeats=2)
+        record = payload["topologies"]["pcu"]
+        assert record["error"] is None
+        assert record["n_atoms"] > 0
+        assert record["build_seconds"] > 0
+        assert record["identify_seconds"] > 0
+        assert record["identified_as"] == ["pcu"]
+
+    def test_unknown_topology_is_data_not_a_raise(self, mofgen):
+        throughput = _load("throughput")
+        payload = throughput.run(mofgen, ["not_a_net"], repeats=1)
+        assert payload["topologies"]["not_a_net"]["error"] == "unknown topology"
+        json.dumps(payload, default=str)


### PR DESCRIPTION
Two more #130 drivers. Unlike the round-trip driver (#138, stacked on the rod PR), these are independent of the Stage-A API and go straight to master.

- **`netid.py`** — identification over a corpus scored against external reference labels (JSON `name -> net(s)`; ARC-MOF's CrystalNets.jl assignments are the intended corpus). Agreement reported overall **and split by matching tier**, so we can state "X% exact-tier, Y% contracted-tier agreement" in the paper; `unlabelled`/`unidentified`/`deconstruction_failed` are recorded outcomes, not aborts.
- **`throughput.py`** — median build + identification wall time per topology from the first compatible SBU combination (deterministic), with atom count and identified net as a self-check; unknown topologies land in the payload as errors.
- Smoke tests import both scripts and cover agree/disagree/unlabelled scoring, list-valued labels, positive timings with correct self-identification, and the unknown-topology path.

Suite: 441 passed, 8 skipped (slow) locally; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)