### PR TITLE
benchmark: rebuild undecorated edges empty, and the corpus-scale #174 result

### DIFF
--- a/scripts/benchmarks/embedding.py
+++ b/scripts/benchmarks/embedding.py
@@ -42,7 +42,10 @@ Two numbers come out, and their separation is the point:
 fragments (gated by exact net verification) and records the realized
 cell, closing the loop on the volume-ratio prediction above. Coverage
 is much lower than the measurement itself - most structures have no
-compatible fragment-to-slot mapping - so it is off by default.
+compatible fragment-to-slot mapping - so it is off by default. A
+2-connected slot type that no harvested fragment fits is rebuilt
+**empty** (#179), which is what brings the edge-decorated nets
+(``tbo``-class) into scoring range at all.
 
 Deterministic (no sampling, sorted corpus order); machine-readable JSON
 out plus a summary table on stdout.
@@ -200,7 +203,25 @@ def blueprint_centers(topology) -> dict[int, np.ndarray]:
 
 
 def _candidate_mappings(topology, fragments):
-    """Fragment-per-slot-type assignments compatible by geometry."""
+    """Fragment-per-slot-type assignments compatible by geometry.
+
+    A 2-connected slot type that *nothing* fits is offered as **empty**
+    (#179) rather than abandoning the net. That is not a fallback of
+    convenience: many blueprints subdivide their edges with
+    2-connected centers the real material does not have - HKUST-1
+    bonds its paddlewheels straight onto BTC while ``tbo`` decorates
+    every edge - and an absent decoration is exactly what a
+    contracted-tier identification means. Without this, the whole
+    edge-decorated family (``tbo``-class, and the ``n_free`` 3-5 nets
+    that carry the free proportions #174 is about) can never rebuild
+    faithfully inside the benchmark, so relaxation has nothing real to
+    be scored against.
+
+    Emptying is offered only where nothing fits, never as an extra
+    option alongside a fitting fragment: it would multiply the
+    combination count for nets that already build, and a decoration
+    the material *does* have should be placed.
+    """
     slot_types = list(topology.mappings)
     options = []
     for slot_type in slot_types:
@@ -208,7 +229,9 @@ def _candidate_mappings(topology, fragments):
             f for f in fragments.values() if f.has_compatible_symmetry(slot_type)
         ]
         if not fitting:
-            return
+            if len(slot_type.atoms.indices_from_symbol("X")) != 2:
+                return  # only 2-connected slots may be emptied
+            fitting = [None]
         options.append(fitting)
     combos = itertools.product(*options)
     for combo in itertools.islice(combos, MAX_MAPPINGS_PER_NET):
