### PR TITLE
refactor: one corpus resolver for every benchmark driver, plus rodtrip

### DIFF
--- a/scripts/benchmarks/_corpus.py
+++ b/scripts/benchmarks/_corpus.py
@@ -1,0 +1,41 @@
+"""Corpus resolution shared by every benchmark driver.
+
+This exists because the same ``_collect`` was copied into three drivers
+and then had to be fixed three times. Manifest support was added to
+``roundtrip.py``, then to ``embedding.py``, and ``rodtrip.py`` silently
+processed one structure and reported a single deconstruction failure --
+which reads like a corpus problem rather than a driver one. One
+implementation, imported everywhere.
+
+A corpus spec may be:
+
+- a directory                -> its ``*.cif`` files, sorted
+- a glob                     -> matching files, sorted
+- a ``.txt`` manifest        -> one CIF path per line
+- a single CIF               -> itself
+
+The manifest form is not a convenience. CoRE MOF 2025 ships several
+solvent-removal variants of most materials, so the analysable unit has
+to be chosen upstream and handed to the driver as an explicit list;
+globbing a directory would count most materials twice.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def collect(spec: str) -> list[Path]:
+    """Resolve a corpus spec to a sorted list of structure paths."""
+    path = Path(spec)
+    if path.is_dir():
+        return sorted(path.glob("*.cif"))
+    if path.suffix.lower() == ".txt" and path.exists():
+        return sorted(
+            Path(line.strip())
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        )
+    if any(char in spec for char in "*?["):
+        return sorted(Path(spec).parent.glob(path.name))
+    return [path]

--- a/scripts/benchmarks/embedding.py
+++ b/scripts/benchmarks/embedding.py
@@ -65,6 +65,7 @@ from collections import Counter
 from pathlib import Path
 
 import numpy as np
+from _corpus import collect as _collect
 from _mapping_order import graded_indices, n_combinations
 
 from autografs import Autografs
@@ -596,16 +597,6 @@ def run(
         "summary": _summarize(records),
         "structures": records,
     }
-
-
-def _collect(spec: str) -> list[Path]:
-    path = Path(spec)
-    if path.is_dir():
-        return sorted(path.glob("*.cif"))
-    if any(char in spec for char in "*?["):
-        base = Path(spec).parent
-        return sorted(base.glob(Path(spec).name))
-    return [path]
 
 
 def main() -> None:

--- a/scripts/benchmarks/netid.py
+++ b/scripts/benchmarks/netid.py
@@ -26,6 +26,8 @@ import time
 from collections import Counter
 from pathlib import Path
 
+from _corpus import collect as _collect
+
 from autografs import Autografs
 from autografs.exceptions import AutografsError
 
@@ -84,20 +86,19 @@ def run(corpus: list[Path], mofgen: Autografs, labels: dict) -> dict:
     }
 
 
-def _collect(spec: str) -> list[Path]:
-    path = Path(spec)
-    if path.is_dir():
-        return sorted(path.glob("*.cif"))
-    if any(char in spec for char in "*?["):
-        return sorted(Path(spec).parent.glob(Path(spec).name))
-    return [path]
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("corpus", help="directory, glob, or single CIF")
     parser.add_argument("--labels", required=True, help="JSON name -> net(s)")
     parser.add_argument("-o", "--output", default="netid.json")
+    parser.add_argument(
+        "--labelled-only",
+        action="store_true",
+        help="skip structures with no reference label instead of "
+        "deconstructing them to report 'unlabelled' - a reference set "
+        "usually covers a fraction of a corpus, and the rest is work "
+        "whose result the benchmark discards",
+    )
     parser.add_argument("--topofile", default=None, help="topology library override")
     args = parser.parse_args()
 
@@ -105,6 +106,11 @@ def main() -> None:
     if not corpus:
         raise SystemExit(f"no structures matched {args.corpus!r}")
     labels = json.loads(Path(args.labels).read_text(encoding="utf-8"))
+    if args.labelled_only:
+        corpus = [path for path in corpus if path.name in labels]
+        if not corpus:
+            raise SystemExit("no structure in the corpus carries a label")
+        print(f"  {len(corpus)} labelled structures of {len(labels)} labels")
     mofgen = Autografs(topofile=args.topofile)
     payload = run(corpus, mofgen, labels)
     Path(args.output).write_text(json.dumps(payload, indent=1, default=str))

--- a/scripts/benchmarks/rodtrip.py
+++ b/scripts/benchmarks/rodtrip.py
@@ -1,0 +1,287 @@
+"""Rod round-trip driver: deconstruct -> rebuild on the rod path -> verify.
+
+The finite round-trip driver (``roundtrip.py``) reports any structure
+containing a 1-periodic building unit as ``rod`` and stops, because a rod
+cannot be placed by the slot-type mappings it enumerates. That leaves the
+rod claim resting on library nets and synthetic fixtures. This driver
+closes the gap: for every structure whose deconstruction yields at least
+one rod, it harvests the rod, chooses lateral SBUs from the same
+structure's finite fragments, and attempts ``build_rod`` on each
+identified net, gated by exact net verification.
+
+Outcomes, most informative first:
+
+- ``closed``          built on the rod path and passed verify_net
+- ``verify_failed``   built, but the realised quotient graph is not the
+                      blueprint's - a different net, which is exactly
+                      what the gate exists to catch
+- ``build_failed``    every net/linker combination was gated (closure,
+                      contact or alignment)
+- ``no_run``          the identified net carries no axial or helical slot
+                      run a rod can occupy
+- ``no_net``          rods present but no library net matched, so there
+                      is no blueprint to build on. This is the dominant
+                      bucket and it is a *identification* limit, not a
+                      building one
+- ``no_rod``          no 1-periodic unit after all (the input list is a
+                      prefilter, so this should be rare)
+- ``deconstruction_failed`` / ``driver_error``
+
+Deterministic, resumable, and parallel in the same way as roundtrip.py.
+
+Usage:
+    python scripts/benchmarks/rodtrip.py corpus_dir -o rodtrip.json
+    python scripts/benchmarks/rodtrip.py corpus_dir --only rods.txt --n-jobs 12
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from collections import Counter
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+from _corpus import collect as _collect
+
+from autografs import Autografs
+from autografs.exceptions import AutografsError
+from autografs.net import axial_runs, helical_runs
+from autografs.rods import rod_fragment
+
+# lateral SBU combinations tried per net before giving up
+MAX_LINKERS_PER_NET = 4
+
+
+def _lateral_candidates(result) -> list:
+    """Finite fragments that could sit on the blueprint's lateral slots.
+
+    Ordered by descending connectivity: a polytopic unit is a more
+    informative first guess than a ditopic one, and the budget is small.
+    """
+    fragments = [
+        fragment
+        for fragment in result.fragments.values()
+        if len(fragment.atoms.indices_from_symbol("X")) >= 2
+    ]
+    return sorted(
+        fragments,
+        key=lambda f: -len(f.atoms.indices_from_symbol("X")),
+    )[:MAX_LINKERS_PER_NET]
+
+
+def rodtrip_one(mofgen: Autografs, source, max_rmsd: float) -> dict:
+    """Deconstruct one structure and attempt the verified rod rebuild."""
+    record: dict = {"outcome": None, "net": None, "error": None}
+    t0 = time.perf_counter()
+    try:
+        result = mofgen.deconstruct(source)
+    except (AutografsError, ValueError, KeyError, IndexError) as exc:
+        record["outcome"] = "deconstruction_failed"
+        record["error"] = f"{type(exc).__name__}: {exc}"
+        record["seconds"] = time.perf_counter() - t0
+        return record
+
+    record["n_rods"] = len(result.rod_units)
+    record["n_fragments"] = len(result.fragments)
+    record["net"] = result.net_candidates or None
+    if not result.rod_units:
+        record["outcome"] = "no_rod"
+        record["seconds"] = time.perf_counter() - t0
+        return record
+    if not result.net_candidates:
+        record["outcome"] = "no_net"
+        record["seconds"] = time.perf_counter() - t0
+        return record
+
+    try:
+        rod = rod_fragment(result.structure, result.rod_units[0])
+        record["screw_order"] = rod.repeat.screw_order
+        record["repeat"] = round(float(rod.repeat.repeat_length), 4)
+        record["screw_angle"] = round(float(rod.repeat.screw_angle), 3)
+    except (AutografsError, ValueError, IndexError) as exc:
+        record["outcome"] = "build_failed"
+        record["error"] = f"rod_fragment: {type(exc).__name__}: {exc}"
+        record["seconds"] = time.perf_counter() - t0
+        return record
+
+    laterals = _lateral_candidates(result)
+    saw_run = False
+    saw_build = False
+    for net in result.net_candidates:
+        topology = mofgen.topologies[net]
+        try:
+            runs = list(axial_runs(topology)) + list(helical_runs(topology))
+        except (AutografsError, ValueError):
+            runs = []
+        if not runs:
+            continue
+        saw_run = True
+        for linker in laterals or [None]:
+            try:
+                framework = mofgen.build_rod(
+                    topology,
+                    rod,
+                    linkers=linker,
+                    max_rmsd=max_rmsd,
+                    verify_net=True,
+                )
+            except AutografsError as exc:
+                record["error"] = f"{type(exc).__name__}: {exc}"
+                continue
+            except Exception as exc:  # noqa: BLE001 - a build bug is data
+                record["error"] = f"{type(exc).__name__}: {exc}"
+                continue
+            saw_build = True
+            record["outcome"] = "closed"
+            record["rebuilt_net"] = net
+            record["min_contact"] = framework.min_contact()
+            record["formula"] = framework.structure.composition.reduced_formula
+            record["experimental_formula"] = (
+                result.structure.composition.reduced_formula
+            )
+            record["seconds"] = time.perf_counter() - t0
+            return record
+
+    if saw_build:
+        record["outcome"] = "verify_failed"
+    elif saw_run:
+        record["outcome"] = "build_failed"
+    else:
+        record["outcome"] = "no_run"
+    record["seconds"] = time.perf_counter() - t0
+    return record
+
+
+_WORKER: dict = {}
+
+
+def _init_worker(topofile: str | None, max_rmsd: float) -> None:
+    _WORKER["mofgen"] = Autografs(topofile=topofile)
+    _WORKER["max_rmsd"] = max_rmsd
+
+
+def _run_worker(path: str) -> tuple[str, dict]:
+    name = Path(path).name
+    try:
+        record = rodtrip_one(_WORKER["mofgen"], path, _WORKER["max_rmsd"])
+    except Exception as exc:  # noqa: BLE001 - never lose a sweep to one CIF
+        record = {"outcome": "driver_error", "error": f"{type(exc).__name__}: {exc}"}
+    return name, record
+
+
+def _load_checkpoint(path: Path) -> dict:
+    records: dict = {}
+    if not path.exists():
+        return records
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        records[entry["name"]] = entry["record"]
+    return records
+
+
+def run(
+    corpus: list[Path],
+    max_rmsd: float = 0.35,
+    topofile: str | None = None,
+    n_jobs: int = 1,
+    checkpoint: Path | None = None,
+) -> dict:
+    records = _load_checkpoint(checkpoint) if checkpoint is not None else {}
+    if records:
+        print(f"  resuming: {len(records)} done")
+    pending = [p for p in sorted(corpus) if p.name not in records]
+    handle = checkpoint.open("a", encoding="utf-8") if checkpoint else None
+    try:
+        if n_jobs > 1 and pending:
+            executor = ProcessPoolExecutor(
+                max_workers=n_jobs,
+                initializer=_init_worker,
+                initargs=(topofile, max_rmsd),
+            )
+            with executor:
+                stream = executor.map(
+                    _run_worker, [str(p) for p in pending], chunksize=1
+                )
+                for index, (name, record) in enumerate(stream, 1):
+                    records[name] = record
+                    _report(index, len(pending), name, record, handle)
+        elif pending:
+            _init_worker(topofile, max_rmsd)
+            for index, path in enumerate(pending, 1):
+                name, record = _run_worker(str(path))
+                records[name] = record
+                _report(index, len(pending), name, record, handle)
+    finally:
+        if handle is not None:
+            handle.close()
+    outcomes = Counter(r["outcome"] for r in records.values())
+    return {
+        "benchmark": "rodtrip",
+        "max_rmsd": max_rmsd,
+        "n_structures": len(records),
+        "outcomes": dict(sorted(outcomes.items())),
+        "structures": dict(sorted(records.items())),
+    }
+
+
+def _report(index: int, total: int, name: str, record: dict, handle) -> None:
+    print(f"  [{index}/{total}] {name:<44} {record['outcome']}", flush=True)
+    if handle is not None:
+        handle.write(json.dumps({"name": name, "record": record}) + "\n")
+        handle.flush()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("corpus", help="directory, glob, or single CIF")
+    parser.add_argument("-o", "--output", default="rodtrip.json")
+    parser.add_argument(
+        "--only",
+        default=None,
+        help="text file of filenames to restrict to (one per line); "
+        "use a prior rod scan so the sweep does not re-deconstruct "
+        "structures already known to be rod-free",
+    )
+    parser.add_argument("--max-rmsd", type=float, default=0.35)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--n-jobs", type=int, default=1)
+    parser.add_argument("--checkpoint", default=None)
+    parser.add_argument("--topofile", default=None)
+    args = parser.parse_args()
+
+    corpus = _collect(args.corpus)
+    if args.only:
+        wanted = {
+            line.strip()
+            for line in Path(args.only).read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        }
+        corpus = [p for p in corpus if p.name in wanted]
+    if args.limit is not None:
+        corpus = corpus[: args.limit]
+    if not corpus:
+        raise SystemExit(f"no structures matched {args.corpus!r}")
+    n_jobs = os.cpu_count() or 1 if args.n_jobs == -1 else args.n_jobs
+    payload = run(
+        corpus,
+        max_rmsd=args.max_rmsd,
+        topofile=args.topofile,
+        n_jobs=n_jobs,
+        checkpoint=Path(args.checkpoint) if args.checkpoint else None,
+    )
+    Path(args.output).write_text(json.dumps(payload, indent=1, default=str))
+    print(f"\n{payload['n_structures']} structures -> {args.output}")
+    for outcome, count in payload["outcomes"].items():
+        print(f"  {outcome:<24} {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/roundtrip.py
+++ b/scripts/benchmarks/roundtrip.py
@@ -46,11 +46,20 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import time
 from collections import Counter
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
+from _corpus import collect as _collect
 from _mapping_order import graded_indices, n_combinations
+
+# sibling driver: the same inter-unit bond measurement, so the two
+# benchmarks report the identical quantity. Imported at module level
+# like _mapping_order - callers put this directory on sys.path only
+# for the import, so a deferred import would not find it.
+from embedding import bond_residuals
 from pymatgen.core.composition import Composition
 
 from autografs import Autografs
@@ -129,7 +138,34 @@ def uncapped_composition(result) -> tuple[str | None, str | None]:
     return Composition(kept).reduced_formula, caps.reduced_formula
 
 
-def roundtrip_one(mofgen: Autografs, source, max_rmsd: float) -> dict:
+def _geometry(framework, result) -> dict:
+    """Packing and closure of a rebuild, against the experimental cell.
+
+    ``volume_ratio`` is per-atom and divided by the interpenetration
+    fold, so it is invariant to supercell choice and compares a single
+    net against a catenated crystal. It is the quantity the embedding
+    relaxation of #174 moves; ``bond_residual`` is what that movement
+    costs. Reported together because the trade between them is the
+    whole point - either one alone is misleading.
+    """
+    built = framework.structure
+    experimental = result.structure
+    fold = result.n_periodic_components
+    return {
+        "volume_ratio": (built.volume / len(built))
+        / (experimental.volume / len(experimental) * fold),
+        "min_contact": framework.min_contact(),
+        "bond_residual": bond_residuals(framework),
+        "empty_slots": sorted(framework.graph.graph.get("empty_slots", ())),
+    }
+
+
+def roundtrip_one(
+    mofgen: Autografs,
+    source,
+    max_rmsd: float,
+    relax_embedding: bool = False,
+) -> dict:
     """Deconstruct one structure and attempt the verified rebuild."""
     record: dict = {"outcome": None, "net": None, "tier": None, "error": None}
     t0 = time.perf_counter()
@@ -174,6 +210,7 @@ def roundtrip_one(mofgen: Autografs, source, max_rmsd: float) -> dict:
                     mappings=mappings,
                     max_rmsd=max_rmsd,
                     verify_net=True,
+                    relax_embedding=relax_embedding,
                 )
             except AutografsError:
                 continue
