### PR TITLE
fix(benchmark): tell a missing cap apart from a wrong material

### DIFF
--- a/scripts/benchmarks/roundtrip.py
+++ b/scripts/benchmarks/roundtrip.py
@@ -12,9 +12,19 @@ useful output - failures are data:
 
 - ``closed``            rebuild passed verify_net AND reproduced the
                         experimental reduced formula
+- ``closed_uncapped``   the rebuild reproduces the framework once its
+                        **monotopic** units are set aside. Those are
+                        pendant substituents and capping residues on
+                        the metal-free (branch-point) path, and no
+                        blueprint has a 1-connected slot to host them,
+                        so a rebuild is short by exactly those atoms.
+                        The net and every polytopic unit are right;
+                        this is a scope limit, not a wrong material
 - ``closed_wrong_composition``  verified rebuilds exist, but none with
-                        the right formula - topologically closed,
-                        chemically not the same material
+                        the right formula even allowing for that -
+                        topologically closed, chemically not the same
+                        material (a fragment on the wrong orbit, which
+                        is what this gate was added to catch)
 - ``rebuild_failed``    every candidate/mapping combination was gated
 - ``no_mapping``        no compatible fragment-to-slot assignment
 - ``rod``               identified, but contains 1-periodic units this
@@ -41,6 +51,7 @@ from collections import Counter
 from pathlib import Path
 
 from _mapping_order import graded_indices, n_combinations
+from pymatgen.core.composition import Composition
 
 from autografs import Autografs
 from autografs.exceptions import AutografsError
@@ -81,6 +92,43 @@ def candidate_mappings(topology, fragments: dict):
         yield dict(zip(slot_types, combo, strict=True))
 
 
+def uncapped_composition(result) -> tuple[str | None, str | None]:
+    """(reduced formula without the monotopic units, their formula).
+
+    A ``cap`` unit is an organic unit of external degree 1 - a pendant
+    substituent or capping residue, found on the metal-free
+    branch-point path. No blueprint carries a 1-connected slot, so a
+    rebuild is short by exactly those atoms however well the net and
+    every polytopic unit match; scoring that as "chemically not the
+    same material" conflates a scope limit with the wrong-orbit
+    assignment the composition gate exists to catch.
+
+    (Metal-bound solvent is *not* a cap: the metal-oxo rule clusters
+    C-free metal-bound atoms into the node, so a capped MOF round-trips
+    with its full formula and never reaches this path.)
+
+    Returns ``(None, None)`` when the structure has no cap units.
+    """
+    cap_atoms = [
+        index
+        for unit in result.units
+        if unit.kind == "cap"
+        for index in unit.atom_indices
+    ]
+    if not cap_atoms:
+        return None, None
+    structure = result.structure
+    caps = Composition(Counter(structure[index].specie.symbol for index in cap_atoms))
+    kept = Counter(
+        site.specie.symbol
+        for index, site in enumerate(structure)
+        if index not in set(cap_atoms)
+    )
+    if not kept:
+        return None, caps.reduced_formula
+    return Composition(kept).reduced_formula, caps.reduced_formula
+
+
 def roundtrip_one(mofgen: Autografs, source, max_rmsd: float) -> dict:
     """Deconstruct one structure and attempt the verified rebuild."""
     record: dict = {"outcome": None, "net": None, "tier": None, "error": None}
@@ -111,8 +159,11 @@ def roundtrip_one(mofgen: Autografs, source, max_rmsd: float) -> dict:
         record["seconds"] = time.perf_counter() - t0
         return record
     experimental_formula = result.structure.composition.reduced_formula
+    uncapped_formula, cap_formula = uncapped_composition(result)
+    record["caps"] = cap_formula
     saw_mapping = False
     saw_verified = False
+    saw_uncapped = False
     for net in result.net_candidates:
         topology = mofgen.topologies[net]
         for mappings in candidate_mappings(topology, result.fragments):
@@ -130,13 +181,21 @@ def roundtrip_one(mofgen: Autografs, source, max_rmsd: float) -> dict:
             # the reduced formula is invariant to supercell choice and
             # interpenetration fold, so it compares across cells
             built_formula = framework.structure.composition.reduced_formula
