### PR TITLE
docs: honesty pass on embedding relaxation and the closure gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,12 @@ is a ground-up rewrite around a small set of design choices:
   inter-SBU bond sits at its covalent (Cordero) bond length, with the crystal
   system's constraints enforced (a cubic net optimizes a single length).
   MOF-5 comes out cubic at 12.89 Å against the experimental 12.9 — *before*
-  any force-field relaxation.
+  any force-field relaxation. For lower-symmetry nets, whose idealized
+  blueprint fixes *proportions* no cell parameter can repair,
+  `build(..., relax_embedding=True)` additionally frees the slot positions
+  within their site symmetry: measured over CoRE MOF, that cuts the
+  built-versus-experimental density error about 3.3× (see
+  [embedding relaxation](docs/building.md#embedding-relaxation)).
 - **Fails loudly, never silently.** Optional hard gates (`max_rmsd`,
   `min_distance`) raise typed exceptions instead of returning distorted or
   interpenetrating structures. Identical inputs give identical outputs.
@@ -196,10 +201,23 @@ crystal. See [2D COFs and stacking](docs/cofs-and-stacking.md).
 deconstruction, and everything else are pure-Python. Install the relaxation
 backend with `pip install "autografs[relax]"`.
 
-**My SBU is rejected / I get `AlignmentError` — why?** The build gate is
-geometric: the SBU's connection-vector *shape* doesn't match the slot's within
+**My SBU is rejected / I get `AlignmentError` — why?** Usually the geometric
+gate: the SBU's connection-vector *shape* doesn't match the slot's within
 `max_rmsd`. Raise `max_rmsd`, pick a net whose vertex figure fits, or edit the
-SBU. Point-group symmetry is diagnostic metadata, not the gate.
+SBU. Point-group symmetry is diagnostic metadata, not the gate. If you passed
+`bond_tolerance`, the same exception also means the build did not *close* —
+correctly shaped units that no cell can bring to bonding distance.
+
+**My built structure is too open / its density looks wrong.** Most likely the
+blueprint's proportions rather than your SBUs. A build places every unit at
+its idealized slot centre and only varies the cell, and the idealized
+(maximum-symmetry, near-equal-edge) embedding is systematically *more open*
+than real chemistry — no single cell scale can fix a fractional coordinate.
+Try `build(..., relax_embedding=True)`, which frees the slot positions within
+their site symmetry; on nets that have any such freedom it cuts the density
+error about 3.3× over a CoRE MOF corpus. High-symmetry nets (pcu, dia, fcu)
+have nothing to free and are unaffected. Details and the measured trade-offs
+are in [embedding relaxation](docs/building.md#embedding-relaxation).
 
 **Is my net in the library?** 2686 RCSR nets ship; list them with
 `mofgen.list_topologies()`. 96.5 % are buildable out of the box — the rest, and

--- a/docs/building.md
+++ b/docs/building.md
@@ -51,6 +51,7 @@ mof = mofgen.build(
     refine_cell=True,   # optimize cell parameters (default)
     max_rmsd=0.3,       # reject builds with bad shape matches
     min_distance=1.0,   # reject builds with overlapping atoms
+    bond_tolerance=0.35,  # reject builds whose bonds do not close
 )
 ```
 
@@ -63,6 +64,21 @@ mof = mofgen.build(
   `autografs.OverlapError` is raised instead of returning overlapping or
   interpenetrating output. The same check is available on any result as
   `Framework.min_contact()`.
+- **`bond_tolerance`** gates *closure*: the deviation of each inter-SBU bond
+  from its covalent target, in Å. The other two gates cannot see this
+  failure — `max_rmsd` measures each SBU's shape against its slot and
+  `min_distance` measures overlap, and a framework whose units are correctly
+  shaped and comfortably spaced can still have every bond between them half an
+  Å too long.
+
+  **Off by default, and that is a measurement rather than caution.** An
+  arbitrary SBU on an arbitrary net frequently cannot close: over a 120-net
+  library sample of builds that pass `max_rmsd=0.5` today, the worst-bond
+  deviation has median 0.43 Å and 90th percentile 1.14 Å. Any default value
+  would silently change which builds the library produces, so the choice is
+  left to you. Set it when closure matters — screening, round-trip work,
+  anything using `relax_embedding` — and read the realized value under
+  `verbose` either way.
 - **Slot indices** (integers) may be used as mapping keys to place a specific
   SBU on a specific slot, overriding the slot-type choice:
 
@@ -110,12 +126,45 @@ frees the slot centres as extra optimization degrees of freedom — one
 displacement per crystallographic orbit, restricted to the directions the
 site's symmetry allows, so the net's declared symmetry is preserved by
 construction — and adds anchor-direction terms to the objective so each bond
-leaves its anchors along the direction the SBU's own chemistry points. Fully
-pinned nets (their embedding is already exact by symmetry) have nothing to
-relax and build exactly as without the flag; for the rest, the topology of
-the output is unchanged (`verify_net` applies as usual) while the packing
-follows the SBUs instead of the idealization. Off by default; the geometry
-of default builds is unchanged.
+leaves its anchors along the direction the SBU's own chemistry points. The
+topology of the output is unchanged (`verify_net` applies as usual) while the
+packing follows the SBUs instead of the idealization. Off by default; the
+geometry of default builds is unchanged.
+
+**What it buys, measured.** Over the first 600 structures of CoRE MOF 2014,
+rebuilt from their own deconstructed fragments and kept only where the rebuild
+reproduces the experimental reduced formula (35 such structures on nets with
+free proportions):
+
+| | fixed slots | `relax_embedding=True` |
+|---|---|---|
+| built-vs-experimental density error, median | 0.260 | **0.079** |
+| inter-SBU bond deviation, median | 0.091 Å | 0.112 Å |
+| closest non-bonded contact, median | 0.84 Å | 0.97 Å |
+
+So the density error falls by about 3.3× and packing improves, at a cost of
+roughly 0.02 Å in bond closure. That trade is the point of the feature, not a
+side effect: the idealized embedding is systematically *more open* than real
+chemistry, and a single cell scale cannot repair a fractional coordinate.
+
+**What it does not buy.** Fully pinned blueprints — every slot on a special
+position, nothing symmetry-allowed to move — build bit-for-bit identically
+with the flag on or off. That is by construction, and it is worth knowing that
+such nets are the *exception*: over a 185-net sample of the shipped library
+only three are fully pinned. Conversely, a low-symmetry net can carry tens of
+free parameters (the sample's largest is 52), and the optimizer is Nelder-Mead,
+so relaxation on such a net is slower and its result less reliable than on a
+net with two or three.
+
+**Closure is protected by a guard, not by the objective.** Freeing the slots
+lets the optimizer trade bond closure against the anchor-direction terms, and
+on a net whose SBU-versus-slot shape mismatch is large that trade can go badly.
+Every relaxed build is therefore scored against two references — closure alone
+over the same free parameters, and the fixed-slot solution the flag-off build
+would give — and the relaxed result is kept only if its worst bond stays within
+0.2 Å of the best of them. The budget is deliberately not zero: a modest
+closure cost bought with a large packing gain is exactly what the feature is
+for. If you need a hard closure guarantee, set `bond_tolerance` as well.
 
 ## Batch enumeration
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -133,6 +133,9 @@ src/autografs/
 ├── builder.py       Autografs: libraries, sieve, build / build_all
 ├── alignment.py     numpy core: direction matching, Kabsch, cell
 │                    parametrization per crystal system, BuildPlan
+├── symmetry.py      blueprint space-group operations recovered from
+│                    the slot-centre set; orbit-constrained slot
+│                    displacements for embedding relaxation
 ├── fragment.py      Fragment: Molecule + dummies, compatibility,
 │                    rotate / flip / functionalize
 ├── topology.py      Topology: lattice + slots + orbit grouping
@@ -192,6 +195,8 @@ flowchart TD
     alignment --> fragment
     alignment --> topology
     alignment --> plane_groups
+    alignment -. "lazy, relax_embedding only" .-> symmetry
+    symmetry --> topology
     topology --> fragment
     topology_io --> topology
     framework --> utils

--- a/docs/rods.md
+++ b/docs/rods.md
@@ -391,7 +391,16 @@ Nets whose laterals are symmetry-pinned (`etb`, whose free orbits are all run
 slots) build identically with the flag on. Where the laterals do carry freedom
 — `etb-e` has three parameters, exactly where MOF-74's node-to-linker
 proportion was measured wrong — a linker whose span does not suit the
-idealized separation closes markedly better. Off by default.
+idealized separation closes markedly better: stretching a ditopic linker 25%
+past what the idealized separation wants takes the worst bond deviation from
+0.0149 Å to 0.0037 Å, a 4× improvement. Off by default.
+
+Note one difference from the [finite pipeline](building.md#embedding-relaxation):
+the rod objective gains **no anchor-direction terms** and needs no closure
+guard. It is simply better conditioned — the rods are symmetry-pinned anchors
+at both ends of every lateral, so a linker between them is fixed by closure
+alone, whereas a freed finite net is generically floppy and needs the
+direction terms to choose among the many closures it admits.
 
 ### Verifying the built net
 

--- a/src/autografs/rod_build.py
+++ b/src/autografs/rod_build.py
@@ -802,11 +802,22 @@ class _RodBuild:
         # the LATERAL slots. The other candidates are all unusable, by
         # construction rather than by choice:
         #
-        # - a helical run's axis line is a screw axis of the net, i.e. a
-        #   symmetry element, and a rotation of order >= 2 fixes no
-        #   transverse vector (order 2 sends v -> -v). Axis lines are
-        #   pinned outright, so rod-to-rod spacing is set by the cell -
-        #   which ``scale`` already varies.
+        # - a helical run's axis line is generally a screw axis of the
+        #   net, i.e. a symmetry element, and a rotation of order >= 2
+        #   fixes no transverse vector (order 2 sends v -> -v), so the
+        #   line cannot move and rod-to-rod spacing is set by the cell -
+        #   which ``scale`` already varies. Measured directly rather
+        #   than assumed: expanding every symmetry-allowed displacement
+        #   mode and looking for a common transverse shift of a run's
+        #   node slots gives EXACTLY zero on all six nets with helical
+        #   runs that the rod path is validated on (etb, etb-e, unc,
+        #   bmn, twt; srs is pinned outright). Caveat worth keeping:
+        #   the same test flags ~1 in 5 of a wider library sample, and
+        #   it is not established whether those are real axis-line
+        #   freedoms or an artifact of the test - ``helical_runs``
+        #   fits a screw geometrically, and the fitted screw's rotation
+        #   part being in the group does not put the LINE on a symmetry
+        #   element. None of them is known to be buildable. See #210.
         # - a run node's freedom is transverse (the nodes sit off the
         #   axis), but that moves the *helix radius*, and a harvested
         #   rod is rigid: placement reads only the node's azimuth and


### PR DESCRIPTION
Part of #174 (its remaining docs item), plus one source **comment** correction that came out of verifying the docs.

The relaxation section promised a benefit it never quantified and implied a scope it does not have, and the closure gate added in #196 was undocumented. Both fixed, with the measurements.

### `docs/building.md`

- **`bond_tolerance` documented** alongside `max_rmsd` / `min_distance`, including why it is off by default: over a 120-net library sample of builds that pass `max_rmsd=0.5` **today**, the worst-bond deviation has median 0.43 Å and p90 1.14 Å, so any default value would silently change which builds the library produces. Also states plainly that the other two gates cannot see this failure mode.
- **`relax_embedding` gains the corpus table** (CoRE MOF, 35 non-pinned faithful rebuilds): density error 0.260 → 0.079, bond residual 0.091 → 0.112 Å, contact 0.84 → 0.97 Å. The 0.02 Å closure cost is stated rather than hidden — it is the trade the feature exists to make.
- **"Fully pinned nets have nothing to relax" no longer reads as the common case.** True, and it stays — but only **3 of 185** sampled library nets are fully pinned, and a low-symmetry net can carry tens of free parameters (largest seen: 52) against a Nelder-Mead optimizer. Both facts are now on the page, because a reader deciding whether to turn the flag on needs them.
- The **closure guard** and its 0.2 Å budget are described, including why the budget is deliberately not zero.

### `docs/rods.md`

The measured payoff (a 25%-stretched `etb-e` linker closing 4× better, 0.0149 → 0.0037 Å), and an explicit note that the rod objective carries **no** anchor-direction terms and needs no guard — it is better conditioned because the rods are symmetry-pinned anchors at both ends of every lateral. Without that, the asymmetry with the finite pipeline reads as an oversight.

### `README.md`

- The "physically meaningful cells" bullet now mentions relaxation for low-symmetry nets.
- The `AlignmentError` FAQ covers the closure failure mode.
- New FAQ entry for *"my built structure is too open / its density looks wrong"* — the question this feature exists to answer, which nothing in the docs answered.

### `docs/internals.md`

`symmetry.py` was missing from the module map and the dependency graph since #181.

### One source comment corrected

`rod_build` justified freeing only lateral slots partly by asserting that helical-run axis lines "are pinned outright". I verified it directly — expand every symmetry-allowed displacement mode, look for a common transverse shift of a run's node slots — and it holds **exactly** (`0.00e+00`) on all six nets the rod path is validated on (etb, etb-e, unc, bmn, twt; srs is pinned entirely).

But the same test flags **14 of 75** sampled library nets with a helical run, and I have not established whether those are genuine axis-line freedoms or an artifact of the test. None of them is known to be buildable, so nothing currently built is affected. The comment now states the verified scope and the caveat and points at **#210**; the claim is no longer stronger than the evidence.

### Verification

Every factual claim was re-checked against the code rather than against my notes: both constants, the signatures and their defaults, pcu/dia/fcu fully pinned, etb 0 / etb-e 3 lateral free parameters, pcu building identically under the flag, and the gate firing at `bond_tolerance=0.1` on tbo (0.22 Å worst bond) while passing at 0.5.

One probe failure worth recording as a non-bug: an initial check asserted the gate fires on pcu at `bond_tolerance=1e-9`. It does not — that build closes to **1.4e-10 Å**, genuinely below the threshold. The gate was right and the probe was wrong.

Docs and comments only; no behaviour change. Lint, format, mypy and the affected tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)