### PR TITLE
docs: correct stale and contradictory comments

### DIFF
--- a/scripts/benchmarks/roundtrip.py
+++ b/scripts/benchmarks/roundtrip.py
@@ -17,8 +17,10 @@ useful output - failures are data:
                         chemically not the same material
 - ``rebuild_failed``    every candidate/mapping combination was gated
 - ``no_mapping``        no compatible fragment-to-slot assignment
-- ``rod``               identified, but contains 1-periodic units the
-                        forward pipeline cannot rebuild (Stage A)
+- ``rod``               identified, but contains 1-periodic units this
+                        driver does not rebuild: rods go through
+                        ``Autografs.build_rod``, not the slot-type
+                        mappings enumerated here
 - ``unidentified``      deconstructed, but no library net matched
 - ``deconstruction_failed``  with the error message
 
@@ -84,8 +86,10 @@ def roundtrip_one(mofgen: Autografs, source, max_rmsd: float) -> dict:
         record["net"] = result.net_candidates
         record["tier"] = result.subframework_nets[0].tier
     if result.rod_units:
-        # identified (often correctly) but not rebuildable: the forward
-        # pipeline has no rod support yet (#91 Stage C)
+        # out of scope for *this* driver, not for the pipeline: rods
+        # build through Autografs.build_rod (#158/#168/#173), which
+        # takes a RodFragment and a run rather than the slot-type
+        # mappings this round trip enumerates
         record["outcome"] = "rod" if result.net_candidates else "unidentified"
         record["seconds"] = time.perf_counter() - t0
         return record

--- a/src/autografs/symmetry.py
+++ b/src/autografs/symmetry.py
@@ -92,10 +92,10 @@ def _lattice_point_group(matrix: np.ndarray) -> list[np.ndarray]:
     metric = matrix @ matrix.T
     scale = float(np.abs(metric).max())
     candidates = []
+    # a column of W is never all-zero (W is invertible), so the search
+    # is over 26^3 = ~17.5k matrices rather than the full 3^9; the
+    # determinant test rejects most of them before the metric check
     columns = [np.array(c) for c in product((-1, 0, 1), repeat=3) if any(c)]
-    # build W column by column, pruning on the diagonal of the metric
-    # condition first (a full 3^9 scan is ~20k matrices; this is
-    # equivalent but keeps the inner check cheap)
     for w in product(columns, repeat=3):
         candidate = np.array(w, dtype=int).T
         if abs(round(float(np.linalg.det(candidate)))) != 1:

--- a/tests/test_empty_slots.py
+++ b/tests/test_empty_slots.py
@@ -93,8 +93,10 @@ class TestEmptySlotBuild:
             mofgen.build(topology, mappings=mappings)
 
     def test_partial_emptying_by_index(self, mofgen):
-        """Emptying one edge center and filling the other two is a
-        different net than pcu - verify_net must say so."""
+        """Emptying one edge center and filling the other two still
+        realizes pcu: the blueprint is contracted on exactly the
+        emptied slot, so verify_net compares like with like and
+        accepts."""
         topology = mofgen.topologies["pcu"]
         mappings = {}
         for key in topology.mappings:


### PR DESCRIPTION
Closes #191.

Three comment corrections found in a post-v3 review sweep. No behaviour change; lint, mypy and the suite are unaffected.

- **`scripts/benchmarks/roundtrip.py`** — the `rod` outcome was documented (module docstring and inline) as *"the forward pipeline has no rod support yet (#91 Stage C)"*. Rod forward-building shipped across #158/#168/#173. The limitation is real but belongs to this driver: it enumerates slot-type mappings, and rods build through `Autografs.build_rod` with a `RodFragment` and a run instead. Reworded to say that.
- **`tests/test_empty_slots.py`** — `test_partial_emptying_by_index`'s docstring claimed the partially-emptied build "is a different net than pcu - verify_net must say so", while the body asserts `verify_net` **accepts**. The assertion is the correct one (the blueprint is contracted on exactly the emptied slot), so the docstring was rewritten to match.
- **`src/autografs/symmetry.py`** — `_lattice_point_group`'s comment described building `W` column by column "pruning on the diagonal of the metric condition first". No such pruning exists; it is a plain scan over invertible {-1,0,1} matrices. Replaced with a description of the search actually performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)