### PR TITLE
Order-canonical relaxed graph construction (#145)

### DIFF
--- a/src/autografs/relax.py
+++ b/src/autografs/relax.py
@@ -326,13 +326,18 @@ def relax_framework(
     new_frac = orig_frac + displacements
     new_coords = new_frac @ prim_matrix
 
+    # nodes first, in sorted order, then edges: the relaxed graph gets
+    # the same insertion order as every builder graph, so edge
+    # iteration (and tuple orientation) matches the input exactly -
+    # adding edges first would order nodes by edge encounter and flip
+    # some reported orientations (networkx-internals-dependent, #145)
     relaxed = networkx.Graph(cell=prim_matrix)
-    relaxed.add_edges_from(framework.graph.edges(data=True))
     # cart_coords (and therefore new_coords) follow sorted node order
     for row, node in enumerate(sorted(framework.graph)):
         copied = dict(framework.graph.nodes[node])
         copied["coord"] = new_coords[row]
         relaxed.add_node(node, **copied)
+    relaxed.add_edges_from(framework.graph.edges(data=True))
     from autografs.framework import Framework as FrameworkCls
 
     result = FrameworkCls(relaxed, name=framework.name)

--- a/tests/test_relax.py
+++ b/tests/test_relax.py
@@ -122,10 +122,14 @@ class TestRelaxIntegration:
 
     def test_relax_mof5(self, mof5):
         relaxed = mof5.relax()
-        # same graph: atom count, species, bonds untouched
+        # same graph: atom count, species, bonds untouched (canonical
+        # comparison - an undirected edge has no defined orientation)
         assert len(relaxed) == len(mof5)
         assert relaxed.symbols == mof5.symbols
-        assert sorted(relaxed.graph.edges()) == sorted(mof5.graph.edges())
+        assert {frozenset(edge) for edge in relaxed.graph.edges()} == {
+            frozenset(edge) for edge in mof5.graph.edges()
+        }
+        assert relaxed.graph.number_of_edges() == mof5.graph.number_of_edges()
         # the input framework is untouched
         assert mof5.energy is None
         # energy recorded per unit cell


### PR DESCRIPTION
Closes #145 — with a corrected diagnosis, better than the one the issue was filed with.

**What it is NOT**: measurement on the failing env showed the canonical edge sets of original and relaxed graphs are **identical** — no bond was ever rewired, and the Hungarian fold-back was a red herring. The issue's "silently rewired bond graph" framing was wrong.

**What it IS**: `relax_framework` added edges before nodes, so node insertion order followed edge-encounter order and networkx reported some edges orientation-flipped (`(7,6)` vs `(6,7)`). `test_relax_mof5` asserted `sorted(edges())` equality, which is orientation-sensitive — failing on this Windows env while Linux CI passes (networkx-internals-dependent).

**Fix, by construction rather than post-check**: nodes first in sorted order (the insertion order every builder graph has), then edges verbatim — edge iteration and orientation now match the input exactly on any platform. The test now compares canonical `frozenset` edge sets + counts, since an undirected edge has no orientation to assert on.

Verified on the failing env: all 9 relax tests pass (previously 1 failing), raw sorted edge lists once again equal, relaxed energy unchanged. Full suite 460 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)