### PR TITLE
Relax lateral slot positions in rod builds (#189, the rod half of #174)

### DIFF
--- a/docs/rods.md
+++ b/docs/rods.md
@@ -360,6 +360,39 @@ An axis-parallel and a diagonal family cannot be mixed in one build: a
 diagonal pin stretches the whole cell along its own direction, which
 cannot also leave a cell row free for the other to pin.
 
+### Relaxing the embedding
+
+Like the finite pipeline, a rod build places its finite units at the
+blueprint's idealized slot centres, so their *proportions* are whatever the
+net's maximum-symmetry embedding chose. `relax_embedding=True` frees the
+**lateral** slot positions as extra optimizer degrees of freedom, one
+displacement per crystallographic orbit restricted to the directions that
+orbit's site symmetry allows:
+
+```python
+mof = mofgen.build_rod(topology, rod, linkers, relax_embedding=True)
+```
+
+Only the laterals are freed, and that is forced by the geometry rather than
+chosen:
+
+- a helical run's **axis line is a screw axis of the net** — a symmetry
+  element — and a rotation of order ≥ 2 fixes no transverse vector, so axis
+  lines cannot move at all. Rod-to-rod spacing is set by the cell, which the
+  build already optimizes.
+- a **run node's** remaining freedom is transverse (its nodes sit off the
+  axis), but that changes the *helix radius*, and a harvested rod is rigid:
+  placement reads a node's azimuth and height, never its radius. The azimuth
+  part is already the build's `theta`.
+- a run's **edge centers** are contracted into the rod's own continuation and
+  never placed.
+
+Nets whose laterals are symmetry-pinned (`etb`, whose free orbits are all run
+slots) build identically with the flag on. Where the laterals do carry freedom
+— `etb-e` has three parameters, exactly where MOF-74's node-to-linker
+proportion was measured wrong — a linker whose span does not suit the
+idealized separation closes markedly better. Off by default.
+
 ### Verifying the built net
 
 Passing `verify_net=True` (or calling `mof.verify_net(topology)` after

--- a/src/autografs/builder.py
+++ b/src/autografs/builder.py
@@ -1137,6 +1137,7 @@ class Autografs:
         min_distance: float | None = 1.0,
         verify_net: bool = False,
         verbose: bool = False,
+        relax_embedding: bool = False,
     ) -> Framework:
         """Build a rod framework — straight or helical (rod Stage C).
 
@@ -1209,4 +1210,5 @@ class Autografs:
             min_distance=min_distance,
             verify_net=verify_net,
             verbose=verbose,
+            relax_embedding=relax_embedding,
         )

--- a/src/autografs/rod_build.py
+++ b/src/autografs/rod_build.py
@@ -602,6 +602,7 @@ class _RodBuild:
         rod: RodFragment,
         linkers: Fragment | dict[int, Fragment | None],
         run: SlotRun | HelicalRun | list[SlotRun | HelicalRun],
+        relax_embedding: bool = False,
     ) -> None:
         self.rod = rod
         # a helical run spirals its nodes: the screw axis is a fixed
@@ -795,6 +796,53 @@ class _RodBuild:
         )
         self.orbit_position = {orbit: k for k, orbit in enumerate(distinct)}
         self.n_orbits = len(distinct)
+
+        # embedding relaxation (#174) for the rod path, restricted to
+        # the LATERAL slots. The other candidates are all unusable, by
+        # construction rather than by choice:
+        #
+        # - a helical run's axis line is a screw axis of the net, i.e. a
+        #   symmetry element, and a rotation of order >= 2 fixes no
+        #   transverse vector (order 2 sends v -> -v). Axis lines are
+        #   pinned outright, so rod-to-rod spacing is set by the cell -
+        #   which ``scale`` already varies.
+        # - a run node's freedom is transverse (the nodes sit off the
+        #   axis), but that moves the *helix radius*, and a harvested
+        #   rod is rigid: placement reads only the node's azimuth and
+        #   height, never its radius. What is left of it - the azimuth -
+        #   is ``theta``.
+        # - a run's edge centers are contracted into the rod's own
+        #   continuation and never placed.
+        #
+        # The laterals are the genuine gap, and the one #174 was opened
+        # on: etb-e carries 3 free lateral parameters, exactly where the
+        # CAXVOO node-to-linker proportion was measured wrong. They are
+        # also better conditioned here than in the finite pipeline: the
+        # rods are symmetry-pinned anchors, so a linker between them is
+        # fixed by closure rather than floppy.
+        self.slot_disp = None
+        self.n_slot_free = 0
+        if relax_embedding and self.lateral:
+            from dataclasses import replace as dataclass_replace
+
+            from autografs.symmetry import orbit_displacements
+
+            placed = {lateral.slot_index for lateral in self.lateral}
+            disp = orbit_displacements(topology)
+            bases = {
+                orbit: (
+                    basis if disp.representatives[orbit] in placed else np.zeros((0, 3))
+                )
+                for orbit, basis in disp.bases.items()
+            }
+            disp = dataclass_replace(disp, bases=bases)
+            if disp.n_free:
+                self.slot_disp = disp
+                self.n_slot_free = disp.n_free
+                logger.debug(
+                    f"Rod embedding relaxation on {topology.name!r}: "
+                    f"{disp.n_free} lateral slot parameters."
+                )
         # linker copies per lateral slot, one per blueprint period the
         # build stacks: a helical blueprint is already the full period
         # (one linker each), a straight one holding a single node is
@@ -943,6 +991,7 @@ class _RodBuild:
         theta: np.ndarray | float,
         z0: np.ndarray | float,
         phi: np.ndarray | None = None,
+        shifts: np.ndarray | None = None,
     ) -> dict:
         """Place everything for one parameter set.
 
