### PR TITLE
fix: filter rod net candidates on screw compatibility (#214)

### DIFF
--- a/docs/rods.md
+++ b/docs/rods.md
@@ -55,6 +55,35 @@ usually match on the *contracted* tier — check
 framework connections still raises `DeconstructionError` (it is not a
 framework), as do 2-periodic (layer) building units.
 
+### Candidates are filtered on screw compatibility
+
+The contracted tier compares **connectivity alone**. The rod's screw —
+the property deciding whether it can occupy a given channel — is
+discarded before the comparison, so on its own that match will propose
+blueprints the structure cannot realise. Measured over CoRE MOF 2014
+before this was fixed: of 21 structures assigned `etb`, whose channels
+are 3₁ helices, **17 had no three-fold axis in their space group at
+all**, one of them P1.
+
+`deconstruct` therefore drops candidates no harvested rod can occupy,
+using the same run-matching `build_rod` applies:
+
+```python
+from autografs.rod_build import rod_fits_topology
+
+rod_fits_topology(mofgen.topologies["etb"], screw_order=1, screw_angle=0.0)
+# False - etb's channels are helical; a screwless rod cannot fill one
+rod_fits_topology(mofgen.topologies["etb"], screw_order=3, screw_angle=120.0)
+# True
+```
+
+The filter is conservative: a rod whose canonical form cannot be derived
+vetoes nothing, and a candidate survives if *any* of the structure's rods
+fits it. If every candidate is incompatible, the structure is reported
+unidentified rather than assigned an impossible net — so a rod MOF that
+used to come back with a confident wrong answer may now come back with
+none. That is the intended change.
+
 ## Canonical rod identity (screw-aware)
 
 A rod's identity is its *chemical* repeat, modulo everything the crystal

--- a/src/autografs/deconstruct.py
+++ b/src/autografs/deconstruct.py
@@ -67,7 +67,7 @@ from pymatgen.analysis.graphs import StructureGraph
 from pymatgen.analysis.local_env import EconNN
 from pymatgen.core.structure import Molecule, Structure
 
-from autografs.exceptions import DeconstructionError
+from autografs.exceptions import AutografsError, DeconstructionError
 from autografs.fragment import Fragment
 
 # _canonical and _split_image are net's gauge conventions; the unit
@@ -944,6 +944,69 @@ def _unit_quotient(
     return edges
 
 
+def _rod_compatible_nets(
+    structure: Structure,
+    rods: list[RodUnit],
+    candidates: list[str],
+    topologies: Mapping[str, Topology],
+) -> list[str]:
+    """Drop candidate nets whose channels this structure's rods cannot fill.
+
+    A rod framework's quotient graph carries no blueprint edge centers,
+    so it matches on the contracted points-of-extension tier, which
+    compares **connectivity alone**. The rod's screw - the property that
+    decides whether it can occupy a channel - is discarded before the
+    comparison, and the identifier therefore proposes geometrically
+    impossible blueprints. Measured over CoRE MOF 2014 before this
+    filter: of 21 structures assigned ``etb``, whose channels are 3_1
+    helices, **17 had no three-fold axis in their space group**, one of
+    them P1. ``build_rod`` then correctly refused them; the assignment
+    was the error (#214).
+
+    Filtering is conservative. A rod whose canonical form cannot be
+    derived does not veto anything, and a candidate survives if *any*
+    harvested rod fits it: this removes impossible assignments without
+    inventing confidence about the rest.
+    """
+    if not candidates:
+        return candidates
+    from autografs.rod_build import rod_fits_topology
+    from autografs.rods import canonical_rod
+
+    screws: list[tuple[int, float]] = []
+    for rod in rods:
+        try:
+            repeat = canonical_rod(structure, rod)
+        except (AutografsError, ValueError, IndexError) as exc:
+            logger.debug(f"rod screw undetermined, not filtering nets: {exc}")
+            return candidates
+        screws.append((repeat.screw_order, repeat.screw_angle))
+
+    kept = []
+    for name in candidates:
+        topology = topologies[name]
+        try:
+            fits = any(
+                rod_fits_topology(topology, order, angle) for order, angle in screws
+            )
+        except (AutografsError, ValueError, IndexError) as exc:
+            logger.debug(f"run analysis failed on {name!r}, keeping it: {exc}")
+            fits = True
+        if fits:
+            kept.append(name)
+        else:
+            logger.info(
+                f"\t[x] dropping net {name!r}: no slot run can host a rod with "
+                f"screw order {screws[0][0]} ({screws[0][1]:.0f} deg)."
+            )
+    if not kept:
+        logger.info(
+            "\t[x] every candidate net was incompatible with the harvested "
+            "rod(s); reporting unidentified rather than an impossible net."
+        )
+    return kept
+
+
 def _identify_subframeworks(
     subframework_edges: list[Counter[Edge]],
     topologies: Mapping[str, Topology],
@@ -1165,6 +1228,10 @@ def deconstruct(
             ],
             topologies,
         )
+        if rods:
+            net_candidates = _rod_compatible_nets(
+                structure, rods, net_candidates, topologies
+            )
 
     return Deconstruction(
         structure=structure,

--- a/src/autografs/rod_build.py
+++ b/src/autografs/rod_build.py
@@ -1501,6 +1501,44 @@ def _select_runs(
     return [runs[0]]
 
 
+def rod_fits_topology(topology: Topology, screw_order: int, screw_angle: float) -> bool:
+    """Can a rod with this screw occupy any slot run of this blueprint?
+
+    The compatibility test ``_select_runs`` applies, exposed so that
+    *identification* can apply it too. A rod framework's quotient graph
+    carries no blueprint edge centers, so it matches on the contracted
+    points-of-extension tier - which compares connectivity alone and
+    discards the screw. Without this check the identifier proposes nets
+    whose channels the rod cannot occupy: measured over CoRE MOF, 17 of
+    21 structures assigned ``etb`` (3_1 helical channels) have no
+    three-fold axis in their space group at all, one of them P1 (#214).
+
+    Returns True when at least one run could host the rod. It is a
+    necessary condition, not a sufficient one - closure and contact
+    still gate the build.
+    """
+    if screw_order > 1:
+        for candidate in helical_runs(topology):
+            if candidate.screw_order != screw_order:
+                continue
+            if abs(abs(candidate.screw_angle) - abs(screw_angle)) <= 5.0:
+                return True
+        # a 2_1 screw still builds on a straight run: a ditopic linker's
+        # arm sign-flip is a no-op there. Higher orders cannot.
+        if screw_order != 2:
+            return False
+    runs = axial_runs(topology)
+    if not runs:
+        return False
+    for straight in runs:
+        nodes = _run_nodes(topology, straight)
+        if len(nodes.slots) == 1 or (nodes.even and _screw_fits(nodes, screw_angle)):
+            return True
+    # a multi-node run whose turn this rod does not match; _select_runs
+    # would fall back to it and the closure gate would reject the build
+    return False
+
+
 def _slot_adjacency(topology: Topology) -> dict[int, list[int]]:
     """Neighbour slot per half-edge, so len(adjacency[s]) is s's degree.
 

--- a/tests/test_rods.py
+++ b/tests/test_rods.py
@@ -2399,3 +2399,50 @@ class TestSingleUnitContact:
         placed = build.evaluate(*build.unpack(build.initial_guess()))
         assert placed["placements"]
         assert math.isfinite(build.min_inter_unit_contact(placed))
+
+
+class TestRodNetCompatibility:
+    """#214: identification must not offer nets a rod cannot occupy.
+
+    A rod framework's quotient graph carries no blueprint edge centers,
+    so it matches on the contracted points-of-extension tier, which
+    compares connectivity alone. The rod's screw - the property that
+    decides whether it fits a channel - is discarded before the
+    comparison. Over CoRE MOF that put 17 of 21 structures assigned
+    ``etb`` (3_1 channels) in space groups with no three-fold axis, one
+    of them P1.
+    """
+
+    def test_straight_rod_is_refused_by_a_helical_net(self, bundled_topologies):
+        """etb's channels are 3_1 helices; a screwless rod cannot fill
+        one, and this is the check identification was missing."""
+        from autografs.rod_build import rod_fits_topology
+
+        etb = bundled_topologies["etb"]
+        assert not rod_fits_topology(etb, screw_order=1, screw_angle=0.0)
+
+    def test_matching_helical_rod_is_accepted(self, bundled_topologies):
+        """The same net accepts the 3_1 rod it was built for."""
+        from autografs.rod_build import rod_fits_topology
+
+        etb = bundled_topologies["etb"]
+        assert rod_fits_topology(etb, screw_order=3, screw_angle=120.0)
+        # handedness is per rod, so the mirror-image screw fits too
+        assert rod_fits_topology(etb, screw_order=3, screw_angle=-120.0)
+
+    def test_wrong_screw_order_is_refused(self, bundled_topologies):
+        """A 4_1 rod does not fit a 3_1 channel."""
+        from autografs.rod_build import rod_fits_topology
+
+        assert not rod_fits_topology(
+            bundled_topologies["etb"], screw_order=4, screw_angle=90.0
+        )
+
+    def test_straight_rod_accepted_by_a_straight_net(self, bundled_topologies):
+        """The filter must not reject what does fit: pcu carries
+        straight axial runs and hosts a screwless rod."""
+        from autografs.rod_build import rod_fits_topology
+
+        assert rod_fits_topology(
+            bundled_topologies["pcu"], screw_order=1, screw_angle=0.0
+        )


### PR DESCRIPTION
Fixes #214.

## The bug

`identify_net` matches a rod framework on the **contracted points-of-extension tier**, which compares connectivity alone. The rod's screw — the property that decides whether it can occupy a channel — is discarded before the comparison, so identification proposed blueprints the structure cannot realise under any embedding.

Measured over CoRE MOF 2014: of 21 structures assigned `etb`, whose channels are 3₁ helices, **17 have no three-fold axis in their space group**.

| structure | space group | 3-fold? | screw read | assigned |
|---|---|---|---|---|
| CAXVOO | R-3 (#148) | yes | 3 (120°) | `etb-e` ✅ |
| LALYOO | R3c (#161) | yes | 3 (120°) | `etb` ✅ |
| ADAXEK | C2/m (#12) | **no** | 1 | `etb` ❌ |
| FEYQIK | P-1 (#2) | **no** | 1 | `etb` ❌ |
| ICOWON | P-1 (#2) | **no** | 1 | `etb` ❌ |
| NETHOJ | **P1 (#1)** | **no** | 1 | `etb` ❌ |

A P1 crystal cannot realise a net requiring a 3₁ screw.

## What it is not

My first diagnosis was a screw-detection failure. That is **wrong**, and worth recording so nobody re-opens it:

- detection is insensitive to `ROD_MATCH_TOLERANCE` across 0.3 → 1.2;
- the space groups confirm the order-1 readings are **correct** — the two `etb`-assigned structures that *are* rhombohedral are exactly the two read as order 3.

`canonical_rod` is right. `build_rod` was right too — its refusal (`'etb' has no straight axial slot run`) was the correct response to a screwless rod on a helical net. **The identifier was at fault.**

## The fix

`deconstruct` drops candidates no harvested rod can occupy, reusing `build_rod`'s own run matching through a new public predicate `rod_build.rod_fits_topology`.

After the fix, the four impossible assignments report no net; CAXVOO and LALYOO keep theirs.

Conservative by design: an underivable rod screw vetoes nothing, and a candidate survives if *any* of the structure's rods fits it. It removes impossible assignments without inventing confidence about the rest.

## Behaviour change

A rod MOF that used to come back with a confident wrong net may now come back **unidentified**. That is the intended change. Any net-ID accuracy figure computed over rod structures before this commit was inflated by these assignments.

## Tests

`TestRodNetCompatibility`: a straight rod is refused by `etb`, a matching 3₁ rod (either hand) is accepted, a 4₁ rod is refused, and — the direction that matters for false positives — a straight rod is still accepted by `pcu`.

Full suite: 735 passed.

Docs: `docs/rods.md` gains a "Candidates are filtered on screw compatibility" subsection; `CLAUDE.md` records the mechanism and the measurement.