### PR TITLE
fix: harden three latent edge cases

### DIFF
--- a/scripts/benchmarks/embedding.py
+++ b/scripts/benchmarks/embedding.py
@@ -274,6 +274,7 @@ def bond_residuals(framework) -> dict:
     cell = np.asarray(graph.graph["cell"], dtype=float)
     inverse = np.linalg.inv(cell)
     deviations: list[float] = []
+    skipped: set[str] = set()
     for node_a, node_b in graph.edges():
         data_a = graph.nodes[node_a]
         data_b = graph.nodes[node_b]
@@ -286,18 +287,28 @@ def bond_residuals(framework) -> dict:
             # produce (#179), so it must be measured.
             continue
         delta -= crossing @ cell
-        target = CovalentRadius.radius.get(
-            data_a["symbol"], 0.0
-        ) + CovalentRadius.radius.get(data_b["symbol"], 0.0)
+        # an element absent from the Cordero table has no target: a 0.0
+        # fallback would report the whole bond length as the deviation,
+        # which reads as a catastrophic build rather than as a missing
+        # radius. Skip the bond and say how many were skipped.
+        symbols = (data_a["symbol"], data_b["symbol"])
+        missing = [s for s in symbols if s not in CovalentRadius.radius]
+        if missing:
+            skipped.update(missing)
+            continue
+        target = sum(CovalentRadius.radius[s] for s in symbols)
         deviations.append(abs(float(np.linalg.norm(delta)) - target))
     if not deviations:
         return {}
     ordered = sorted(deviations)
-    return {
+    summary = {
         "median": statistics.median(ordered),
         "max": ordered[-1],
         "n_bonds": len(ordered),
     }
+    if skipped:
+        summary["skipped_elements"] = sorted(skipped)
+    return summary
 
 
 def _rebuild(

--- a/src/autografs/rod_build.py
+++ b/src/autografs/rod_build.py
@@ -96,6 +96,7 @@ What is structurally different from the finite-SBU pipeline:
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -1343,6 +1344,11 @@ class _RodBuild:
         inter-unit distances change and only they can clash. Matched
         rod-linker anchor bonds are ~one covalent length and never the
         binding constraint, so they need no special exemption.
+
+        A build with a *single* unit has no inter-unit pair at all -
+        one rod on a net whose every lateral slot is emptied (#168/
+        #179) - and reports ``inf``, the same "nothing within reach"
+        convention ``Framework.min_contact`` uses.
         """
         cell = placed["cell"]
         inv = np.linalg.inv(cell)
@@ -1364,6 +1370,8 @@ class _RodBuild:
             labels.append(np.full(len(reals), p_index))
         points = np.vstack(coords)
         unit = np.concatenate(labels)
+        if len(np.unique(unit)) < 2:
+            return math.inf
         # minimum-image pairwise distances between different units
         delta = points[:, None, :] - points[None, :, :]
         frac = delta @ inv

--- a/src/autografs/symmetry.py
+++ b/src/autografs/symmetry.py
@@ -344,6 +344,15 @@ def orbit_displacements(
             representatives[orbits[slot]] = slot
             propagation[slot] = np.eye(3)
         # rebuild orbit_of_slot consistency below
+    if any(w is None for w in propagation):  # pragma: no cover - the loop above
+        # `expand` indexes propagation *by slot*, so a gap would not
+        # shorten the result, it would silently shift every later
+        # slot's displacement onto the wrong site
+        raise AssertionError(
+            f"Slot displacement propagation is incomplete on "
+            f"{topology.name!r}; the unreached-slot pass should have "
+            "filled every entry."
+        )
     bases: dict[int, np.ndarray] = {}
     for orbit, representative in representatives.items():
         stabilizer = [
@@ -356,5 +365,6 @@ def orbit_displacements(
         orbit_of_slot=tuple(orbits),
         representatives=representatives,
         bases=bases,
-        propagation=tuple(w for w in propagation if w is not None),
+        # indexed by slot: every entry is set, checked above
+        propagation=tuple(np.asarray(w) for w in propagation),
     )

--- a/tests/test_rods.py
+++ b/tests/test_rods.py
@@ -2361,3 +2361,41 @@ class TestRodEmbeddingRelaxation:
                 default.graph.nodes[node]["coord"],
                 atol=1e-9,
             )
+
+
+class TestSingleUnitContact:
+    """A build can legitimately place exactly one unit: one rod on a
+    net whose every lateral slot is emptied (#168/#179). There is then
+    no inter-unit pair to measure, and the contact must report the
+    "nothing within reach" convention rather than reducing over an
+    empty array."""
+
+    def test_no_inter_unit_pair_reports_inf(self, mofgen):
+        from autografs.rod_build import _RodBuild, _select_runs
+
+        result = mofgen.harvest([_rod_pillar_structure(1)])
+        rod = result.rods["rod_OZn"]
+        linker = result.fragments[
+            next(n for n, k in result.kinds.items() if k == "linker")
+        ]
+        pcu = mofgen.topologies["pcu"]
+        build = _RodBuild(pcu, rod, linker, _select_runs(pcu, rod, False)[0])
+        assert build.n_rods == 1
+        placed = build.evaluate(*build.unpack(build.initial_guess()))
+        # the all-lateral-slots-empty case: nothing but the rod is placed
+        placed["placements"] = []
+        assert build.min_inter_unit_contact(placed) == math.inf
+
+    def test_two_units_still_measure_a_contact(self, mofgen):
+        from autografs.rod_build import _RodBuild, _select_runs
+
+        result = mofgen.harvest([_rod_pillar_structure(1)])
+        rod = result.rods["rod_OZn"]
+        linker = result.fragments[
+            next(n for n, k in result.kinds.items() if k == "linker")
+        ]
+        pcu = mofgen.topologies["pcu"]
+        build = _RodBuild(pcu, rod, linker, _select_runs(pcu, rod, False)[0])
+        placed = build.evaluate(*build.unpack(build.initial_guess()))
+        assert placed["placements"]
+        assert math.isfinite(build.min_inter_unit_contact(placed))


### PR DESCRIPTION
Closes #192.

Three defensive fixes found in a post-v3 review sweep. None is reachable in a currently-tested configuration; each fails unhelpfully rather than raising something readable.

### `_RodBuild.min_inter_unit_contact` reduced over an empty array

`dist[cross_unit].min()` with an all-`False` mask raises a bare `ValueError: zero-size array to reduction operation minimum`. That happens when a build places exactly **one** unit: one rod on a net whose every lateral slot is emptied (`None`), which #168/#179 made a supported configuration. Not reachable on etb-e (six rods) but reachable on a single-helix net such as `unc`.

Now returns `math.inf` — the same "nothing within reach" convention `Framework.min_contact` uses — with tests for both branches (`TestSingleUnitContact`).

### `orbit_displacements` filtered `propagation` by value

```python
propagation=tuple(w for w in propagation if w is not None)
```

`OrbitDisplacements.expand` indexes this **by slot**. The `unreached` pass above fills every entry, so the filter was a no-op — but had it ever not been, the result would have been silently misaligned by slot (every displacement after the gap applied to the wrong site) rather than raising. The invariant is now asserted and the tuple stays slot-indexed.

### Benchmark bond residuals fabricated a 0 A target

`scripts/benchmarks/embedding.py` used `CovalentRadius.radius.get(symbol, 0.0)`. An element absent from the Cordero table yielded target 0, so the reported deviation was the full bond length — a garbage residual that reads as a catastrophic build. Those bonds are now skipped and the elements responsible recorded under `skipped_elements`, so the omission is visible instead of poisoning the median.

Lint, format, mypy and the full suite pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)