### PR TITLE
release: 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,11 +264,12 @@ generators. Architecture and module map: [How it works](docs/internals.md).
 
 The 3.x line has reached feature parity with 2.x and gone well beyond it: the
 inverse pipeline (deconstruction, net identification, SBU harvesting for MOFs
-and COFs), rod-MOF support in both directions (including helical rods), IZA
-zeolite import (`autografs-topologies --use_iza`), partial charges, ASE-driven
-relaxation, elastic constants, and commensurate twisted bilayers have all
-landed. Remaining directions — cross-linked multi-rod nets (`etb` itself),
-EPINET import, and curated high-connectivity SBU packs for the last uncovered
+and COFs), rod-MOF support in both directions (helical, cross-linked multi-rod
+`etb`/MOF-74, woven multi-axis and lattice-diagonal channels), IZA zeolite
+import (`autografs-topologies --use_iza`), partial charges, ASE-driven
+relaxation, elastic constants, commensurate twisted bilayers, and embedding
+relaxation for low-symmetry nets have all landed. Remaining directions —
+EPINET import and curated high-connectivity SBU packs for the last uncovered
 nets — are tracked in the [issue tracker](https://github.com/DCoupry/autografs/issues).
 
 ## Citing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "AuToGraFS"
-version = "3.1.0"
+version = "3.2.0"
 description = "Automatic Topological Generator for Framework Structures"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Version bump for the 3.2.0 release.

**136 commits since v3.1.0**, 13 new modules, ~7.9k added lines in `src/`. No public API removed and every signature change is additive, so 3.1.0 code keeps working — a minor bump under semver, not a major one.

### What's in it

- **Rod MOFs, forward and inverse** — canonical rod repeats, helical rods, cross-linked multi-rod nets (`etb`/MOF-74), woven multi-axis packings, lattice-diagonal channels, mixed rod/finite mappings
- **Inverse pipeline hardening** — assembly fingerprints, empty-slot builds (`tbo`-class edge-decorated nets), the matcher multi-start fix that unblocked UiO-66 on `fcu`
- **New science surfaces** — EQeq partial charges, ASE-calculator relaxation (GFN-FF / GFN1 / DFTB+), elastic constants, commensurate twisted bilayers
- **IZA zeolite import** via `autografs-topologies --use_iza`, license-gated and cached
- **Embedding relaxation** for low-symmetry nets, corpus-calibrated
- **A closure gate** (`bond_tolerance`) the finite pipeline never had

### Behaviour note

`match_directions` gained extra multi-start rotations (#178), which changes the default build path: arm sets whose own rotation group swallowed the cube starts now match correctly. This is a bug fix, and it means some builds produce different (better) geometry than under 3.1.0 — UiO-66's cuboctahedral node scored 0.363 against `fcu`'s identical slot and now scores 0. Worth knowing if you have pinned expected outputs.

`relax_embedding` and `bond_tolerance` are both **off by default**, so nothing else in the default path moves.

### Also here

The README roadmap still listed cross-linked multi-rod nets (`etb` itself) as a remaining direction; that landed in #167, along with woven multi-axis, diagonal channels and embedding relaxation. Corrected.

### Pre-tag verification

- wheel and sdist build; `twine check` passes on both
- wheel contents confirmed: all 13 new modules, `py.typed`, and every data file (`topologies.json.gz`, `iza_aliases.json`, `iza_codes.py`, `eqeq.py`, both SBU libraries)
- **clean-venv install of the wheel**: loads 2686 topologies and 930 SBUs, builds and `verify_net`s pcu, exercises `relax_embedding` + `bond_tolerance`, imports every new module, and runs both console entry points

`publish.yml` guards that the release tag matches this version, so the tag must be `v3.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)