### PR TITLE
Synthetic helical (2_1-screw) rod fixture — MOF-74 class

### DIFF
--- a/tests/test_deconstruct.py
+++ b/tests/test_deconstruct.py
@@ -407,6 +407,60 @@ def _rod_pillar_structure(n_repeats: int = 1):
     return Structure(lattice, species, coords, coords_are_cartesian=True)
 
 
+def _helical_rod_structure(n_repeats: int = 2):
+    """Tetragonal 2_1-screw -Zn-O- rod, pyrazine linkers laterally.
+
+    A synthetic helical rod MOF standing in for the MOF-74 class: the
+    bridging oxygen sits off the rod axis and alternates side by 180
+    degrees each chemical repeat, so the -Zn-O- chain is a 2_1 screw
+    (screw order 2, angle 180 degrees). Detection and canonicalization
+    must recover that screw - and forward building must refuse it,
+    since Stage C3 handles straight rods only. Real helical rods
+    (zinc formate, Mg carboxylates, ...) look the same to the pipeline
+    but are CSD-derived and stay out of the repo; see the rod-fixture
+    notes. ``n_repeats`` must be even (>=2) so the screw closes.
+    """
+    import math
+
+    import numpy as np
+
+    a, c0, rho = 7.4, 3.9, 0.85
+    lattice = Lattice.tetragonal(a, n_repeats * c0)
+    species, coords = [], []
+    for r in range(n_repeats):
+        species.append("Zn")
+        coords.append([0.0, 0.0, r * c0])
+        theta = r * math.pi  # alternate the bridging O side each repeat
+        species.append("O")
+        coords.append([rho * math.cos(theta), rho * math.sin(theta), r * c0 + c0 / 2])
+    tilt = math.sqrt(0.5)
+    ring = [
+        ("N", -1.395, 0.0),
+        ("N", 1.395, 0.0),
+        ("C", -0.6975, 1.208),
+        ("C", 0.6975, 1.208),
+        ("C", -0.6975, -1.208),
+        ("C", 0.6975, -1.208),
+        ("H", -1.237, 2.143),
+        ("H", 1.237, 2.143),
+        ("H", -1.237, -2.143),
+        ("H", 1.237, -2.143),
+    ]
+    for r in range(n_repeats):
+        for center, plane in (
+            (np.array([a / 2, 0.0, r * c0]), "x"),
+            (np.array([0.0, a / 2, r * c0]), "y"),
+        ):
+            for symbol, along, out in ring:
+                if plane == "x":
+                    pos = center + np.array([along, out * tilt, out * tilt])
+                else:
+                    pos = center + np.array([out * tilt, along, -out * tilt])
+                species.append(symbol)
+                coords.append(pos.tolist())
+    return Structure(lattice, species, coords, coords_are_cartesian=True)
+
+
 class TestRodMOF:
     @pytest.fixture(scope="class")
     def rod_result(self, mofgen):
@@ -451,6 +505,22 @@ class TestRodMOF:
         assert rod.n_connections == 8
         assert result.net_candidates == ["pcu"]
         assert result.subframework_nets[0].tier == "contracted"
+
+    def test_helical_rod_detected(self, mofgen):
+        """The 2_1-screw synthetic rod (MOF-74 class) deconstructs to a
+        single 1-periodic unit whose canonical form carries the screw:
+        order 2, 180 degrees, its chemical repeat half the
+        crystallographic one, and (being helical) no template bonds."""
+        from autografs.rods import rod_fragment
+
+        result = mofgen.deconstruct(_helical_rod_structure())
+        assert len(result.rod_units) == 1
+        frag = rod_fragment(result.structure, result.rod_units[0])
+        assert frag.repeat.formula == "OZn"
+        assert frag.repeat.screw_order == 2
+        assert abs(frag.repeat.screw_angle) == pytest.approx(180.0, abs=1.0)
+        assert frag.repeat.repeat_length == pytest.approx(3.9, abs=0.05)
+        assert frag.bonds == []  # helical: template bonds not recorded
 
 
 class TestErrors:

--- a/tests/test_rods.py
+++ b/tests/test_rods.py
@@ -20,7 +20,7 @@ from pymatgen.core.structure import Structure
 from autografs.deconstruct import RodUnit
 from autografs.rods import RodRepeat, canonical_rod, merge_rod
 
