### PR TITLE
Tetrahedral topology extraction: zeolite crystal → buildable blueprint (#128)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ Modules in `src/autografs/`, in pipeline order:
 - **`relax.py`** — LAMMPS relaxation backend behind `Framework.relax`.
 - **`plane_groups.py`** — the 17 plane groups, used for 2D layer nets.
 - **`cgd.py`** — CGD parser and `autografs-topologies` CLI (RCSR download, spacegroup expansion, orbit extraction).
+- **`extract_topology.py`** — `topology_from_tetrahedral(structure, name)`: idealized zeolite crystal (T atoms + bridging O, e.g. IZA CIFs) → buildable Topology. Emits the exact CGD conventions (Z-encodes coordination on centers, X dummies at T–O midpoints = quarter points) and reuses `cgd.analyze`/`orbit_equivalence_classes`, so extracted zeolites are indistinguishable from CGD-imported nets down to the exact identification tier. Rejects interrupted/non-tetrahedral input (`TopologyExtractionError`). The `--use_iza` importer (#128 phase 2) builds on this.
 - **`cli.py`** — `autografs` interactive wizard (questionary + rich). Deliberately has no non-interactive build flags; scripted use is the Python API.
 - **`utils.py`** — XYZ parsing, UFF4MOF atom typing (constants in `data/uff4mof.py`), Fragment→graph conversions, GULP export.
 - **`exceptions.py`** — `AutografsError` hierarchy: `AlignmentError`, `OverlapError`, `StackingError`, `RelaxationError`, `TopologyExtractionError`, `NetMismatchError`, `DeconstructionError`.

--- a/src/autografs/extract_topology.py
+++ b/src/autografs/extract_topology.py
@@ -1,0 +1,157 @@
+"""Topology extraction from tetrahedral framework structures.
+
+The fast path from an idealized zeolite crystal (T atoms bridged by
+oxygen, e.g. the IZA idealized SiO2 CIFs) to a buildable library
+Topology: T atoms become 4-connected node slots, bridging oxygens
+become 2-connected edge-center slots, and the connection dummies sit
+at the T-O midpoints - the quarter points of the T...T edge, exactly
+the convention the CGD parser produces for RCSR nets, so an extracted
+zeolite and a CGD-imported net are structurally identical down to the
+exact identification tier. Slot extraction, point groups, and
+crystallographic orbits are cgd.analyze / cgd.orbit_equivalence_classes,
+shared with the CGD path rather than re-implemented.
+
+>>> from autografs.extract_topology import topology_from_tetrahedral
+>>> topology = topology_from_tetrahedral(Structure.from_file("FAU.cif"), "FAU")
+>>> identify_net(topology_quotient_edges(topology), mofgen.topologies)
+['fau']
+
+Interrupted frameworks (terminal OH/F on a T site, IZA dash codes) are
+rejected: a T atom with fewer than four bridges has no 4-c vertex, and
+the extracted net would not be the framework type. General MOF
+topology extraction (from arbitrary deconstructions) is a separate,
+harder problem and deliberately out of scope here.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+from pymatgen.core.periodic_table import get_el_sp
+from pymatgen.core.structure import Structure
+from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
+from autografs.cgd import analyze, orbit_equivalence_classes
+from autografs.exceptions import TopologyExtractionError
+from autografs.topology import Topology
+
+__all__ = ["topology_from_tetrahedral"]
+
+logger = logging.getLogger(__name__)
+
+# a T-O bond in tetrahedral frameworks is 1.5-1.8 A (Si/Al/P/Ge...);
+# the next-nearest contact (O-O at ~2.6 A) is comfortably beyond
+T_O_CUTOFF = 2.3
+
+
+def topology_from_tetrahedral(
+    structure: Structure, name: str, cutoff: float = T_O_CUTOFF
+) -> Topology:
+    """Extract a buildable Topology from a tetrahedral framework.
+
+    Parameters
+    ----------
+    structure : Structure
+        The idealized crystal: T atoms (any non-oxygen species) and
+        bridging oxygens, nothing else. Cell and coordinates are used
+        as given - IZA idealized CIFs are already maximum-symmetry
+        embeddings.
+    name : str
+        Name of the resulting topology (e.g. the framework type code).
+    cutoff : float, optional
+        T-O bond cutoff in Angstrom.
+
+    Returns
+    -------
+    Topology
+        Node slots on the T atoms, edge-center slots on the oxygens,
+        shared dummies at the T-O midpoints, orbits from spglib.
+
+    Raises
+    ------
+    TopologyExtractionError
+        For non-tetrahedral input: an oxygen not bridging exactly two
+        T atoms, or a T atom without exactly four bridges (interrupted
+        frameworks, dash-coded in the IZA nomenclature).
+    """
+    structure = structure.copy()
+    structure.remove_oxidation_states()
+    t_indices = [i for i, site in enumerate(structure) if site.specie.symbol != "O"]
+    o_indices = [i for i, site in enumerate(structure) if site.specie.symbol == "O"]
+    if not t_indices or not o_indices:
+        raise TopologyExtractionError(
+            f"{name}: a tetrahedral framework needs T atoms and bridging "
+            f"oxygens; got {len(t_indices)} T and {len(o_indices)} O sites."
+        )
+    t_set = set(t_indices)
+
+    # every oxygen must bridge exactly two T atoms; collect the bridge
+    # geometry (the neighbor coords carry the correct periodic image).
+    # Species follow the CGD convention: centers encode their
+    # coordination as the atomic number (Z=4 nodes, Z=2 edge centers),
+    # dummies are X at the T-O midpoints - the quarter points of the
+    # T...T edge, exactly where the CGD parser puts them
+    node_species = get_el_sp(4)
+    edge_species = get_el_sp(2)
+    dummy_species = get_el_sp("X")
+    species: list = [node_species] * len(t_indices)
+    coords: list[np.ndarray] = [structure[i].coords for i in t_indices]
+    t_bridges = dict.fromkeys(t_indices, 0)
+    for o_index in o_indices:
+        site = structure[o_index]
+        neighbors = [
+            neighbor
+            for neighbor in structure.get_neighbors(site, r=cutoff)
+            if neighbor.index in t_set
+        ]
+        if len(neighbors) != 2:
+            raise TopologyExtractionError(
+                f"{name}: an oxygen bridges {len(neighbors)} T atom(s) "
+                "instead of two - a terminal or over-coordinated oxygen "
+                "(interrupted or non-tetrahedral framework)."
+            )
+        species.append(edge_species)
+        coords.append(site.coords)
+        for neighbor in neighbors:
+            t_bridges[neighbor.index] += 1
+            species.append(dummy_species)
+            coords.append((site.coords + neighbor.coords) / 2.0)
+    under = {i: n for i, n in t_bridges.items() if n != 4}
+    if under:
+        example = structure[min(under)].specie.symbol
+        raise TopologyExtractionError(
+            f"{name}: {len(under)} T atom(s) (e.g. {example}) do not carry "
+            "exactly four oxygen bridges - an interrupted or "
+            "non-tetrahedral framework, which has no 4-coordinated net."
+        )
+
+    net = Structure(
+        structure.lattice,
+        species,
+        [structure.lattice.get_fractional_coords(c) for c in coords],
+    )
+    fragments = analyze(net)
+    # center indices inside net: all T first, then one He per oxygen
+    # every third site (each O appended as He, X, X)
+    n_t = len(t_indices)
+    centers = list(range(n_t)) + [n_t + 3 * k for k in range(len(o_indices))]
+    equivalence_classes = orbit_equivalence_classes(net, centers)
+    try:
+        spacegroup = SpacegroupAnalyzer(
+            structure, symprec=1e-3
+        ).get_space_group_number()
+    except Exception:  # noqa: BLE001 - spglib failure is metadata loss only
+        spacegroup = None
+    logger.info(
+        f"\t[x] extracted {name}: {len(t_indices)} T slots, "
+        f"{len(o_indices)} edge centers, spacegroup {spacegroup}."
+    )
+    return Topology(
+        name=name,
+        slots=fragments,
+        cell=net.lattice,
+        equivalence_classes=equivalence_classes or None,
+        spacegroup_number=spacegroup,
+        is_2d=False,
+    )

--- a/tests/test_extract_topology.py
+++ b/tests/test_extract_topology.py
@@ -1,0 +1,130 @@
+"""Tests for tetrahedral topology extraction (autografs.extract_topology)."""
+
+import os
+
+import numpy as np
+import pytest
+from pymatgen.core.lattice import Lattice
+from pymatgen.core.structure import Structure
+
+from autografs.exceptions import TopologyExtractionError
+from autografs.extract_topology import topology_from_tetrahedral
+from autografs.net import identify_net, topology_quotient_edges
+
+FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "data", "topologies_fixture.json"
+)
+
+
+@pytest.fixture(scope="module")
+def mofgen():
+    from autografs import Autografs
+
+    return Autografs(topofile=FIXTURE_PATH)
+
+
+def _tetrahedral_crystal(topology, t_o: float = 1.61) -> Structure:
+    """Idealized 'SiO2' crystal realizing a 4-c net: Si on the node
+    slot centers, O on the edge-center slot centers, cell scaled to a
+    realistic T-O bond length."""
+    inv = np.linalg.inv(topology.cell.matrix)
+    t_frac, o_frac = [], []
+    for slot in topology.slots:
+        # library slots hold only the X arms; their centroid is the
+        # slot center (T position for nodes, O position for edges)
+        n_arms = len(slot.atoms.indices_from_symbol("X"))
+        frac = slot.atoms.cart_coords.mean(axis=0) @ inv
+        (t_frac if n_arms == 4 else o_frac).append(frac)
+    unscaled = Structure(
+        topology.cell,
+        ["Si"] * len(t_frac) + ["O"] * len(o_frac),
+        t_frac + o_frac,
+    )
+    current = min(
+        neighbor.nn_distance
+        for neighbor in unscaled.get_neighbors(
+            unscaled[0], r=2.0 * max(unscaled.lattice.abc)
+        )
+    )
+    scale = t_o / current
+    return Structure(
+        Lattice(topology.cell.matrix * scale),
+        unscaled.species,
+        unscaled.frac_coords,
+    )
+
+
+@pytest.fixture(scope="module")
+def dia_crystal(mofgen):
+    return _tetrahedral_crystal(mofgen.topologies["dia"])
+
+
+class TestExtraction:
+    def test_dia_roundtrips_on_the_exact_tier(self, mofgen, dia_crystal):
+        """The extracted net must be indistinguishable from the
+        CGD-imported entry: same slot structure, same uncontracted
+        signature - the exact identification tier, not the fallback."""
+        extracted = topology_from_tetrahedral(dia_crystal, "dia-extracted")
+        assert len(extracted) == len(mofgen.topologies["dia"])
+        matches = identify_net(topology_quotient_edges(extracted), mofgen.topologies)
+        assert matches == ["dia"]
+        assert matches.tier == "exact"
+
+    def test_crystallography_recovered(self, dia_crystal):
+        extracted = topology_from_tetrahedral(dia_crystal, "dia-extracted")
+        assert extracted.spacegroup_number == 227  # Fd-3m, diamond
+        assert all(slot.equivalence_class is not None for slot in extracted.slots)
+
+    def test_extracted_topology_is_buildable(self, mofgen, dia_crystal):
+        """The end goal: the extracted blueprint builds and the result
+        verifies against it exactly."""
+        extracted = topology_from_tetrahedral(dia_crystal, "dia-extracted")
+        by_arms = {
+            len(key.atoms.indices_from_symbol("X")): key for key in extracted.mappings
+        }
+        tetrahedral = sorted(
+            name
+            for name, fragment in mofgen.sbu.items()
+            if fragment.has_compatible_symmetry(by_arms[4])
+        )
+        assert tetrahedral, "no tetrahedral SBU fits the extracted node slot"
+        framework = mofgen.build(
+            extracted,
+            mappings={by_arms[4]: tetrahedral[0], by_arms[2]: "Benzene_linear"},
+            max_rmsd=0.5,
+            verify_net=True,
+        )
+        assert len(framework) > 0
+
+    def test_interrupted_framework_rejected(self, dia_crystal):
+        """Removing one bridging oxygen leaves two 3-bridged T atoms -
+        the IZA dash-code situation, which has no 4-c net."""
+        broken = dia_crystal.copy()
+        oxygens = [i for i, site in enumerate(broken) if site.specie.symbol == "O"]
+        broken.remove_sites([oxygens[0]])
+        with pytest.raises(TopologyExtractionError, match="four oxygen bridges"):
+            topology_from_tetrahedral(broken, "broken")
+
+    def test_nonbridging_oxygen_rejected(self):
+        """A terminal oxygen (one T neighbor) is not a bridge: an
+        isolated SiO4 tetrahedron has four of them."""
+        arm = 1.61 / np.sqrt(3.0)
+        sio4 = Structure(
+            Lattice.cubic(12.0),
+            ["Si", "O", "O", "O", "O"],
+            [
+                [0.0, 0.0, 0.0],
+                [arm, arm, arm],
+                [-arm, -arm, arm],
+                [-arm, arm, -arm],
+                [arm, -arm, -arm],
+            ],
+            coords_are_cartesian=True,
+        )
+        with pytest.raises(TopologyExtractionError, match="instead of two"):
+            topology_from_tetrahedral(sio4, "sio4")
+
+    def test_missing_species_rejected(self):
+        all_si = Structure(Lattice.cubic(5.0), ["Si"], [[0.0, 0.0, 0.0]])
+        with pytest.raises(TopologyExtractionError, match="T atoms and bridging"):
+            topology_from_tetrahedral(all_si, "no-oxygen")


### PR DESCRIPTION
The conversion core for `--use_iza` phase 2 (#128); the fetch + license-gate machinery comes separately.

- **`topology_from_tetrahedral(structure, name)`**: idealized zeolite crystal (T atoms + bridging O) → library `Topology`. The expanded net uses the *exact* CGD conventions — coordination-encoded center species (Z=4 nodes, Z=2 edge centers), X dummies at T–O midpoints (the quarter points of the T…T edge) — and then reuses `cgd.analyze` + `cgd.orbit_equivalence_classes` wholesale instead of re-implementing slot extraction, point groups, or orbits.
- Because the conventions match, an extracted zeolite is indistinguishable from a CGD-imported net: the headline test extracts an idealized SiO2 **diamond** crystal and gets a blueprint that identifies as `dia` on the **exact tier** (not the contraction-blind fallback), recovers space group 227, and **builds** — tetrahedral SBU + benzene, gated by `verify_net`. That's the full circle: crystal → blueprint → new framework → exact verification.
- Interrupted frameworks (any T with fewer than four bridges — the IZA dash codes) and non-bridging oxygens raise `TopologyExtractionError`, matching the #128 phase-2 exclusion list. Cell and coordinates are taken as given (IZA idealized CIFs are already maximum-symmetry embeddings).
- Once the fetcher lands, the 55 aliased RCSR overlaps become a free cross-validation corpus: converted FAU must exact-match RCSR's `fau`, etc.

Suite: 458 passed, 8 skipped (slow); ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)