### PR TITLE
fix(benchmark): rebuild once per structure, on its best candidate

### DIFF
--- a/scripts/benchmarks/embedding.py
+++ b/scripts/benchmarks/embedding.py
@@ -429,10 +429,6 @@ def measure_one(
         entry = compare(real, ideal)
         entry["spacegroup"] = topology.spacegroup_number
         entry["buildable"] = is_buildable(topology, result.fragments)
-        if rebuild and entry["buildable"]:
-            entry["rebuild"] = _rebuild(
-                mofgen, topology, result, max_rmsd, relax_embedding
-            )
         record["nets"][net] = entry
     if not record["nets"]:
         record["outcome"] = (
@@ -456,6 +452,16 @@ def measure_one(
     record["buildable"] = record["nets"][best]["buildable"]
     record["size_error"] = record["nets"][best]["size_error"]
     record["shape_error"] = record["nets"][best]["shape_error"]
+    # the rebuild closes the loop on *this* structure's volume-ratio
+    # prediction, so it belongs to the same population the prediction
+    # does: the best candidate, once. Rebuilding every candidate made
+    # an ambiguous structure contribute one row to the size/shape
+    # statistics but several to the rebuild ones, and cost a full
+    # build per runner-up.
+    if rebuild and record["buildable"]:
+        record["nets"][best]["rebuild"] = _rebuild(
+            mofgen, mofgen.topologies[best], result, max_rmsd, relax_embedding
+        )
     record["outcome"] = "measured"
     record["seconds"] = time.perf_counter() - t0
     return record
@@ -525,11 +531,12 @@ def _summarize(records: dict) -> dict:
                 system: _stats(values) for system, values in sorted(by_system.items())
             },
         }
+    # one rebuild per *structure*, on its best candidate - the same
+    # population the size/shape statistics above are taken from
     rebuilds = [
-        entry["rebuild"]
+        record["nets"][record["best_net"]]["rebuild"]
         for record in measured
-        for entry in record["nets"].values()
-        if entry.get("rebuild")
+        if record["nets"][record["best_net"]].get("rebuild")
     ]
     # only rebuilds that reproduced the material's own formula say
     # anything about its packing (see _rebuild)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -156,6 +156,25 @@ def test_embedding_predicts_the_rebuilt_cell(mofgen, embedding, mof5, tmp_path):
     )
 
 
+def test_embedding_rebuilds_once_per_structure(mofgen, embedding, mof5, tmp_path):
+    """The rebuild closes the loop on one structure's volume-ratio
+    prediction, so it belongs to the same population the prediction
+    does: the best candidate, once. An ambiguous structure must not
+    contribute several rows to the rebuild statistics while
+    contributing one to the size/shape ones."""
+    mof5.write_cif(tmp_path / "mof5.cif")
+
+    payload = embedding.run(
+        [tmp_path / "mof5.cif"], mofgen, rebuild=True, verbose=False
+    )
+
+    record = payload["structures"]["mof5.cif"]
+    carrying = [net for net, entry in record["nets"].items() if "rebuild" in entry]
+    assert carrying == [record["best_net"]]
+    summary = payload["summary"]
+    assert summary["n_rebuilt"] <= summary["n_measured"]
+
+
 def test_embedding_reports_failures_as_data(mofgen, embedding, tmp_path):
     """A non-framework input lands in the taxonomy, not a raise."""
     from pymatgen.core.lattice import Lattice


### PR DESCRIPTION
Closes #194. Stacked on #201 (targets `fix-mapping-enumeration-order`; will retarget to master once that merges).

`_summarize` collected rebuilds by walking **every** net candidate of every structure:

```python
rebuilds = [
    entry["rebuild"]
    for record in measured
    for entry in record["nets"].values()
    if entry.get("rebuild")
]
```

while every other statistic in the same block — `size_error`, `shape_error`, `size_bias` — is taken from `record["nets"][record["best_net"]]`, one value per structure. A structure whose identification is ambiguous therefore contributed **one** row to the size/shape statistics but **two or more** to `n_rebuilt`, `n_rebuilt_faithful`, `rebuilt_min_contact` and `rebuilt_bond_residual`.

The rebuild is what closes the loop on *that structure's* volume-ratio prediction, so it belongs to the same population the prediction does. `measure_one` now rebuilds the best (buildable) candidate only, after the choice has been made, and `_summarize` reads that single entry.

This is not only a counting fix: structures with several rebuildable candidates are exactly the ones most likely to rebuild faithfully on one net and not on the other, so the old aggregation biased the *faithful fraction* as well as inflating the denominator.

Side benefit: an ambiguous structure no longer pays for a full build per runner-up.

### Tests

`test_embedding_rebuilds_once_per_structure` asserts the invariant directly — only the best net carries a `rebuild` entry, and `n_rebuilt <= n_measured`. The existing `test_embedding_predicts_the_rebuilt_cell` still passes (pcu is MOF-5's best candidate).

Lint, format and the driver tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)