@@ -1094,7 +1143,12 @@ class _RodBuild:
                 centered = Rotation.from_rotvec(angle * species.relief_axis).apply(
                     centered
                 )
-            linker0 = centered @ rotation.T + lateral.center_frac @ linker_cell
+            center_frac = lateral.center_frac
+            if shifts is not None:
+                # embedding relaxation: the slot centre moves within its
+                # site symmetry, the SBU rides along rigidly
+                center_frac = center_frac + shifts[lateral.slot_index]
+            linker0 = centered @ rotation.T + center_frac @ linker_cell
             for n in range(self.linker_copies):
                 placements.append(
                     {
@@ -1160,15 +1214,29 @@ class _RodBuild:
         }
 
     def unpack(self, params: np.ndarray) -> tuple[float, np.ndarray, np.ndarray]:
-        """(scale, theta per family, z0 per family) from a flat vector."""
-        rest = np.asarray(params[1:], dtype=float).reshape(self.n_families, 2)
+        """(scale, theta per family, z0 per family) from a flat vector.
+
+        Reads the head only; any trailing lateral-displacement block
+        (embedding relaxation) is left to ``lateral_shifts``.
+        """
+        head = np.asarray(params[1 : 1 + 2 * self.n_families], dtype=float)
+        rest = head.reshape(self.n_families, 2)
         return float(params[0]), rest[:, 0], rest[:, 1]
+
+    def lateral_shifts(self, params: np.ndarray) -> np.ndarray | None:
+        """Per-slot fractional displacements from the parameter tail."""
+        if self.slot_disp is None:
+            return None
+        tail = np.asarray(params[1 + 2 * self.n_families :], dtype=float)
+        return self.slot_disp.expand(tail)
 
     def objective(self, params: np.ndarray) -> float:
         scale, theta, z0 = self.unpack(params)
         if scale <= 0.05:
             return 1e6
-        residuals = self.evaluate(scale, theta, z0)["residuals"]
+        residuals = self.evaluate(scale, theta, z0, shifts=self.lateral_shifts(params))[
+            "residuals"
+        ]
         return float(np.sqrt((residuals**2).mean()))
 
     def initial_guess(self) -> np.ndarray:
@@ -1239,12 +1307,14 @@ class _RodBuild:
             if self._arm_rows
             else 0.0
         )
