### PR TITLE
fix(benchmarks): spread the mapping budget across every slot type

### DIFF
--- a/scripts/benchmarks/_mapping_order.py
+++ b/scripts/benchmarks/_mapping_order.py
@@ -1,0 +1,84 @@
+"""Order in which fragment-to-slot assignments are tried.
+
+Both closure drivers (``roundtrip.py``, ``embedding.py``) enumerate one
+compatible fragment per slot type and try the first N combinations,
+because a multi-orbit net with several interchangeable fragments
+explodes combinatorially and a benchmark has to terminate.
+
+``itertools.product`` is the wrong enumeration for that budget. It
+advances the **last** iterable fastest, so the first N combinations all
+share the same fragment on every slot type but the last: a 3-orbit net
+with 4 fitting fragments each has 64 combinations, and a budget of 8
+spends every one of them on ``(f0, f0, *)``. The first slot type is
+never varied at all.
+
+That matters precisely because the point of trying several mappings is
+that a net with interchangeable slot types can take a fragment on the
+wrong orbit. A structure whose correct assignment differs in an early
+slot type is then recorded as a failure when a mapping inside the
+budget would have worked.
+
+``graded_indices`` enumerates by **ascending total index** instead: the
+all-first assignment, then every one-step variation (one per slot type,
+in turn), then every two-step one, and so on. The budget is spent on
+the combinations nearest the reference assignment in *every* direction
+rather than in one. The first combination is unchanged, so a driver
+that only ever needed one attempt behaves exactly as before.
+"""
+
+from __future__ import annotations
+
+import heapq
+import math
+from collections.abc import Iterator, Sequence
+
+__all__ = ["graded_indices", "n_combinations"]
+
+
+def n_combinations(sizes: Sequence[int]) -> int:
+    """Total number of assignments, for reporting what was dropped."""
+    return math.prod(sizes) if sizes else 0
+
+
+def graded_indices(sizes: Sequence[int], limit: int) -> Iterator[tuple[int, ...]]:
+    """Index tuples in ascending total-index order, at most ``limit``.
+
+    Parameters
+    ----------
+    sizes : sequence of int
+        Number of options available for each slot type, in order.
+    limit : int
+        Maximum number of tuples to yield.
+
+    Yields
+    ------
+    tuple[int, ...]
+        One index per slot type. The first yield is always all-zero;
+        ties at equal total index break lexicographically, so the
+        enumeration is deterministic.
+
+    Notes
+    -----
+    Grown lazily from the all-zero tuple through single-step
+    increments, so the full product is never materialized: a net with
+    a combinatorially large assignment space costs the budget, not the
+    product.
+    """
+    if not sizes or any(size <= 0 for size in sizes) or limit <= 0:
+        return
+    start = (0,) * len(sizes)
+    heap: list[tuple[int, tuple[int, ...]]] = [(0, start)]
+    seen: set[tuple[int, ...]] = {start}
+    emitted = 0
+    while heap and emitted < limit:
+        _rank, current = heapq.heappop(heap)
+        yield current
+        emitted += 1
+        for axis, size in enumerate(sizes):
+            if current[axis] + 1 >= size:
+                continue
+            nxt = current[:axis] + (current[axis] + 1,) + current[axis + 1 :]
+            if nxt in seen:
+                continue
+            seen.add(nxt)
+            heapq.heappush(heap, (sum(nxt), nxt))

--- a/scripts/benchmarks/embedding.py
+++ b/scripts/benchmarks/embedding.py
@@ -58,7 +58,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import itertools
 import json
 import statistics
 import time
@@ -66,6 +65,7 @@ from collections import Counter
 from pathlib import Path
 
 import numpy as np
+from _mapping_order import graded_indices, n_combinations
 
 from autografs import Autografs
 from autografs.exceptions import AutografsError
@@ -221,6 +221,10 @@ def _candidate_mappings(topology, fragments):
     option alongside a fitting fragment: it would multiply the
     combination count for nets that already build, and a decoration
     the material *does* have should be placed.