-            if built_formula != experimental_formula:
-                continue  # right topology, wrong material - keep trying
-            record["outcome"] = "closed"
-            record["rebuilt_net"] = net
-            record["seconds"] = time.perf_counter() - t0
-            return record
-    if saw_verified:
+            if built_formula == experimental_formula:
+                record["outcome"] = "closed"
+                record["rebuilt_net"] = net
+                record["seconds"] = time.perf_counter() - t0
+                return record
+            if uncapped_formula is not None and built_formula == uncapped_formula:
+                # everything but the monotopic units: no blueprint has a
+                # 1-connected slot for those, so keep looking for a full
+                # match and fall back to this if none turns up
+                saw_uncapped = True
+                record["rebuilt_net"] = net
+            # else: right topology, wrong material - keep trying
+    if saw_uncapped:
+        record["outcome"] = "closed_uncapped"
+    elif saw_verified:
         record["outcome"] = "closed_wrong_composition"
     elif saw_mapping:
         record["outcome"] = "rebuild_failed"

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -263,3 +263,81 @@ def test_embedding_scores_only_what_the_pipeline_would_build(
     assert payload["summary"]["buildable"]["size_error"]["max"] == pytest.approx(
         0.0, abs=1e-6
     )
+
+
+class TestRoundtripCapTaxonomy:
+    """#195: a monotopic ``cap`` unit has no 1-connected blueprint slot
+    to go to, so a rebuild is short by exactly those atoms however well
+    the net and every polytopic unit match. That is a scope limit, not
+    the wrong-orbit assignment the composition gate exists to catch, and
+    the taxonomy has to tell them apart.
+
+    (Metal-bound solvent is *not* a cap - the metal-oxo rule clusters
+    C-free metal-bound atoms into the node - so this only arises on the
+    metal-free branch-point path.)
+    """
+
+    @staticmethod
+    def _result(structure, units):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(structure=structure, units=units)
+
+    def test_no_caps_reports_nothing(self, roundtrip, mof5):
+        assert roundtrip.uncapped_composition(self._result(mof5.structure, [])) == (
+            None,
+            None,
+        )
+
+    def test_cap_atoms_are_subtracted(self, roundtrip, mof5):
+        from autografs.deconstruct import BuildingUnit
+
+        structure = mof5.structure
+        hydrogens = [i for i, site in enumerate(structure) if site.specie.symbol == "H"]
+        assert hydrogens, "fixture has no hydrogens to stand in for caps"
+        units = [
+            BuildingUnit(name="cap", kind="cap", atom_indices=[index], n_connections=1)
+            for index in hydrogens
+        ]
+
+        uncapped, caps = roundtrip.uncapped_composition(self._result(structure, units))
+
+        from pymatgen.core.composition import Composition
+
+        assert caps == Composition({"H": len(hydrogens)}).reduced_formula
+        # the framework minus every H, as a reduced formula
+        remaining = Composition(
+            {
+                symbol: sum(1 for site in structure if site.specie.symbol == symbol)
+                for symbol in {site.specie.symbol for site in structure}
+                if symbol != "H"
+            }
+        )
+        assert uncapped == remaining.reduced_formula
+        assert uncapped != structure.composition.reduced_formula
+
+    def test_polytopic_units_are_never_subtracted(self, roundtrip, mof5):
+        """Only ``kind == "cap"`` counts: a linker is placeable."""
+        from autografs.deconstruct import BuildingUnit
+
+        units = [
+            BuildingUnit(
+                name="linker", kind="linker", atom_indices=[0, 1], n_connections=2
+            ),
+            BuildingUnit(name="node", kind="node", atom_indices=[2], n_connections=6),
+        ]
+        assert roundtrip.uncapped_composition(self._result(mof5.structure, units)) == (
+            None,
+            None,
+        )
+
+    def test_capless_structure_records_no_caps(self, mofgen, roundtrip, tmp_path, mof5):
+        """The record carries the cap formula so an outcome is
+        interpretable; a MOF without monotopic units reports None and
+        still closes."""
+        mof5.write_cif(tmp_path / "mof5.cif")
+
+        payload = roundtrip.run([tmp_path / "mof5.cif"], mofgen, max_rmsd=0.5)
+
+        assert payload["outcomes"] == {"closed": 1}
+        assert payload["structures"]["mof5.cif"]["caps"] is None


### PR DESCRIPTION
Closes #195. Stacked on #202 → #201 (will retarget to master as those merge).

**The premise in the issue as filed was wrong, and I corrected it there before writing this.** Worth repeating here.

### What is *not* the problem

Metal-bound solvent never reaches the composition gate. Building MOF-5 from the fixture library, hanging a terminal `-OH` on every Zn, and round-tripping it:

```
built:  Zn4H12C24O13
capped: Zn4H16C24O17   (+4 OH)
units by kind: {'node': 1, 'linker': 3}     <- no cap unit at all
OUTCOME: {'closed': 1}
```

The metal-oxo clustering rule absorbs C-free metal-bound atoms **into** the node, exactly as it should. Capped MOFs were never affected.

### What is

Caps come from the metal-free **branch-point** path, where an organic unit of external degree 1 is classified `cap` — pendant substituents, capping residues, modulators. No blueprint carries a 1-connected slot, so those atoms can never be placed and a rebuild is short by exactly them however well the net and every polytopic unit match. Building a fully organic framework on `bor` from bundled SBUs:

```
bor  kinds={'node': 16, 'linker': 6, 'cap': 6}
  -> roundtrip outcome {'closed_wrong_composition': 1}
```

Labelled *"topologically closed, chemically not the same material"*, when the only thing wrong is that the pipeline has no slot for a monotopic decoration. That is a scope limit, not the wrong-orbit assignment the gate was added to catch, and lumping the two together both depresses the reported closure rate and hides the signal in `closed_wrong_composition`.

### Change

- `uncapped_composition(result)` → the reduced formula with `cap`-unit atoms removed, plus the caps' own formula. `(None, None)` when there are no caps, so cap-free structures take exactly the old path.
- New **`closed_uncapped`** outcome, ranked *below* `closed`: a full-formula rebuild still wins if any mapping produces one, and only if none does is the uncapped match reported.
- `record["caps"]` carries the cap formula so an outcome is interpretable.
- Module docstring taxonomy updated, including the note about why metal-bound solvent is not a cap.

With this, the `bor` case above reports `closed_uncapped`.

### Tests

`TestRoundtripCapTaxonomy` covers `uncapped_composition` against a real structure: no-caps → `(None, None)`, cap atoms subtracted from the reduced formula, only `kind == "cap"` subtracted (a linker is placeable), and a cap-free MOF still reporting `caps: None` and `closed`. The end-to-end `closed_wrong_composition` → `closed_uncapped` transition was verified manually on the `bor` COF above; it is not in CI because building it needs the bundled library rather than the small test fixture.

Lint, format, mypy and the driver tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)