### PR TITLE
perf: memoize blueprint symmetry derivation

### DIFF
--- a/src/autografs/symmetry.py
+++ b/src/autografs/symmetry.py
@@ -143,6 +143,42 @@ def _match_sites(
     return image
 
 
+# Derivation costs 0.2-0.4 s per net (more for a 152-slot blueprint
+# like tbo) and is pure in its geometric input, while callers re-derive
+# it once per *build attempt* - a corpus sweep trying several mappings
+# per net candidate over thousands of structures repeats the identical
+# work hundreds of times. Keyed on the rounded centre set, orbit labels
+# and cell rather than on the Topology object, so a mutated or rebuilt
+# blueprint cannot collide with a stale entry; a name would.
+_OPERATIONS_CACHE: dict[tuple, list[SymmetryOperation]] = {}
+_DISPLACEMENTS_CACHE: dict[tuple, OrbitDisplacements] = {}
+_CACHE_LIMIT = 512
+
+
+def _cache_key(topology: Topology) -> tuple:
+    centers, orbits = _slot_centers(topology)
+    matrix = np.asarray(topology.cell.matrix, dtype=float)
+    return (
+        np.round(centers, 6).tobytes(),
+        centers.shape,
+        tuple(orbits),
+        np.round(matrix, 6).tobytes(),
+    )
+
+
+def _cache_put(cache: dict, key: tuple, value):
+    if len(cache) >= _CACHE_LIMIT:
+        cache.clear()
+    cache[key] = value
+    return value
+
+
+def clear_symmetry_cache() -> None:
+    """Drop the memoized operations and displacements."""
+    _OPERATIONS_CACHE.clear()
+    _DISPLACEMENTS_CACHE.clear()
+
+
 def blueprint_operations(topology: Topology) -> list[SymmetryOperation]:
     """Space-group operations of a blueprint, from its own embedding.
 
@@ -163,6 +199,12 @@ def blueprint_operations(topology: Topology) -> list[SymmetryOperation]:
     list[SymmetryOperation]
         All operations found, identity first. Proper and improper.
     """
+    # NB: `key` is taken further down by the duplicate-operation guard
+    cache_key = _cache_key(topology)
+    cached = _OPERATIONS_CACHE.get(cache_key)
+    if cached is not None:
+        # a fresh list: the entries are immutable, the container is not
+        return list(cached)
     centers, orbits = _slot_centers(topology)
     if not len(centers):
         return []
@@ -203,7 +245,8 @@ def blueprint_operations(topology: Topology) -> list[SymmetryOperation]:
             op.translation,
         )
     )
-    return operations
+    _cache_put(_OPERATIONS_CACHE, cache_key, operations)
+    return list(operations)
 
 
 @dataclass(frozen=True)