+
+    Enumerated in graded order (see ``_mapping_order``) rather than
+    ``itertools.product`` order, so the budget varies every slot type
+    instead of only the last one.
     """
     slot_types = list(topology.mappings)
     options = []
@@ -233,8 +237,9 @@ def _candidate_mappings(topology, fragments):
                 return  # only 2-connected slots may be emptied
             fitting = [None]
         options.append(fitting)
-    combos = itertools.product(*options)
-    for combo in itertools.islice(combos, MAX_MAPPINGS_PER_NET):
+    sizes = [len(fitting) for fitting in options]
+    for indices in graded_indices(sizes, MAX_MAPPINGS_PER_NET):
+        combo = [option[index] for option, index in zip(options, indices, strict=True)]
         yield dict(zip(slot_types, combo, strict=True))
 
 
@@ -303,7 +308,9 @@ def _rebuild(
     No overlap gate: a compressed packing is exactly what this
     benchmark is here to measure, so it must not be rejected.
     """
+    tried = 0
     for mappings in _candidate_mappings(topology, result.fragments):
+        tried += 1
         try:
             framework = mofgen.build(
                 topology,
@@ -339,8 +346,27 @@ def _rebuild(
             ),
             "formula": built.composition.reduced_formula,
             "formula_experimental": experimental.composition.reduced_formula,
+            # no silent caps: how much of the assignment space the
+            # budget actually covered
+            "assignments_tried": tried,
+            "assignments_total": _assignment_space(topology, result.fragments),
         }
     return None