+        # lateral displacements start at the idealized embedding
+        tail = [0.0] * self.n_slot_free
         if self.helical:
             per_family = [0.0, -z_arms] * self.n_families
-            return np.array([scale0, *per_family])
+            return np.array([scale0, *per_family, *tail])
         cell_p = self._cell_one_period(scale0)
         z_node = float((self.node_center_frac @ cell_p) @ self.axis_hat)
-        return np.array([scale0, 0.0, z_node - z_arms])
+        return np.array([scale0, 0.0, z_node - z_arms, *tail])
 
     def refresh_assignments(self, scale: float) -> None:
         """Re-solve which SBU arm fills which slot dummy, at this cell.
@@ -1503,6 +1573,7 @@ def build_rod_framework(
     bond_tolerance: float = DEFAULT_BOND_TOLERANCE,
     verify_net: bool = False,
     verbose: bool = False,
+    relax_embedding: bool = False,
 ) -> Framework:
     """Build a rod framework - straight or helical - from a rod and linkers.
 
@@ -1675,7 +1746,13 @@ def build_rod_framework(
     lateral_slots = [s for s in range(len(topology.slots)) if s not in run_slots]
     per_slot = _validate_linkers(topology, linkers, lateral_slots)
 
-    build = _RodBuild(topology, rod, per_slot, runs if len(runs) > 1 else runs[0])
+    build = _RodBuild(
+        topology,
+        rod,
+        per_slot,
+        runs if len(runs) > 1 else runs[0],
+        relax_embedding=relax_embedding,
+    )
 
     # optimize: coarse rotation grid per axis family (a full product
     # grid would be 16^families), then refine everything with Nelder-Mead
@@ -1696,6 +1773,7 @@ def build_rod_framework(
         options={"xatol": 1e-4, "fatol": 1e-6, "maxiter": 2000},
     )
     scale, theta, z0 = build.unpack(result.x)
+    shifts = build.lateral_shifts(result.x)
     # the polytopic arm assignments were fixed at the blueprint cell;
     # re-solve them now that the cell has moved
     build.refresh_assignments(scale)
@@ -1706,7 +1784,9 @@ def build_rod_framework(
     # relievable lateral orbit. A ring has pi symmetry, so the search
     # spans [0, pi); grid then refine.
     def relief(phi: np.ndarray) -> float:
-        return -build.min_inter_unit_contact(build.evaluate(scale, theta, z0, phi=phi))
+        return -build.min_inter_unit_contact(
+            build.evaluate(scale, theta, z0, phi=phi, shifts=shifts)
+        )
 
     best_phi: np.ndarray | None = None
     if build.n_orbits == 1:
@@ -1733,7 +1813,7 @@ def build_rod_framework(
         )
         if -refined.fun >= -relief(best_phi):
             best_phi = refined.x
-    placed = build.evaluate(scale, theta, z0, phi=best_phi)
+    placed = build.evaluate(scale, theta, z0, phi=best_phi, shifts=shifts)
 
     worst_bond = float(placed["residuals"].max())
     if worst_bond > bond_tolerance:

--- a/tests/test_rods.py
+++ b/tests/test_rods.py
@@ -2230,3 +2230,134 @@ class TestForwardUnwrap:
 
         result = mofgen.deconstruct(_helical_rod_structure())
         return rod_fragment(result.structure, result.rod_units[0])
+
+
+class TestRodEmbeddingRelaxation:
+    """Embedding relaxation for the rod path (#189 / #174).
+
+    Only the *lateral* slots are freed, and that restriction is forced
+    rather than chosen: a helical run's axis is a screw axis of the net,
+    so it is a symmetry element and cannot move; a run node's remaining
+    freedom is the helix radius, which a rigid harvested rod cannot
+    follow (placement reads its azimuth and height only); and a run's
+    edge centers are contracted into the rod. The laterals are what is
+    left, and they are where #174 was measured wrong on MOF-74.
+    """
+
+    def test_only_lateral_orbits_are_freed(self, bundled_topologies):
+        """etb-e's blueprint carries free run-node and run-edge orbits
+        too; the rod build must expose only the lateral ones."""
+        from autografs.rod_build import _RodBuild, _select_runs, _validate_linkers
+        from autografs.symmetry import orbit_displacements
+
+        etbe = bundled_topologies["etb-e"]
+        rod, ditopic, tetratopic, dit_slots, tet_slots = _etbe_mixed_mapping(etbe)
+        mapping = {s: ditopic for s in dit_slots} | {s: tetratopic for s in tet_slots}
+        per_slot = _validate_linkers(
+            etbe, mapping, sorted(dit_slots) + sorted(tet_slots)
+        )
+        runs = _select_runs(etbe, rod, True)
+
+        build = _RodBuild(etbe, rod, per_slot, runs, relax_embedding=True)
+
+        # the whole blueprint has more freedom than the rod path can use
+        assert orbit_displacements(etbe).n_free > build.n_slot_free
+        assert build.n_slot_free == 3
+        # and the parameter vector grew by exactly that much
+        assert len(build.initial_guess()) == 1 + 2 * build.n_families + 3
+
+    def test_the_new_parameters_are_not_flat(self, bundled_topologies):
+        """A freed parameter the objective cannot see would be a
+        wandering direction for Nelder-Mead, not a degree of freedom."""
+        from autografs.rod_build import _RodBuild, _select_runs, _validate_linkers
+
+        etbe = bundled_topologies["etb-e"]
+        rod, ditopic, tetratopic, dit_slots, tet_slots = _etbe_mixed_mapping(etbe)
+        mapping = {s: ditopic for s in dit_slots} | {s: tetratopic for s in tet_slots}
+        per_slot = _validate_linkers(
+            etbe, mapping, sorted(dit_slots) + sorted(tet_slots)
+        )
+        build = _RodBuild(
+            etbe, rod, per_slot, _select_runs(etbe, rod, True), relax_embedding=True
+        )
+
+        start = build.initial_guess()
+        base = build.objective(start)
+        for k in range(build.n_slot_free):
+            moved = start.copy()
+            moved[1 + 2 * build.n_families + k] += 0.3
+            assert abs(build.objective(moved) - base) > 1e-6
+
+    def test_relaxation_closes_a_mismatched_linker(self, bundled_topologies):
+        """The #174 situation: a linker whose span does not suit the
+        idealized node-to-linker proportion. Freeing the lateral slots
+        must close the bonds better than the cell alone can."""
+        import numpy as np
+        from scipy.optimize import minimize
+
+        from autografs.rod_build import _RodBuild, _select_runs, _validate_linkers
+
+        etbe = bundled_topologies["etb-e"]
+        rod, ditopic, tetratopic, dit_slots, tet_slots = _etbe_mixed_mapping(etbe)
+        # stretch the ditopic linker so the ideal separation misfits it
+        stretched = ditopic.copy()
+        coords = np.asarray(stretched.atoms.cart_coords)
+        center = coords.mean(axis=0)
+        stretched.atoms = type(stretched.atoms)(
+            stretched.atoms.species,
+            center + (coords - center) * 1.25,
+            site_properties=stretched.atoms.site_properties,
+        )
+        stretched._clear_geometry_caches()
+
+        worst = {}
+        for label, relax in (("default", False), ("relaxed", True)):
+            mapping = {s: stretched for s in dit_slots} | {
+                s: tetratopic for s in tet_slots
+            }
+            per_slot = _validate_linkers(
+                etbe, mapping, sorted(dit_slots) + sorted(tet_slots)
+            )
+            build = _RodBuild(
+                etbe,
+                rod,
+                per_slot,
+                _select_runs(etbe, rod, True),
+                relax_embedding=relax,
+            )
+            result = minimize(
+                build.objective,
+                build.initial_guess(),
+                method="Nelder-Mead",
+                options={"xatol": 1e-4, "fatol": 1e-6, "maxiter": 2000},
+            )
+            scale, theta, z0 = build.unpack(result.x)
+            placed = build.evaluate(
+                scale, theta, z0, shifts=build.lateral_shifts(result.x)
+            )
+            worst[label] = float(placed["residuals"].max())
+
+        assert worst["relaxed"] < 0.5 * worst["default"]
+
+    def test_pinned_laterals_build_identically(self, bundled_topologies):
+        """etb's laterals are symmetry-pinned (its free orbits are all
+        run slots), so the flag must be a no-op there - the rod mirror
+        of the finite pipeline's pinned-net guarantee."""
+        import numpy as np
+
+        from autografs.rod_build import build_rod_framework
+
+        etb = bundled_topologies["etb"]
+        rod, linker = _etb_helical_rod(etb)
+        default = build_rod_framework(etb, rod, linker, min_distance=None)
+        relaxed = build_rod_framework(
+            etb, rod, linker, min_distance=None, relax_embedding=True
+        )
+
+        assert np.allclose(relaxed.cell, default.cell, atol=1e-9)
+        for node in default.graph:
+            np.testing.assert_allclose(
+                relaxed.graph.nodes[node]["coord"],
+                default.graph.nodes[node]["coord"],
+                atol=1e-9,
+            )


### PR DESCRIPTION
Closes #189. `build_rod(..., relax_embedding=True)` frees the **lateral** slot centres as optimizer degrees of freedom — one displacement per crystallographic orbit, restricted to its site-symmetry subspace — reusing the `autografs.symmetry` machinery #182 added for the finite pipeline.

## The design pass overturned the issue's premise

I filed #189 proposing a transverse **axis-line** offset. That would have done nothing, and measuring it is the useful part of this PR:

**A helical run's axis line *is* a screw axis of the net** — a symmetry element. A rotation of order ≥ 2 fixes no transverse vector (order 2 sends `v → −v`), so axis lines are pinned in *every* net that has one. Measured 8/8 (etb, etb-e, unc, bmn, srs, twt, cds, bcu): for etb, 36 operations permute the six helices into a single orbit with **zero** transverse freedom. Rod-to-rod spacing is set by the cell, which `scale` already varies.

Breaking the free orbits down by slot class showed where the freedom actually lives:

| net | run-node | run-edge | lateral |
|---|---|---|---|
| etb | 1 | 1 | 0 |
| **etb-e** | 1 | 1 | **3** |
| unc | 1 | 2 | 0 |
| bmn | 1 | 1 | 0 |

- **run-node** freedom is transverse but moves the *helix radius*, and a harvested rod is rigid — placement reads a node's azimuth (already `theta`) and height, never its radius.
- **run-edge** slots are contracted into the rod's continuation and never placed.
- **lateral** is the one usable gap, and etb-e's three parameters are exactly where #174's opening CAXVOO measurement (node→linker separation 0.168 of the in-plane cell vs 0.284 real) found the error.

## Why it behaves better than the finite case

In the finite pipeline, degrees of freedom without the anchor-direction terms left a floppy net (see #182). Here the **rods are symmetry-pinned anchors**, so a linker between them is fixed by closure rather than free to wander — no extra objective term needed.

## Measured

- mechanism live: 3 parameters on etb-e, objective responds to each (not flat — a freed parameter the objective can't see would just be a wandering direction for Nelder-Mead)
- a deliberately mismatched linker (25 % stretch, mimicking the CAXVOO proportion error) closes **4× better**: worst inter-unit bond deviation **0.0149 → 0.0037 Å**
- `etb`, whose laterals are pinned, builds **bit-identically** with the flag on — the rod mirror of the finite pipeline's pinned-net guarantee

**Caveat, stated plainly:** that 4× is on a synthetic fixture which already closed to 0.015 Å. The real proof is CAXVOO on `etb-e`, which is local-CIF-only (CSD-derived, never committed), so this evidence stays weaker than the finite side's corpus result.

## Testing

4 new tests (lateral-only restriction, parameters not flat, mismatched-linker improvement, pinned-net bit-identity). All 95 existing rod tests pass; full suite, ruff, mypy clean. `docs/rods.md` gains a "Relaxing the embedding" section explaining why only the laterals move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