-from .test_deconstruct import _rod_pillar_structure
+from .test_deconstruct import _helical_rod_structure, _rod_pillar_structure
 
 
 @pytest.fixture(scope="module")
@@ -465,3 +465,52 @@ class TestRodEditingGuards:
         assert loaded.is_rod is True
         with pytest.raises(ValueError, match="rod framework"):
             loaded.flip(0)
+
+
+class TestHelicalRodFixture:
+    """The synthetic 2_1-screw rod (MOF-74 class): full deconstruct path."""
+
+    def _canonical(self, mofgen, n_repeats=2):
+        result = mofgen.deconstruct(_helical_rod_structure(n_repeats))
+        assert len(result.rod_units) == 1
+        return canonical_rod(result.structure, result.rod_units[0])
+
+    def test_screw_recovered(self, mofgen):
+        rep = self._canonical(mofgen)
+        assert rep.screw_order == 2
+        assert abs(rep.screw_angle) == pytest.approx(180.0, abs=1.0)
+        assert rep.formula == "OZn"
+
+    def test_supercell_dedupes_with_base(self, mofgen):
+        # a 4-repeat cell is a supercell of the 2-repeat helical rod;
+        # both canonicalize to the same chemical repeat and match
+        base = self._canonical(mofgen, 2)
+        big = self._canonical(mofgen, 4)
+        assert big.screw_order == 4
+        assert base.matches(big)
+
+    def test_forward_build_refuses_helical(self, mofgen):
+        # Stage C3 builds straight rods only; a real helical rod must
+        # be rejected with a clear reason, not mis-built
+        from autografs.rod_build import build_rod_framework
+
+        result = mofgen.harvest([_helical_rod_structure()])
+        rod = result.rods["rod_OZn"]
+        linker = mofgen.sbu["Benzene_linear"]
+        with pytest.raises(Exception, match="straight"):
+            build_rod_framework(mofgen.topologies["pcu"], rod, linker)
+
+    def test_harvest_keeps_helical_and_straight_apart(self, mofgen):
+        # the straight pillar and the helical screw rod are different
+        # building units even though both are -Zn-O- (OZn)
+        result = mofgen.harvest([_rod_pillar_structure(1), _helical_rod_structure()])
+        assert sorted(result.rods) == ["rod_OZn", "rod_OZn_2"]
+        straight, helical = (
+            result.rods["rod_OZn"],
+            result.rods["rod_OZn_2"],
+        )
+        # whichever is which, one is straight and one is the 2_1 screw
+        angles = sorted(abs(r.repeat.screw_angle) for r in (straight, helical))
+        assert angles[0] == pytest.approx(0.0, abs=1.0)
+        assert angles[1] == pytest.approx(180.0, abs=1.0)
+        assert not straight.repeat.matches(helical.repeat)


### PR DESCRIPTION
Part of #91 — the real-geometry-validation follow-up to Stage C.

Adds `_helical_rod_structure`: a tetragonal `-Zn-O-` rod whose bridging oxygen alternates side by 180° each chemical repeat, making the chain a **2₁ screw** (order 2, 180°) — the pillar fixture's helical counterpart, standing in for the MOF-74 class. It's the first **full deconstruct-path** test of a helical rod:

- detection → one rod unit; screw recovery → order 2, 180°, half-length chemical repeat, no template bonds (helical);
- supercell dedup (a 4-repeat cell matches the 2-repeat);
- harvest keeps the straight pillar and the screw rod as **distinct** `OZn` building units;
- forward-build (`build_rod`) **refuses** it — Stage C3 is straight-only.

**Why synthetic, not a real CIF**: I validated the whole rod pipeline locally against Damien's CoRE MOF 2014 copy (4,764 CIFs, 1,077 rod MOFs; `ADAXEK` = a real **etb / MOF-74** rod, net correctly identified; zinc formate & Mg rods correctly flagged as ±180° screws). But CoRE MOF CIFs are CSD-derived, and per the project's no-redistribution stance (the same reason IZA/EPINET are local-fetch), those structures stay out of the repo. The synthetic fixture covers the identical screw path for CI. Details in the local `research/rod-fixtures.md`.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)