### PR TITLE
Silence lammps-interface's import-time git noise

### DIFF
--- a/src/autografs/relax.py
+++ b/src/autografs/relax.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import contextlib
 import io
 import logging
+import os
 import re
 import sys
 import tempfile
@@ -52,13 +53,35 @@ logger = logging.getLogger(__name__)
 _ELEMENT_OF_TYPE = re.compile(r"^([A-Z][a-z]?)")
 
 
+@contextlib.contextmanager
+def _muted_stderr_fd():
+    """Silence the OS-level stderr file descriptor.
+
+    Python-level redirect_stderr only reroutes sys.stderr;
+    lammps_interface shells out to ``git rev-list HEAD`` inside
+    site-packages at import time to stamp its version, and the child
+    process writes 'fatal: not a git repository' straight to fd 2.
+    The failure itself is caught and harmless - only the noise leaks.
+    """
+    saved = os.dup(2)
+    devnull = os.open(os.devnull, os.O_WRONLY)
+    try:
+        os.dup2(devnull, 2)
+        yield
+    finally:
+        os.dup2(saved, 2)
+        os.close(saved)
+        os.close(devnull)
+
+
 def _import_backends():
     """Import the optional LAMMPS backends with a helpful error."""
     try:
-        import lammps
-        from lammps_interface.InputHandler import Options
-        from lammps_interface.lammps_main import LammpsSimulation
-        from lammps_interface.structure_data import from_CIF
+        with _muted_stderr_fd():
+            import lammps
+            from lammps_interface.InputHandler import Options
+            from lammps_interface.lammps_main import LammpsSimulation
+            from lammps_interface.structure_data import from_CIF
     except ImportError as exc:
         raise RelaxationError(
             "UFF4MOF relaxation needs the optional LAMMPS backend: "


### PR DESCRIPTION
Fixes the scary-but-harmless `fatal: not a git repository (or any of the parent directories): .git` that appears mid-relax in the CLI.

**Root cause**: `lammps_interface/InputHandler.py` runs `git rev-list HEAD` *inside site-packages at import time* to fabricate a version string. The Python exception is caught (hardcoded fallback), but the git child process inherits the OS-level stderr descriptor, so its `fatal:` line prints straight to the terminal. The relaxation is completely unaffected — reproduced before/after with identical relaxed energy.

**Fix**: `_import_backends` mutes fd 2 (dup2 to devnull) for the duration of the backend imports — `redirect_stderr` can't do it since subprocesses bypass `sys.stderr`. Scope is exactly the first import; our own `ImportError` handling is unaffected.

Found while investigating: the slow `test_relax_mof5` fails on this Windows env **on unmodified master too** (bond `(6,7)` → `(6,16)` after fold-back; Linux CI passes) — that's a separate pre-existing issue, filed with diagnosis rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)