@@ -313,8 +356,15 @@ def orbit_displacements(
     Returns
     -------
     OrbitDisplacements
+        Treat as read-only: when ``operations`` is omitted the result is
+        memoized and shared between callers.
     """
+    cache_key = None
     if operations is None:
+        cache_key = _cache_key(topology)
+        cached = _DISPLACEMENTS_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
         operations = blueprint_operations(topology)
     centers, orbits = _slot_centers(topology)
     n_slots = len(centers)
@@ -361,10 +411,13 @@ def orbit_displacements(
             if operation.slot_image[representative] == representative
         ]
         bases[orbit] = _fixed_subspace(stabilizer, matrix)
-    return OrbitDisplacements(
+    displacements = OrbitDisplacements(
         orbit_of_slot=tuple(orbits),
         representatives=representatives,
         bases=bases,
         # indexed by slot: every entry is set, checked above
         propagation=tuple(np.asarray(w) for w in propagation),
     )
+    if cache_key is not None:
+        _cache_put(_DISPLACEMENTS_CACHE, cache_key, displacements)
+    return displacements

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -8,7 +8,14 @@ from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Molecule
 
 from autografs.fragment import Fragment
-from autografs.symmetry import blueprint_operations, orbit_displacements
+from autografs.symmetry import (
+    _DISPLACEMENTS_CACHE,
+    _OPERATIONS_CACHE,
+    _cache_key,
+    blueprint_operations,
+    clear_symmetry_cache,
+    orbit_displacements,
+)
 from autografs.topology import Topology
 
 FIXTURE_PATH = os.path.join(
@@ -179,3 +186,69 @@ class TestOrbitDisplacements:
             cartesian = basis @ matrix
             gram = cartesian @ cartesian.T
             assert np.allclose(gram, np.eye(len(basis)), atol=1e-8)
+
+
+class TestMemoization:
+    """The derivation is memoized; the cache must be invisible."""
+
+    def test_repeat_calls_agree(self, mofgen):
+        """Warm results must equal cold ones, element for element."""
+        clear_symmetry_cache()
+        cold_ops = blueprint_operations(mofgen.topologies["pcu"])
+        cold = orbit_displacements(mofgen.topologies["pcu"])
+        warm_ops = blueprint_operations(mofgen.topologies["pcu"])
+        warm = orbit_displacements(mofgen.topologies["pcu"])
+        assert cold_ops == warm_ops
+        assert cold.orbit_of_slot == warm.orbit_of_slot
+        assert cold.n_free == warm.n_free
+        for orbit, basis in cold.bases.items():
+            assert np.array_equal(basis, warm.bases[orbit])
+
+    def test_entry_is_stored_under_the_content_key(self, mofgen):
+        """The store and the lookup must use the same key.
+
+        Regression: the cache key was once shadowed by the local `key`
+        of the duplicate-operation guard, so entries were stored under
+        the last operation's (rotation, translation) while lookups used
+        the content key - every call recomputed. Results stayed correct,
+        so no behavioural test can see it; only the key can.
+        """
+        clear_symmetry_cache()
+        topology = mofgen.topologies["pcu"]
+        blueprint_operations(topology)
+        assert _cache_key(topology) in _OPERATIONS_CACHE
+        orbit_displacements(topology)
+        assert _cache_key(topology) in _DISPLACEMENTS_CACHE
+
+    def test_distinct_blueprints_do_not_collide(self, mofgen):
+        """Different blueprints must keep their own answers.
+
+        Guards the keying itself: a key derived from something coarser
+        than the embedding - a net name, a slot count - would let two
+        blueprints read each other's operations. Interleave blueprints
+        of different symmetry, slot count and free dimension."""
+        blueprints = {
+            "pcu": mofgen.topologies["pcu"],
+            "p1": _p1_topology(),
+            "pillar": _pillar_topology(),
+        }
+        clear_symmetry_cache()
+        alone = {
+            name: orbit_displacements(topology).n_free
+            for name, topology in blueprints.items()
+        }
+        # the free dimensions must actually differ, or the assertion
+        # below would pass on a fully broken cache
+        assert len(set(alone.values())) == len(alone), alone
+        clear_symmetry_cache()
+        for name in ("pcu", "p1", "pillar", "pcu", "pillar", "p1"):
+            assert orbit_displacements(blueprints[name]).n_free == alone[name]
+
+    def test_returned_operation_list_is_not_shared(self, mofgen):
+        """Callers get their own container; mutating it must not
+        corrupt the next caller's answer."""
+        clear_symmetry_cache()
+        first = blueprint_operations(mofgen.topologies["pcu"])
+        expected = len(first)
+        first.clear()
+        assert len(blueprint_operations(mofgen.topologies["pcu"])) == expected


### PR DESCRIPTION
## What

`blueprint_operations` and `orbit_displacements` are pure in their geometric input but were re-derived on **every build attempt**. At 0.2–0.4 s per net (more for a 152-slot blueprint like `tbo`), a sweep that tries several mappings per net candidate over thousands of structures repeats the identical work hundreds of times.

Found while running the corpus round-trip for the update paper: the same 4764-structure sweep with `relax_embedding=True` ran **48× slower** than with it off, almost entirely here.

## How

Memoized on the rounded slot-centre set, orbit labels and cell — *not* on the `Topology` object or its name — so a mutated or rebuilt blueprint cannot pick up a stale entry. Bounded dict with an explicit `clear_symmetry_cache()`.

Measured, cold → warm, results identical in every field:

| net | n_free | cold | warm | speedup |
|---|---|---|---|---|
| tbo | 3 | 0.650 s | 0.0026 s | 252× |
| sra | 4 | 0.242 s | 0.0006 s | 428× |
| etb-e | 5 | 0.193 s | 0.0014 s | 135× |
| pcu | 0 | 0.238 s | 0.0002 s | 979× |
| dia | 0 | 0.203 s | 0.0005 s | 423× |

## A note on the guard

While writing this I shadowed the cache key with the local `key` that the duplicate-operation guard uses inside the rotation loop. Entries then landed under the last operation's `(rotation, translation)` while lookups used the content key — a silent no-op cache.

It cannot return a wrong answer, since the two key shapes never collide. That is precisely why **no behavioural test can detect it**: every result stays correct, only the speed is lost. I confirmed this by mutation — reintroducing the shadowing left the behavioural tests green.

So the regression guard is white-box: it asserts the entry is stored under the content key. Verified to fail with the bug reintroduced and pass without it.

## Tests

`TestMemoization`: warm results equal cold ones field by field; entries stored under the content key (the guard above); distinct blueprints do not collide; the returned operation list is a fresh container.

Full suite: 725 passed.