+
+
+def _assignment_space(topology, fragments) -> int:
+    """Total compatible fragment-per-slot-type assignments, 0 if none."""
+    sizes = []
+    for slot_type in topology.mappings:
+        fitting = sum(
+            1 for f in fragments.values() if f.has_compatible_symmetry(slot_type)
+        )
+        if not fitting:
+            if len(slot_type.atoms.indices_from_symbol("X")) != 2:
+                return 0
+            fitting = 1  # the empty-slot option
+        sizes.append(fitting)
+    return n_combinations(sizes)
 
 
 def measure_one(

--- a/scripts/benchmarks/roundtrip.py
+++ b/scripts/benchmarks/roundtrip.py
@@ -35,11 +35,12 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import itertools
 import json
 import time
 from collections import Counter
 from pathlib import Path
+
+from _mapping_order import graded_indices, n_combinations
 
 from autografs import Autografs
 from autografs.exceptions import AutografsError
@@ -51,7 +52,12 @@ MAX_MAPPINGS_PER_NET = 16
 
 
 def candidate_mappings(topology, fragments: dict):
-    """Yield fragment-per-slot-type assignments compatible by geometry."""
+    """Yield fragment-per-slot-type assignments compatible by geometry.
+
+    Enumerated in graded order (see ``_mapping_order``) rather than
+    ``itertools.product`` order, so the budget varies every slot type
+    instead of only the last one.
+    """
     slot_types = list(topology.mappings)
     options = []
     for slot_type in slot_types:
@@ -63,8 +69,15 @@ def candidate_mappings(topology, fragments: dict):
         if not fitting:
             return
         options.append(fitting)
-    combos = itertools.product(*options)
-    for combo in itertools.islice(combos, MAX_MAPPINGS_PER_NET):
+    sizes = [len(fitting) for fitting in options]
+    total = n_combinations(sizes)
+    if total > MAX_MAPPINGS_PER_NET:
+        print(
+            f"    [!] {topology.name}: {total} compatible assignments, "
+            f"trying the {MAX_MAPPINGS_PER_NET} nearest the first choice"
+        )
+    for indices in graded_indices(sizes, MAX_MAPPINGS_PER_NET):
+        combo = [option[index] for option, index in zip(options, indices, strict=True)]
         yield dict(zip(slot_types, combo, strict=True))
 
 

--- a/tests/test_mapping_order.py
+++ b/tests/test_mapping_order.py
@@ -1,0 +1,86 @@
+"""Tests for the benchmark drivers' assignment enumeration order.
+
+``itertools.product`` advances its last iterable fastest, so a capped
+budget spent on it never varies the first slot type at all. The graded
+enumeration spends the same budget on the combinations nearest the
+reference assignment in *every* direction.
+"""
+
+import itertools
+import os
+import sys
+
+import pytest
+
+SCRIPTS = os.path.join(os.path.dirname(__file__), "..", "scripts", "benchmarks")
+
+
+def _load(name):
+    sys.path.insert(0, SCRIPTS)
+    try:
+        return __import__(name)
+    finally:
+        sys.path.pop(0)
+
+
+@pytest.fixture(scope="module")
+def order():
+    return _load("_mapping_order")
+
+
+class TestGradedIndices:
+    def test_first_yield_is_the_reference_assignment(self, order):
+        """Unchanged behaviour for a driver that only needs one try."""
+        assert next(iter(order.graded_indices([4, 4, 4], 8))) == (0, 0, 0)
+
+    def test_every_axis_is_varied_within_the_budget(self, order):
+        """The bug this replaces: on a 4x4x4 space a budget of 8 spent
+        in product order leaves the first slot type pinned at its first
+        fragment, so an assignment differing there is never tried."""
+        product_order = list(itertools.islice(itertools.product(*[range(4)] * 3), 8))
+        assert {combo[0] for combo in product_order} == {0}  # the old bias
+
+        graded = list(order.graded_indices([4, 4, 4], 8))
+        varied = {axis for combo in graded for axis, value in enumerate(combo) if value}
+        assert varied == {0, 1, 2}
+
+    def test_ascending_total_index(self, order):
+        totals = [sum(combo) for combo in order.graded_indices([3, 4, 5], 30)]
+        assert totals == sorted(totals)
+
+    def test_enumeration_is_exhaustive_and_unique(self, order):
+        sizes = [3, 2, 4]
+        everything = list(order.graded_indices(sizes, 10_000))
+        assert len(everything) == len(set(everything))
+        assert set(everything) == set(itertools.product(*(range(s) for s in sizes)))
+        assert len(everything) == order.n_combinations(sizes)
+
+    def test_deterministic(self, order):
+        assert list(order.graded_indices([3, 3, 3], 12)) == list(
+            order.graded_indices([3, 3, 3], 12)
+        )
+
+    def test_budget_is_respected(self, order):
+        assert len(list(order.graded_indices([9, 9, 9], 5))) == 5
+
+    @pytest.mark.parametrize(
+        "sizes,limit", [([], 5), ([3, 0, 2], 5), ([3, 3], 0), ([2, 2], -1)]
+    )
+    def test_degenerate_inputs_yield_nothing(self, order, sizes, limit):
+        assert list(order.graded_indices(sizes, limit)) == []
+
+    def test_single_slot_type(self, order):
+        assert list(order.graded_indices([3], 10)) == [(0,), (1,), (2,)]
+
+    def test_n_combinations(self, order):
+        assert order.n_combinations([3, 4, 5]) == 60
+        assert order.n_combinations([]) == 0
+
+
+class TestDriversUseIt:
+    """Both closure drivers must go through the shared enumeration."""
+
+    @pytest.mark.parametrize("driver", ["roundtrip", "embedding"])
+    def test_driver_imports_the_shared_order(self, driver):
+        module = _load(driver)
+        assert module.graded_indices is _load("_mapping_order").graded_indices


### PR DESCRIPTION
Closes #193.

Both closure drivers cap how many fragment-per-slot-type assignments they try, and spent that cap on `itertools.product` order:

```python
combos = itertools.product(*options)
for combo in itertools.islice(combos, MAX_MAPPINGS_PER_NET):
```

`product` advances its **last** iterable fastest, so the first N combinations all share the same fragment on every slot type but the last. On a 3-orbit net with 4 fitting fragments each (64 combinations), a budget of 8 covers exactly `(f0, f0, *)` — the first slot type is never varied at all.

That defeats the purpose of the budget. The reason to try more than one mapping is that a net with interchangeable slot types can take a fragment on the wrong orbit — which is why #180 added the composition gate in the first place. A structure whose correct assignment differs in an early slot type was recorded as `rebuild_failed` / `closed_wrong_composition` even though a mapping well inside the budget would have worked.

### Change

New shared `scripts/benchmarks/_mapping_order.py`:

- `graded_indices(sizes, limit)` enumerates index tuples by **ascending total index** — the reference assignment, then every one-step variation (one per slot type, in turn), then every two-step one, and so on. Ties break lexicographically, so it is deterministic.
- Grown lazily from the all-zero tuple through single-step increments over a heap, so a combinatorially large assignment space costs the budget rather than the product.
- The **first** combination is unchanged (`(0, 0, …, 0)`), so any driver run that only ever needed one attempt behaves exactly as before — including the existing smoke tests.

Both drivers now also report what the cap dropped instead of truncating silently: `roundtrip` prints it, `embedding` records `assignments_tried` / `assignments_total` on each rebuild entry.

### Tests

New `tests/test_mapping_order.py` pins the properties, including the old bias as an explicit contrast (`product` order leaves the first axis at 0 for the whole budget, graded order varies all three), exhaustiveness, uniqueness, ascending totals, determinism, budget adherence, degenerate inputs, and that both drivers actually route through the shared function.

Lint, format, mypy and the full suite pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)