### PR TITLE
Funnel orchestration: staged multi-fidelity screening driver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Pipeline: libraries → geometric compatibility sieve (`list_building_units(siev
 ## Gotchas
 
 - **Everything ships in the wheel**: `data/topologies.json.gz` (2686 RCSR nets) and both SBU files are bundled; no generation step is needed. Regeneration (only when updating the library): `autografs-topologies --use_rcsr -o topologies.json.gz`. `scripts/cgd2pkl.py` is a deprecated shim for that command.
+- **Research tooling lives in `scripts/`, not the library**: `scripts/benchmarks/` (net-ID accuracy, round-trip closure, throughput) and `scripts/funnel/` (staged multi-fidelity screening driver: level escalation asbuilt→UFF4MOF→GFN-FF/GFN1/DFTB+, top-N selection, per-candidate provenance, checkpoint/restart compatible with `build_all` checkpoint dirs, Spearman rank-stability report). Both have path-insertion smoke tests in `tests/` so CI catches API breakage.
 - Dummy atoms use pymatgen's `"X"` species convention throughout. Slot/SBU compatibility is decided by dummy count + arm-direction match, NOT point group (symbols are metadata only).
 - In `cgd.py`, `# EDGE_CENTER` lines in RCSR files look commented out but are deliberately uncommented by the parser (they create the 2-connected slots). Preserve that behavior when refactoring.
 - `Autografs._validate_mappings` deep-copies fragments: alignment mutates them in place, and aliasing would corrupt the SBU library. Keep that invariant.

--- a/scripts/funnel/funnel.py
+++ b/scripts/funnel/funnel.py
@@ -1,0 +1,331 @@
+"""
+Staged multi-fidelity screening driver (the "funnel").
+
+Drives a candidate population of built frameworks through escalating
+levels of theory, computing the properties each level unlocks,
+selecting the top N, and escalating the survivors:
+
+    asbuilt   no relaxation; geometric descriptors only
+    uff4mof   LAMMPS/UFF4MOF relax; energy, elastic moduli, EQeq
+              charges, geometry recomputed on the relaxed structure
+    gfn-ff    periodic GFN-FF relax (xtb-python) on the survivors
+    gfn1      GFN1-xTB relax (tblite)
+    dftb      DFTB+ relax (binary + Slater-Koster files)
+
+Every candidate keeps full provenance in the work directory: the
+framework JSON after each level (charges included), a properties
+record per level, and the selection history in ``funnel.json``.
+Finished (candidate, level) pairs are recorded atomically and skipped
+on restart, so an interrupted run resumes where it stopped — the same
+contract as build_all checkpointing (#121), whose output directories
+are directly usable as funnel input.
+
+Usage::
+
+    python scripts/funnel/funnel.py run "ckpt/*.json.gz" --workdir funnel/ \
+        --levels asbuilt,uff4mof --keep 20 --rank-by void_fraction
+    python scripts/funnel/funnel.py report funnel/
+
+``report`` prints the per-level rankings and the Spearman rank
+correlation of every property between adjacent levels — the
+rank-stability data that decides each property's safe screening level.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger("funnel")
+
+
+@dataclass(frozen=True)
+class Level:
+    """One rung of the funnel."""
+
+    name: str
+    relax: str | None  # None, "uff4mof"/"uff"/"dreiding" (LAMMPS), or ASE name
+    elastic: bool = False
+    charges: bool = False
+
+
+LEVELS = {
+    "asbuilt": Level("asbuilt", None),
+    "uff4mof": Level("uff4mof", "uff4mof", elastic=True, charges=True),
+    "gfn-ff": Level("gfn-ff", "gfn-ff"),
+    "gfn1": Level("gfn1", "gfn1"),
+    "dftb": Level("dftb", "dftb"),
+}
+
+LAMMPS_FORCE_FIELDS = {"uff4mof": "UFF4MOF", "uff": "UFF", "dreiding": "Dreiding"}
+
+
+def geometric_properties(framework, spacing: float) -> dict:
+    """The descriptors available at every level."""
+    return {
+        "density": float(framework.density),
+        "void_fraction": float(framework.void_fraction(spacing=spacing)),
+        "largest_cavity_diameter": float(
+            framework.largest_cavity_diameter(spacing=spacing)
+        ),
+        "pore_limiting_diameter": float(
+            framework.pore_limiting_diameter(spacing=spacing)
+        ),
+    }
+
+
+def run_level(
+    framework,
+    level: Level,
+    spacing: float,
+    elastic: bool = True,
+    charges: bool = True,
+):
+    """One candidate through one level: relax + properties.
+
+    Returns (framework, properties). The framework is the relaxed
+    (and possibly charged) structure to carry to the next level.
+    """
+    if level.relax is not None:
+        if level.relax in LAMMPS_FORCE_FIELDS:
+            framework = framework.relax(force_field=LAMMPS_FORCE_FIELDS[level.relax])
+        else:
+            framework = framework.relax(calculator=level.relax)
+    properties = geometric_properties(framework, spacing)
+    if framework.energy is not None:
+        properties["energy"] = float(framework.energy)
+        properties["energy_per_atom"] = float(framework.energy) / len(framework)
+    if level.elastic and elastic:
+        elastic_props = framework.elastic_properties()
+        properties.update(
+            bulk_hill=elastic_props.bulk_hill,
+            shear_hill=elastic_props.shear_hill,
+            young_hill=elastic_props.young_hill,
+            young_min=elastic_props.young_min,
+            young_max=elastic_props.young_max,
+            born_stable=bool(elastic_props.is_stable),
+        )
+    if level.charges and charges:
+        framework = framework.assign_charges("eqeq")
+        assigned = framework.charges
+        assert assigned is not None
+        properties["charge_min"] = float(assigned.min())
+        properties["charge_max"] = float(assigned.max())
+    return framework, properties
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    """Atomic JSON write: finished records never appear half-written."""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=1, sort_keys=True), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def select_top(
+    records: dict[str, dict], key: str, keep: int, ascending: bool = False
+) -> list[str]:
+    """The candidate names surviving a selection round.
+
+    Candidates whose record lacks the key (or errored) are dropped;
+    ties break by name for reproducibility.
+    """
+    ranked = sorted(
+        (name for name, props in records.items() if key in props),
+        key=lambda name: (
+            records[name][key] if ascending else -records[name][key],
+            name,
+        ),
+    )
+    return ranked[:keep]
+
+
+def run_funnel(
+    inputs: list[str],
+    workdir: str | Path,
+    levels: list[str],
+    keep: list[int],
+    rank_by: str,
+    ascending: bool = False,
+    spacing: float = 0.5,
+    elastic: bool = True,
+    charges: bool = True,
+) -> dict:
+    """Drive the full funnel; returns (and writes) the summary."""
+    from autografs.framework import Framework
+
+    for name in levels:
+        if name not in LEVELS:
+            raise ValueError(f"Unknown level {name!r}; known: {sorted(LEVELS)}.")
+    if len(keep) != max(len(levels) - 1, 0):
+        raise ValueError(
+            f"{len(levels)} levels need {len(levels) - 1} keep counts "
+            f"(one per escalation), got {len(keep)}."
+        )
+    workdir = Path(workdir)
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    paths: dict[str, Path] = {}
+    for pattern in inputs:
+        matched = sorted(glob.glob(pattern)) or [pattern]
+        for item in matched:
+            path = Path(item)
+            stem = path.name.removesuffix(".gz").removesuffix(".json")
+            paths[stem] = path
+    if not paths:
+        raise ValueError(f"No candidate frameworks matched {inputs}.")
+    logger.info(f"Funnel over {len(paths)} candidates: {' -> '.join(levels)}")
+
+    survivors = sorted(paths)
+    history = []
+    for rung, level_name in enumerate(levels):
+        level = LEVELS[level_name]
+        records: dict[str, dict] = {}
+        for name in survivors:
+            candidate_dir = workdir / name
+            candidate_dir.mkdir(exist_ok=True)
+            props_path = candidate_dir / f"{level_name}.props.json"
+            frame_path = candidate_dir / f"{level_name}.json.gz"
+            if props_path.exists():
+                records[name] = json.loads(props_path.read_text(encoding="utf-8"))
+                continue
+            try:
+                if rung == 0:
+                    framework = Framework.load(paths[name])
+                else:
+                    framework = Framework.load(
+                        workdir / name / f"{levels[rung - 1]}.json.gz"
+                    )
+                framework, properties = run_level(
+                    framework, level, spacing, elastic=elastic, charges=charges
+                )
+                framework.save(frame_path)
+            except Exception as exc:
+                logger.warning(f"{name} failed at {level_name}: {exc}")
+                properties = {"error": f"{type(exc).__name__}: {exc}"}
+            _write_json(props_path, properties)
+            records[name] = properties
+        entry: dict = {"level": level_name, "evaluated": sorted(records)}
+        if rung < len(levels) - 1:
+            survivors = select_top(records, rank_by, keep[rung], ascending)
+            entry["selected"] = survivors
+            logger.info(
+                f"{level_name}: kept {len(survivors)}/{len(records)} by {rank_by}"
+            )
+        history.append(entry)
+
+    summary = {
+        "levels": levels,
+        "rank_by": rank_by,
+        "ascending": ascending,
+        "keep": keep,
+        "history": history,
+    }
+    _write_json(workdir / "funnel.json", summary)
+    return summary
+
+
+def rank_stability(workdir: str | Path) -> dict[str, dict[str, float]]:
+    """Spearman rank correlation of each property between level pairs.
+
+    For every property present at two adjacent levels of a finished
+    run, correlates the values over the candidates evaluated at both.
+    High correlation means the cheaper level ranks candidates the same
+    way — it is a safe screening level for that property.
+    """
+    from scipy.stats import spearmanr
+
+    workdir = Path(workdir)
+    summary = json.loads((workdir / "funnel.json").read_text(encoding="utf-8"))
+    levels = summary["levels"]
+    table: dict[str, dict[str, float]] = {}
+    for low, high in zip(levels, levels[1:], strict=False):
+        pair = f"{low}->{high}"
+        merged: dict[str, dict[str, tuple]] = {}
+        for candidate in workdir.iterdir():
+            low_path = candidate / f"{low}.props.json"
+            high_path = candidate / f"{high}.props.json"
+            if not (low_path.exists() and high_path.exists()):
+                continue
+            low_props = json.loads(low_path.read_text(encoding="utf-8"))
+            high_props = json.loads(high_path.read_text(encoding="utf-8"))
+            for key in set(low_props) & set(high_props):
+                if isinstance(low_props[key], (int, float)) and not isinstance(
+                    low_props[key], bool
+                ):
+                    merged.setdefault(key, {})[candidate.name] = (
+                        low_props[key],
+                        high_props[key],
+                    )
+        for key, values in merged.items():
+            if len(values) < 3:
+                continue
+            lows, highs = zip(*values.values(), strict=True)
+            rho = spearmanr(lows, highs).statistic
+            table.setdefault(key, {})[pair] = float(rho)
+    return table
+
+
+def _main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    runner = sub.add_parser("run", help="drive the funnel")
+    runner.add_argument("inputs", nargs="+", help="framework JSONs or globs")
+    runner.add_argument("--workdir", required=True)
+    runner.add_argument(
+        "--levels",
+        default="asbuilt,uff4mof",
+        help=f"comma-separated, from {sorted(LEVELS)}",
+    )
+    runner.add_argument(
+        "--keep",
+        default=None,
+        help="comma-separated survivor counts, one per escalation",
+    )
+    runner.add_argument("--rank-by", default="void_fraction")
+    runner.add_argument("--ascending", action="store_true")
+    runner.add_argument("--spacing", type=float, default=0.5)
+    runner.add_argument("--no-elastic", action="store_true")
+    runner.add_argument("--no-charges", action="store_true")
+
+    reporter = sub.add_parser("report", help="rank-stability report")
+    reporter.add_argument("workdir")
+
+    args = parser.parse_args(argv)
+    if args.command == "run":
+        levels = [name.strip() for name in args.levels.split(",") if name.strip()]
+        if args.keep is None:
+            keep = [10] * max(len(levels) - 1, 0)
+        else:
+            keep = [int(k) for k in args.keep.split(",") if k.strip()]
+        run_funnel(
+            args.inputs,
+            args.workdir,
+            levels,
+            keep,
+            rank_by=args.rank_by,
+            ascending=args.ascending,
+            spacing=args.spacing,
+            elastic=not args.no_elastic,
+            charges=not args.no_charges,
+        )
+        return 0
+    table = rank_stability(args.workdir)
+    if not table:
+        print("No overlapping property records found.")
+        return 1
+    for key in sorted(table):
+        for pair, rho in table[key].items():
+            print(f"{key:28s} {pair:22s} rho = {rho:+.3f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/tests/test_funnel_driver.py
+++ b/tests/test_funnel_driver.py
@@ -1,0 +1,180 @@
+"""
+Smoke tests for the multi-fidelity funnel driver (scripts/funnel).
+
+The driver is a script, not a package module; it is imported via a
+path insertion so CI catches breakage of the library APIs it leans
+on. The heavy relaxation levels need the optional backends and are
+exercised on HPC, not here: these tests drive the geometric level,
+the selection/checkpoint/restart machinery, and the rank-stability
+report on synthetic records.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+SCRIPTS = os.path.join(os.path.dirname(__file__), "..", "scripts", "funnel")
+FIXTURE_PATH = os.path.join(
+    os.path.dirname(__file__), "data", "topologies_fixture.json"
+)
+
+
+def _load():
+    sys.path.insert(0, SCRIPTS)
+    try:
+        return __import__("funnel")
+    finally:
+        sys.path.pop(0)
+
+
+funnel = _load()
+
+
+@pytest.fixture(scope="module")
+def candidates(tmp_path_factory):
+    """Two saved frameworks: MOF-5 (pcu) and a boroxine COF layer."""
+    from autografs import Autografs
+
+    mofgen = Autografs(topofile=FIXTURE_PATH)
+    inputs = tmp_path_factory.mktemp("inputs")
+
+    pcu = mofgen.topologies["pcu"]
+    mappings = {}
+    for key in pcu.mappings:
+        conn = len(key.atoms.indices_from_symbol("X"))
+        mappings[key] = {6: "Zn_mof5_octahedral", 2: "Benzene_linear"}[conn]
+    mofgen.build(pcu, mappings=mappings).save(inputs / "mof5.json.gz")
+
+    hcb = mofgen.topologies["hcb"]
+    mappings = {}
+    for key in hcb.mappings:
+        conn = len(key.atoms.indices_from_symbol("X"))
+        mappings[key] = {3: "Boroxine_triangle", 2: "Benzene_linear"}[conn]
+    mofgen.build(hcb, mappings=mappings, max_rmsd=0.5).save(inputs / "cof.json.gz")
+    return inputs
+
+
+class TestSelectTop:
+    RECORDS = {
+        "a": {"void_fraction": 0.8},
+        "b": {"void_fraction": 0.5},
+        "c": {"void_fraction": 0.9},
+        "broken": {"error": "boom"},
+    }
+
+    def test_descending_default(self):
+        assert funnel.select_top(self.RECORDS, "void_fraction", 2) == ["c", "a"]
+
+    def test_ascending(self):
+        chosen = funnel.select_top(self.RECORDS, "void_fraction", 2, ascending=True)
+        assert chosen == ["b", "a"]
+
+    def test_missing_key_dropped(self):
+        assert "broken" not in funnel.select_top(self.RECORDS, "void_fraction", 4)
+
+    def test_ties_break_by_name(self):
+        records = {"b": {"x": 1.0}, "a": {"x": 1.0}}
+        assert funnel.select_top(records, "x", 1) == ["a"]
+
+
+class TestRunFunnel:
+    def test_geometric_level_and_provenance(self, candidates, tmp_path):
+        workdir = tmp_path / "funnel"
+        summary = funnel.run_funnel(
+            [str(candidates / "*.json.gz")],
+            workdir,
+            levels=["asbuilt"],
+            keep=[],
+            rank_by="void_fraction",
+            spacing=1.0,
+        )
+        assert summary["history"][0]["evaluated"] == ["cof", "mof5"]
+        for name in ("mof5", "cof"):
+            props = json.loads((workdir / name / "asbuilt.props.json").read_text())
+            assert 0.0 < props["void_fraction"] < 1.0
+            assert props["density"] > 0.0
+            assert (workdir / name / "asbuilt.json.gz").exists()
+        assert (workdir / "funnel.json").exists()
+
+    def test_selection_between_levels(self, candidates, tmp_path):
+        workdir = tmp_path / "funnel"
+        summary = funnel.run_funnel(
+            [str(candidates / "*.json.gz")],
+            workdir,
+            levels=["asbuilt", "asbuilt"],
+            keep=[1],
+            rank_by="void_fraction",
+            spacing=1.0,
+        )
+        first = summary["history"][0]
+        assert len(first["selected"]) == 1
+        records = {
+            name: json.loads((workdir / name / "asbuilt.props.json").read_text())
+            for name in first["evaluated"]
+        }
+        best = max(records, key=lambda n: records[n]["void_fraction"])
+        assert first["selected"] == [best]
+        assert summary["history"][1]["evaluated"] == [best]
+
+    def test_restart_skips_finished_work(self, candidates, tmp_path):
+        workdir = tmp_path / "funnel"
+        args = dict(levels=["asbuilt"], keep=[], rank_by="void_fraction", spacing=1.0)
+        funnel.run_funnel([str(candidates / "*.json.gz")], workdir, **args)
+        stamp = (workdir / "mof5" / "asbuilt.props.json").stat().st_mtime_ns
+        funnel.run_funnel([str(candidates / "*.json.gz")], workdir, **args)
+        assert (workdir / "mof5" / "asbuilt.props.json").stat().st_mtime_ns == stamp
+
+    def test_failures_recorded_not_fatal(self, candidates, tmp_path):
+        broken = tmp_path / "broken.json.gz"
+        broken.write_bytes(b"not a gzip")
+        workdir = tmp_path / "funnel"
+        summary = funnel.run_funnel(
+            [str(candidates / "mof5.json.gz"), str(broken)],
+            workdir,
+            levels=["asbuilt"],
+            keep=[],
+            rank_by="void_fraction",
+            spacing=1.0,
+        )
+        assert set(summary["history"][0]["evaluated"]) == {"mof5", "broken"}
+        props = json.loads((workdir / "broken" / "asbuilt.props.json").read_text())
+        assert "error" in props
+
+    def test_bad_level_and_keep_validation(self, tmp_path):
+        with pytest.raises(ValueError, match="Unknown level"):
+            funnel.run_funnel(["x.json"], tmp_path, ["nope"], [], rank_by="density")
+        with pytest.raises(ValueError, match="keep"):
+            funnel.run_funnel(
+                ["x.json"], tmp_path, ["asbuilt", "uff4mof"], [], rank_by="density"
+            )
+
+
+class TestRankStability:
+    def test_spearman_between_levels(self, tmp_path):
+        levels = ["asbuilt", "uff4mof"]
+        low = {"a": 1.0, "b": 2.0, "c": 3.0}
+        # monotone for void_fraction (rho +1), reversed for density (-1)
+        for name, value in low.items():
+            candidate = tmp_path / name
+            candidate.mkdir()
+            (candidate / "asbuilt.props.json").write_text(
+                json.dumps({"void_fraction": value, "density": value})
+            )
+            (candidate / "uff4mof.props.json").write_text(
+                json.dumps({"void_fraction": value * 2.0, "density": -value})
+            )
+        (tmp_path / "funnel.json").write_text(json.dumps({"levels": levels}))
+        table = funnel.rank_stability(tmp_path)
+        assert table["void_fraction"]["asbuilt->uff4mof"] == pytest.approx(1.0)
+        assert table["density"]["asbuilt->uff4mof"] == pytest.approx(-1.0)
+
+    def test_too_few_candidates_ignored(self, tmp_path):
+        (tmp_path / "only").mkdir()
+        (tmp_path / "only" / "asbuilt.props.json").write_text(json.dumps({"x": 1.0}))
+        (tmp_path / "only" / "uff4mof.props.json").write_text(json.dumps({"x": 2.0}))
+        (tmp_path / "funnel.json").write_text(
+            json.dumps({"levels": ["asbuilt", "uff4mof"]})
+        )
+        assert funnel.rank_stability(tmp_path) == {}


### PR DESCRIPTION
Closes #127 — the last piece of the funnel stack (#124 charges, #125 ASE bridge, #126 elastic all merged).

`scripts/funnel/funnel.py` (script suite, not library code, mirroring `scripts/benchmarks/`):

- **Level escalation**: `asbuilt` (geometric descriptors) → `uff4mof` (LAMMPS relax + energy + VRH elastic moduli + EQeq charges) → `gfn-ff`/`gfn1`/`dftb` (ASE bridge) — each level computes what it newly unlocks, ranks by a chosen property (`--rank-by`, `--ascending`), keeps top N (`--keep`), escalates the survivors.
- **Provenance-preserving**: per candidate, the work directory keeps the framework JSON after every level (charges included), a properties record per level, and the selection history in `funnel.json` — nothing about a candidate's path through the funnel is lost.
- **Checkpoint/restart for HPC**: records written atomically (tmp + `os.replace`); finished (candidate, level) pairs are loaded, not recomputed, so interrupted runs resume — and `build_all` checkpoint directories (#121) are directly consumable as input. Per-candidate failures are recorded and skip ranking without aborting the run.
- **`report` subcommand**: Spearman rank correlation of every property between adjacent levels over the common survivors — the rank-stability table that decides each property's "safe screening level" (the sensitivity study's central deliverable).

Smoke tests (`tests/test_funnel_driver.py`, path-insertion import like the benchmark drivers): selection ordering/ties/missing keys, the geometric level end-to-end over a built MOF-5 + boroxine COF pair, restart idempotence pinned by record mtimes, corrupt-input failure capture, and the Spearman report checked against hand-built monotone/anti-monotone records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)