@@ -222,9 +245,9 @@ def is_buildable(topology, fragments) -> bool:
     right topology, right composition, wrong packing. A structure whose
     units cannot be placed on the blueprint's slots at all fails for an
     unrelated reason (a square-planar node measured against a
-    tetrahedral dia slot, or a net whose edge centers no real unit
-    fills) and its reduced lengths say nothing about the embedding.
-    Same geometric test the builder applies, before any cell work.
+    tetrahedral dia slot) and its reduced lengths say nothing about the
+    embedding. Same geometric test the builder applies, before any cell
+    work - including the empty-slot option for undecorated edges.
     """
     return next(_candidate_mappings(topology, fragments), None) is not None
 
@@ -249,10 +272,15 @@ def bond_residuals(framework) -> dict:
     for node_a, node_b in graph.edges():
         data_a = graph.nodes[node_a]
         data_b = graph.nodes[node_b]
-        if data_a.get("slot") == data_b.get("slot"):
-            continue  # internal to one SBU: fixed by the fragment, not the cell
         delta = np.asarray(data_a["coord"], float) - np.asarray(data_b["coord"], float)
-        delta -= np.round(delta @ inverse) @ cell
+        crossing = np.round(delta @ inverse)
+        if data_a.get("slot") == data_b.get("slot") and not np.any(crossing):
+            # internal to one SBU: fixed by the fragment, not the cell.
+            # A same-slot bond that *does* cross is a unit bonded to its
+            # own periodic image - real, and what emptied edge centers
+            # produce (#179), so it must be measured.
+            continue
+        delta -= crossing @ cell
         target = CovalentRadius.radius.get(
             data_a["symbol"], 0.0
         ) + CovalentRadius.radius.get(data_b["symbol"], 0.0)
@@ -296,6 +324,9 @@ def _rebuild(
             / (experimental.volume / len(experimental) * result.n_periodic_components),
             "min_contact": framework.min_contact(),
             "bond_residual": bond_residuals(framework),
+            # which blueprint slots were rebuilt empty, so a result on
+            # an edge-decorated net is interpretable
+            "empty_slots": sorted(framework.graph.graph.get("empty_slots", ())),
             # a compatible mapping is not necessarily the *right* one -
             # a net with several interchangeable slot types can take a
             # fragment in the wrong place. Only a rebuild that

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -169,6 +169,66 @@ def test_embedding_reports_failures_as_data(mofgen, embedding, tmp_path):
     assert payload["summary"]["n_measured"] == 0
 
 
+class TestEmbeddingEmptySlotFallback:
+    """#179 in the benchmark: a 2-connected slot type nothing fits is
+    offered empty, which is what brings edge-decorated nets (tbo-class,
+    where #174's free proportions live) into scoring range."""
+
+    def test_undecorated_edges_are_offered_empty(self, mofgen, embedding):
+        """Only a 6-connected node harvested: pcu's edge centers have
+        no candidate, so the mapping must empty them rather than
+        abandon the net."""
+        topology = mofgen.topologies["pcu"]
+        fragments = {"node": mofgen.sbu["Zn_mof5_octahedral"]}
+
+        mappings = list(embedding._candidate_mappings(topology, fragments))
+
+        assert mappings, "net abandoned instead of emptying its edge centers"
+        assert embedding.is_buildable(topology, fragments)
+        for mapping in mappings:
+            emptied = [k for k, v in mapping.items() if v is None]
+            assert len(emptied) == 1
+            assert len(emptied[0].atoms.indices_from_symbol("X")) == 2
+
+    def test_unfittable_node_still_abandons_the_net(self, mofgen, embedding):
+        """Only a ditopic linker harvested: pcu's 6-connected slot has
+        no candidate and cannot be emptied, so the net is refused."""
+        topology = mofgen.topologies["pcu"]
+        fragments = {"linker": mofgen.sbu["Benzene_linear"]}
+
+        assert list(embedding._candidate_mappings(topology, fragments)) == []
+        assert not embedding.is_buildable(topology, fragments)
+
+    def test_emptying_is_not_offered_when_something_fits(self, mofgen, embedding):
+        """A decoration the material does have must be placed, and the
+        combination count must not inflate."""
+        topology = mofgen.topologies["pcu"]
+        fragments = {
+            "node": mofgen.sbu["Zn_mof5_octahedral"],
+            "linker": mofgen.sbu["Benzene_linear"],
+        }
+
+        for mapping in embedding._candidate_mappings(topology, fragments):
+            assert None not in mapping.values()
+
+
+def test_embedding_bond_residuals_count_self_image_bonds(mofgen, embedding):
+    """With edge centers empty a node bonds its own periodic image;
+    those are the only inter-unit bonds left, so skipping same-slot
+    pairs outright would report no residuals at all."""
+    topology = mofgen.topologies["pcu"]
+    mappings = {}
+    for key in topology.mappings:
+        conn = len(key.atoms.indices_from_symbol("X"))
+        mappings[key] = "Zn_mof5_octahedral" if conn == 6 else None
+    framework = mofgen.build(topology, mappings=mappings, max_rmsd=0.5)
+
+    residuals = embedding.bond_residuals(framework)
+
+    assert residuals, "self-image bonds were skipped as intra-SBU"
+    assert residuals["n_bonds"] == 3  # one direct bond per cell axis
+
+
 def test_embedding_scores_only_what_the_pipeline_would_build(
     mofgen, embedding, mof5, tmp_path
 ):


### PR DESCRIPTION
The embedding benchmark could not exercise embedding relaxation at all — not for a numerical reason, but a structural one. After #178/#179/#180 landed, the first 600 CoRE MOF structures gave 71 buildable, 21 rebuilding faithfully — and **all 21 sat on fully pinned nets** (pcu ×17, nbo ×4; `fcu` is pinned too). Relaxation is a provable no-op on those, so the corpus said nothing about whether it helps.

The gap was the driver's: `_candidate_mappings` abandoned any net with a slot type nothing fits, which is exactly the edge-decorated family — blueprints that subdivide edges with 2-connected centers the real material doesn't have (HKUST-1 bonds paddlewheels straight onto BTC while `tbo` decorates every edge; an absent decoration is what a contracted-tier ID *means*). #179 made those builds possible; this teaches the benchmark to ask for them.

## The change

- A 2-connected slot type with no compatible fragment is offered as `None` (empty). Only where nothing fits — never alongside a fitting fragment (that would inflate the combination count and skip a decoration the material has). Higher-connectivity unfittable slots still abandon the net (genuine incompatibility, e.g. a square-planar paddlewheel against `dia`).
- `bond_residuals` needed the same correction `net.framework_quotient_edges` took in #179: a same-slot bond that crosses a boundary is a unit bonded to its own periodic image (what emptied edge centers produce), not intra-SBU — skipping all same-slot pairs reported *no* residuals for such a build.
- The rebuild record now carries the emptied slot indices.

Four tests target the new logic directly (no fixture net has the node+linker+edge-center shape this serves, and emptying the only 2-c type leaves node-node bonds that deconstruct as one 3-periodic cluster — verified, not assumed): undecorated edges offered empty, an unfittable *node* still abandons the net, emptying not offered when something fits, self-image bonds counted.

## What it unlocks — the corpus-scale #174 answer

Rebuilt **42 → 102**, faithful **21 → 56**, and **non-pinned faithful 0 → 35** (16 nets, `n_free` 1–14). Scoring base vs `--relax-embedding` on the 56 faithful-in-both:

| population | \|vr−1\| median | min_contact | bond residual |
|---|---|---|---|
| **pinned** (21, control) | 0.482 → 0.482 | 0.641 → 0.641 | 0.226 → 0.226 |
| **non-pinned** (35) | **0.260 → 0.052** | 0.836 → 1.056 | 0.091 → 0.214 |

The pinned control is byte-identical — the check that the measurement is sound. On the non-pinned population the built density lands **5× closer to the experimental crystal**; 21/35 improve, 5 worsen, and the 9 unchanged are all `n_free` 1–2 nets. The `rtl` family is the clearest signal: six structures whose idealized embedding packs at *half* the real density (vr ≈ 0.49–0.51) all relax to within ~5%.

Honest trade-off: bond closure loosens (0.091 → 0.214 Å median) as the anchor-direction terms pull the packing toward the chemistry — sub-0.25 Å, `relax()` territory, with contact improving rather than degrading, so a favourable exchange but an exchange. This is the corpus-scale answer to the question #174 opened with: **for low-symmetry nets, relaxing the embedding measurably fixes the proportions the idealization got wrong.**

Ruff, mypy, benchmark tests clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