@@ -184,6 +221,7 @@ def roundtrip_one(mofgen: Autografs, source, max_rmsd: float) -> dict:
             if built_formula == experimental_formula:
                 record["outcome"] = "closed"
                 record["rebuilt_net"] = net
+                record.update(_geometry(framework, result))
                 record["seconds"] = time.perf_counter() - t0
                 return record
             if uncapped_formula is not None and built_formula == uncapped_formula:
@@ -205,31 +243,128 @@ def roundtrip_one(mofgen: Autografs, source, max_rmsd: float) -> dict:
     return record
 
 
-def run(corpus: list[Path], mofgen: Autografs, max_rmsd: float) -> dict:
-    """Round-trip every structure; returns the results payload."""
-    records = {}
-    for path in sorted(corpus):
-        records[path.name] = roundtrip_one(mofgen, str(path), max_rmsd)
-        outcome = records[path.name]["outcome"]
-        print(f"  {path.name:<40} {outcome}")
+# one Autografs per worker process: the topology library costs seconds
+# to load and is read-only during a run, so it is built once in the
+# initializer rather than per structure
+_WORKER: dict = {}
+
+
+def _init_worker(topofile: str | None, max_rmsd: float, relax: bool) -> None:
+    _WORKER["mofgen"] = Autografs(topofile=topofile)
+    _WORKER["max_rmsd"] = max_rmsd
+    _WORKER["relax"] = relax
+
+
+def _run_worker(path: str) -> tuple[str, dict]:
+    """Round-trip one structure in a worker; never raises.
+
+    A corpus-scale sweep must not lose 4000 results to one pathological
+    CIF, and an unexpected exception is itself data - it becomes a
+    ``driver_error`` outcome rather than a traceback that kills the run.
+    """
+    name = Path(path).name
+    try:
+        record = roundtrip_one(
+            _WORKER["mofgen"], path, _WORKER["max_rmsd"], _WORKER["relax"]
+        )
+    except Exception as exc:  # noqa: BLE001 - deliberate: see docstring
+        record = {
+            "outcome": "driver_error",
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    return name, record
+
+
+def _load_checkpoint(path: Path) -> dict:
+    """Read a JSONL checkpoint into ``{name: record}``.
+
+    Truncated trailing lines (a killed run mid-write) are dropped
+    rather than fatal.
+    """
+    records: dict = {}
+    if not path.exists():
+        return records
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            records[entry["name"]] = entry["record"]
+    return records
+
+
+def run(
+    corpus: list[Path],
+    mofgen: Autografs | None = None,
+    max_rmsd: float = 0.5,
+    *,
+    relax_embedding: bool = False,
+    topofile: str | None = None,
+    n_jobs: int = 1,
+    checkpoint: Path | None = None,
+) -> dict:
+    """Round-trip every structure; returns the results payload.
+
+    Deterministic in sorted corpus order regardless of ``n_jobs`` - the
+    results are keyed by structure name, so worker completion order
+    does not reach the output.
+
+    ``mofgen`` is used only by the serial path; workers build their own
+    (an Autografs does not survive pickling to a spawned process, and
+    the library load is why they are built in an initializer rather
+    than per structure).
+    """
+    records = _load_checkpoint(checkpoint) if checkpoint is not None else {}
+    if records:
+        print(f"  resuming: {len(records)} structures already done")
+    pending = [path for path in sorted(corpus) if path.name not in records]
+    handle = checkpoint.open("a", encoding="utf-8") if checkpoint is not None else None
+    try:
+        if n_jobs > 1 and pending:
+            executor = ProcessPoolExecutor(
+                max_workers=n_jobs,
+                initializer=_init_worker,
+                initargs=(topofile, max_rmsd, relax_embedding),
+            )
+            with executor:
+                stream = executor.map(
+                    _run_worker, [str(path) for path in pending], chunksize=1
+                )
+                for index, (name, record) in enumerate(stream, 1):
+                    records[name] = record
+                    _report(index, len(pending), name, record, handle)
+        elif pending:
+            if mofgen is None:
+                _init_worker(topofile, max_rmsd, relax_embedding)
+            else:
+                _WORKER.update(mofgen=mofgen, max_rmsd=max_rmsd, relax=relax_embedding)
+            for index, path in enumerate(pending, 1):
+                name, record = _run_worker(str(path))
+                records[name] = record
+                _report(index, len(pending), name, record, handle)
+    finally:
+        if handle is not None:
+            handle.close()
     outcomes = Counter(record["outcome"] for record in records.values())
     return {
         "benchmark": "roundtrip",
         "max_rmsd": max_rmsd,
+        "relax_embedding": relax_embedding,
         "n_structures": len(records),
         "outcomes": dict(sorted(outcomes.items())),
-        "structures": records,
+        "structures": dict(sorted(records.items())),
     }
 
 
-def _collect(spec: str) -> list[Path]:
-    path = Path(spec)
-    if path.is_dir():
-        return sorted(path.glob("*.cif"))
-    if any(char in spec for char in "*?["):
-        base = Path(spec).parent
-        return sorted(base.glob(Path(spec).name))
-    return [path]
+def _report(index: int, total: int, name: str, record: dict, handle) -> None:
+    print(f"  [{index}/{total}] {name:<40} {record['outcome']}", flush=True)
+    if handle is not None:
+        handle.write(json.dumps({"name": name, "record": record}) + "\n")
+        handle.flush()
 
 
 def main() -> None:
@@ -237,14 +372,43 @@ def main() -> None:
     parser.add_argument("corpus", help="directory, glob, or single CIF")
     parser.add_argument("-o", "--output", default="roundtrip.json")
     parser.add_argument("--max-rmsd", type=float, default=0.5)
+    parser.add_argument(
+        "--relax-embedding",
+        action="store_true",
+        help="rebuild with embedding relaxation (#174): symmetry-allowed "
+        "slot displacements + anchor-direction objective",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None, help="round-trip only the first N"
+    )
+    parser.add_argument(
+        "--n-jobs",
+        type=int,
+        default=1,
+        help="worker processes (default 1; -1 uses all cores)",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        default=None,
+        help="JSONL file of finished structures; resumes from it if present",
+    )
     parser.add_argument("--topofile", default=None, help="topology library override")
     args = parser.parse_args()
 
     corpus = _collect(args.corpus)
+    if args.limit is not None:
+        corpus = corpus[: args.limit]
     if not corpus:
         raise SystemExit(f"no structures matched {args.corpus!r}")
-    mofgen = Autografs(topofile=args.topofile)
-    payload = run(corpus, mofgen, args.max_rmsd)
+    n_jobs = os.cpu_count() or 1 if args.n_jobs == -1 else args.n_jobs
+    payload = run(
+        corpus,
+        max_rmsd=args.max_rmsd,
+        relax_embedding=args.relax_embedding,
+        topofile=args.topofile,
+        n_jobs=n_jobs,
+        checkpoint=Path(args.checkpoint) if args.checkpoint else None,
+    )
     Path(args.output).write_text(json.dumps(payload, indent=1, default=str))
     print(f"\n{payload['n_structures']} structures -> {args.output}")
     for outcome, count in payload["outcomes"].items():


### PR DESCRIPTION
Adds `scripts/benchmarks/rodtrip.py` — the rod round-trip driver used to find and measure #214 — and consolidates corpus resolution across the benchmark drivers.

## Why

Every driver had its own copy of `_collect`. Manifest support (a `.txt` of CIF paths, one per line) was added to `roundtrip.py`, then separately to `embedding.py`, and `rodtrip.py` was written from the old copy.

So a rod sweep over the CoRE MOF 2025 manifest **silently processed one structure** and reported a single deconstruction failure. That reads like a bad corpus rather than a broken driver, which is the worst way for this to fail.

Three copies, three separate fixes, one silent failure. Now one implementation in `_corpus.py`, imported by all five drivers.

## Why manifests exist at all

Not a convenience. CoRE MOF 2025 ships **9256 CIFs for 4886 distinct materials** — ASR and FSR solvent-removal variants of most entries. The analysable unit has to be chosen upstream and handed over as an explicit list; globbing the directory counts most materials twice and pseudo-replicates every statistic computed on it.

## rodtrip.py

Deconstruct → harvest the rod → choose lateral SBUs from the same structure → `build_rod` on each identified net → gate on exact net verification. Outcome taxonomy ordered by pipeline stage (`closed` / `verify_failed` / `build_failed` / `no_run` / `no_net` / `no_rod`), resumable and parallel like `roundtrip.py`.

This is what produced the #214 evidence: over 1077 rod-containing structures, `no_run` went 93 → 0 and structures reaching a build went 206 → 20 once the identification fix landed.

## Verified

4886 paths from the 2025 manifest, 4764 from the 2014 directory. `test_benchmarks.py` and `test_rods.py` pass.