### PR TITLE
Self-templated round trips, rod self-templates, and the production bugs they exposed

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -201,11 +201,23 @@ benefit, and nothing at build time distinguishes that case. Set
 lets the optimizer trade bond closure against the anchor-direction terms, and
 on a net whose SBU-versus-slot shape mismatch is large that trade can go badly.
 Every relaxed build is therefore scored against two references — closure alone
-over the same free parameters, and the fixed-slot solution the flag-off build
-would give — and the relaxed result is kept only if its worst bond stays within
-0.2 Å of the best of them. The budget is deliberately not zero: a modest
-closure cost bought with a large packing gain is exactly what the feature is
-for. If you need a hard closure guarantee, set `bond_tolerance` as well.
+over the same free parameters (started from the fixed-slot solution, which its
+feasible set contains, so it can only refine that solution), and the fixed-slot
+solution the flag-off build would give — and the relaxed result is kept only if
+its worst bond stays within 0.2 Å of the best of them. The budget is
+deliberately not zero: a modest closure cost bought with a large packing gain
+is exactly what the feature is for. If you need a hard closure guarantee, set
+`bond_tolerance` as well.
+
+Two interactions worth knowing. **Empty slots pin their displacements**: an
+orbit whose every slot is empty has no placement to move, so an edge-decorated
+net built with its 2-connected slots empty usually falls below
+`MIN_FREE_DISPLACEMENTS` and relaxation silently does not run — check the
+`relaxation` graph marker (`framework.graph.graph["relaxation"]`), which
+records the effective free-displacement count, which candidate the guard kept,
+and the per-candidate worst-bond scores. And the guard's decision is made at
+the pre-`finalize` arm assignment; the `verbose` bond report re-solves the
+assignment at the final cell, so the two can differ on hard structures.
 
 ## Batch enumeration
 

--- a/docs/deconstruction.md
+++ b/docs/deconstruction.md
@@ -75,6 +75,16 @@ centers, rod nets typically match on the contracted tier (check
 framework connections still raises `DeconstructionError`, as do
 2-periodic (layer) building units.
 
+One opt-in convention changes what a building unit is. Real crystals
+often join two nodes by a **pair of parallel identical linkers**; the
+net has one edge there, and identification counts it once, but the
+doubled node's fragment carries twice the arms and fits no slot of the
+identified net. `deconstruct(..., fuse_parallel_bridges=True)` fuses
+such a bundle into one composite unit with one connection per end —
+both molecules kept, so composition is exact; the merged end realizes
+a single bond in a rebuilt framework, as a documented convention. Off
+by default; `result.fused_bridges` counts the bundles when on.
+
 Two refinements to rod identification are worth knowing about. First,
 candidates are filtered for **rod compatibility**: a matched net whose
 every channel the harvested rod's screw cannot occupy is removed from

--- a/docs/deconstruction.md
+++ b/docs/deconstruction.md
@@ -75,6 +75,20 @@ centers, rod nets typically match on the contracted tier (check
 framework connections still raises `DeconstructionError`, as do
 2-periodic (layer) building units.
 
+Two refinements to rod identification are worth knowing about. First,
+candidates are filtered for **rod compatibility**: a matched net whose
+every channel the harvested rod's screw cannot occupy is removed from
+`net_candidates` (the buildable answer), but stays visible in
+`topological_candidates` (the quotient-graph answer) — the distinction
+between "matched but geometrically impossible for this rod" and
+"matched nothing". Second, when the per-atom PoE convention finds
+nothing rod-compatible, identification retries with a **grouped-PoE
+fallback**: cut endpoints of one rod at the same axial height merged
+into a single point of extension (a paddlewheel ring's four
+carboxylate carbons become one PoE, which is how O'Keeffe counts
+them); `result.poe_merged` records that the fallback answered. The
+fallback never moves a structure the primary convention answers.
+
 Rods get a canonical, screw-aware identity and a buildable form, and
 they can be **built forward again** — for straight and helical rods
 alike, including general (non-180°) screws such as MOF-74's. That is a

--- a/scripts/benchmarks/calibrate_direction_weight.py
+++ b/scripts/benchmarks/calibrate_direction_weight.py
@@ -1,0 +1,268 @@
+"""Calibrate DIRECTION_WEIGHT against the displacement-seeded optimizer.
+
+The shipped weight (0.5) was selected by the #207 sweep, whose optimizer
+explored the displacement block through a nearly degenerate initial
+simplex (scipy seeds exactly-zero coordinates with zdelt = 0.00025,
+four orders of magnitude below xatol), so the calibration never saw the
+relaxed objective's true optima. Seeding the main solve reaches them,
+and on shape-mismatched nets they are the #197 pathology (pts inflates
+its cell 2.9x at guard-passing closure) - so the seeded explorer needs
+its own weight, chosen the #207 way: on the population, never on one
+material.
+
+Protocol (per structure, first N of the corpus manifest):
+
+1. deconstruct once;
+2. lock a (net, mapping): the first candidate mapping whose FIXED-slot
+   build passes ``verify_net`` and reproduces the experimental reduced
+   formula - the faithful-rebuild criterion of #207, decided by a
+   weight-independent build so every arm rebuilds the same thing;
+3. rebuild that mapping once per arm: the unseeded shipped config as
+   baseline, and each swept weight with the main solve seeded;
+4. record packing (|volume_ratio - 1|), closure (worst bond), and which
+   candidate the guard kept, per arm.
+
+The pinned stratum (no effective displacement freedom) must come out
+byte-identical across arms; it is the measurement's internal check.
+
+Usage:
+    python scripts/benchmarks/calibrate_direction_weight.py \
+        research/paper/data/corpus-2025-files.txt --limit 600 \
+        -o calibration-seeded.json --n-jobs 10
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import traceback
+from collections import Counter
+from contextlib import contextmanager
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _corpus import collect as _collect  # noqa: E402
+from embedding import bond_residuals  # noqa: E402
+from roundtrip import candidate_mappings  # noqa: E402
+
+import autografs.alignment  # noqa: E402
+import autografs.builder  # noqa: E402
+from autografs import Autografs  # noqa: E402
+from autografs.exceptions import AutografsError  # noqa: E402
+
+# the #207 grid, extended one step DOWN: with a working explorer the
+# direction terms bite harder, so the optimum may sit below the old one
+WEIGHTS = (0.1, 0.25, 0.5, 1.0, 2.0)
+
+_WORKER: dict = {}
+
+
+@contextmanager
+def _arm(weight: float | None, seed_main: bool):
+    """Temporarily set the direction weight and main-solve seeding."""
+    saved_weight = autografs.alignment.DIRECTION_WEIGHT
+    saved_seed = autografs.builder.SEED_MAIN_SOLVE
+    if weight is not None:
+        autografs.alignment.DIRECTION_WEIGHT = weight
+    autografs.builder.SEED_MAIN_SOLVE = seed_main
+    try:
+        yield
+    finally:
+        autografs.alignment.DIRECTION_WEIGHT = saved_weight
+        autografs.builder.SEED_MAIN_SOLVE = saved_seed
+
+
+def _metrics(framework, result) -> dict:
+    built = framework.structure
+    experimental = result.structure
+    fold = result.n_periodic_components
+    marker = framework.graph.graph.get("relaxation") or {}
+    return {
+        "volume_ratio": (built.volume / len(built))
+        / (experimental.volume / len(experimental) * fold),
+        "worst_bond": (bond_residuals(framework) or {}).get("max"),
+        "n_slot_free": marker.get("n_slot_free"),
+        "kept": marker.get("kept"),
+    }
+
+
+def calibrate_one(mofgen: Autografs, path: Path, max_rmsd: float) -> dict:
+    record: dict = {"outcome": None, "seconds": 0.0}
+    start = time.perf_counter()
+    try:
+        result = mofgen.deconstruct(str(path))
+    except (AutografsError, ValueError, KeyError, IndexError) as exc:
+        record["outcome"] = "deconstruction_failed"
+        record["error"] = f"{type(exc).__name__}: {exc}"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    if result.rod_units or not result.net_candidates:
+        record["outcome"] = "rod" if result.rod_units else "unidentified"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    experimental_formula = result.structure.composition.reduced_formula
+
+    # lock (net, mapping) with a weight-independent fixed-slot build so
+    # every arm rebuilds the identical assignment
+    locked = None
+    for net in result.net_candidates:
+        topology = mofgen.topologies[net]
+        for mappings in candidate_mappings(topology, result.fragments, max_rmsd):
+            try:
+                framework = mofgen.build(
+                    topology, mappings=mappings, max_rmsd=max_rmsd, verify_net=True
+                )
+            except AutografsError:
+                continue
+            faithful = (
+                framework.structure.composition.reduced_formula == experimental_formula
+            )
+            if faithful:
+                locked = (net, mappings, framework)
+                break
+        if locked:
+            break
+    if locked is None:
+        record["outcome"] = "no_faithful_rebuild"
+        record["seconds"] = time.perf_counter() - start
+        return record
+
+    net, mappings, fixed_framework = locked
+    record["outcome"] = "calibrated"
+    record["net"] = net
+    record["arms"] = {"fixed": _metrics(fixed_framework, result)}
+
+    def relaxed_arm(label: str, weight: float, seed_main: bool) -> None:
+        with _arm(weight, seed_main):
+            try:
+                framework = mofgen.build(
+                    topology,
+                    mappings=mappings,
+                    max_rmsd=max_rmsd,
+                    verify_net=True,
+                    relax_embedding=True,
+                )
+            except AutografsError as exc:
+                record["arms"][label] = {"error": f"{type(exc).__name__}: {exc}"}
+                return
+        record["arms"][label] = _metrics(framework, result)
+
+    topology = mofgen.topologies[net]
+    relaxed_arm("unseeded-0.5", 0.5, seed_main=False)
+    for weight in WEIGHTS:
+        relaxed_arm(f"seeded-{weight}", weight, seed_main=True)
+    record["seconds"] = time.perf_counter() - start
+    return record
+
+
+def _init_worker(topofile: str | None, max_rmsd: float) -> None:
+    _WORKER["mofgen"] = Autografs(topofile=topofile) if topofile else Autografs()
+    _WORKER["max_rmsd"] = max_rmsd
+
+
+def _run_worker(path: str) -> tuple[str, dict]:
+    name = Path(path).name
+    try:
+        return name, calibrate_one(_WORKER["mofgen"], Path(path), _WORKER["max_rmsd"])
+    except Exception as error:  # noqa: BLE001 - one bad CIF must not kill a sweep
+        return name, {
+            "outcome": "driver_error",
+            "error": f"{type(error).__name__}: {error}",
+            "traceback": traceback.format_exc(limit=3),
+        }
+
+
+def run(
+    corpus: list[Path],
+    *,
+    max_rmsd: float = 0.5,
+    topofile: str | None = None,
+    n_jobs: int = 1,
+    checkpoint: Path | None = None,
+) -> dict:
+    records: dict[str, dict] = {}
+    if checkpoint and checkpoint.exists():
+        for line in checkpoint.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                entry = json.loads(line)
+                records[entry["name"]] = entry["record"]
+        print(f"resuming: {len(records)} already done")
+    todo = [p for p in corpus if p.name not in records]
+    handle = checkpoint.open("a", encoding="utf-8") if checkpoint else None
+    try:
+        if n_jobs > 1:
+            from concurrent.futures import ProcessPoolExecutor
+
+            with ProcessPoolExecutor(
+                max_workers=n_jobs,
+                initializer=_init_worker,
+                initargs=(topofile, max_rmsd),
+            ) as pool:
+                for index, (name, record) in enumerate(
+                    pool.map(_run_worker, [str(p) for p in todo], chunksize=2), 1
+                ):
+                    records[name] = record
+                    _report(index, len(todo), name, record, handle)
+        else:
+            _init_worker(topofile, max_rmsd)
+            for index, path in enumerate(todo, 1):
+                name, record = _run_worker(str(path))
+                records[name] = record
+                _report(index, len(todo), name, record, handle)
+    finally:
+        if handle:
+            handle.close()
+    return {
+        "benchmark": "direction-weight-calibration-seeded",
+        "corpus_note": "first N structures of the CoRE MOF 2025 manifest",
+        "weights": list(WEIGHTS),
+        "max_rmsd": max_rmsd,
+        "n_structures": len(records),
+        "outcomes": dict(Counter(r["outcome"] for r in records.values())),
+        "structures": records,
+    }
+
+
+def _report(index: int, total: int, name: str, record: dict, handle) -> None:
+    print(f"[{index}/{total}] {name}: {record['outcome']}", flush=True)
+    if handle:
+        handle.write(json.dumps({"name": name, "record": record}, default=str) + "\n")
+        handle.flush()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("corpus", help="directory, glob, manifest, or single CIF")
+    parser.add_argument("-o", "--output", default="calibration-seeded.json")
+    parser.add_argument("--max-rmsd", type=float, default=0.5)
+    parser.add_argument("--limit", type=int, default=600)
+    parser.add_argument("--n-jobs", type=int, default=1)
+    parser.add_argument("--checkpoint", default=None)
+    parser.add_argument("--topofile", default=None)
+    args = parser.parse_args()
+
+    corpus = _collect(args.corpus)
+    if args.limit is not None:
+        corpus = corpus[: args.limit]
+    if not corpus:
+        raise SystemExit(f"no structures matched {args.corpus!r}")
+    n_jobs = os.cpu_count() or 1 if args.n_jobs == -1 else args.n_jobs
+    payload = run(
+        corpus,
+        max_rmsd=args.max_rmsd,
+        topofile=args.topofile,
+        n_jobs=n_jobs,
+        checkpoint=Path(args.checkpoint) if args.checkpoint else None,
+    )
+    Path(args.output).write_text(json.dumps(payload, indent=1, default=str))
+    print(f"\n{payload['n_structures']} structures -> {args.output}")
+    for outcome, count in sorted(payload["outcomes"].items()):
+        print(f"  {outcome:<24} {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/mapping_gap.py
+++ b/scripts/benchmarks/mapping_gap.py
@@ -1,0 +1,276 @@
+"""Why identified structures have no compatible fragment-to-slot mapping.
+
+``roundtrip.py`` reports ``no_mapping`` for a structure whose net was
+found and whose own harvested units then fit no slot of it. That is the
+second-largest outcome in the census and, pooled, it says nothing: it is
+consistent both with a *connectivity* mismatch (a unit whose arm count
+matches no vertex figure of the net, which is a statement about how the
+deconstruction cuts and how the net is decorated) and with a *geometric*
+one (right arm count, arm directions too far from the slot's, which is
+the same shape error the embedding analysis measures continuously).
+Those are different findings and the distinction is not recoverable from
+the round-trip output, because the driver records only that no mapping
+existed.
+
+This re-runs deconstruction on those structures and asks, per candidate
+net and per slot type, which of the two walls was hit first --- reusing
+``Fragment.has_compatible_symmetry``'s own two-stage test rather than
+reimplementing it, so the answer is about the shipped predicate and not
+about a model of it.
+
+A structure is attributed to the *most favourable* candidate net it has,
+since a single net that fails on arm count while another fails only on
+geometry is a geometry-limited structure: some net of the library got
+the connectivity right.
+
+Usage:
+    python scripts/benchmarks/mapping_gap.py CORPUS -o mapping-gap.json
+    python scripts/benchmarks/mapping_gap.py CORPUS --only no-mapping.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import traceback
+from collections import Counter
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _corpus import collect as _collect  # noqa: E402
+
+from autografs import Autografs  # noqa: E402
+from autografs.exceptions import AutografsError  # noqa: E402
+from autografs.fragment import COMPATIBILITY_MAX_RMSD  # noqa: E402
+
+_WORKER: dict = {}
+
+
+def _slot_verdict(slot, fragments, max_rmsd: float) -> dict:
+    """How close any harvested unit comes to occupying this slot.
+
+    Two walls, in the order ``has_compatible_symmetry`` applies them:
+    an equal dummy count is required outright, and only then are the
+    arm directions matched. Reporting which one stopped a slot is the
+    whole point of this driver, so both are recorded -- along with the
+    best directional RMSD achieved among the right-sized candidates,
+    which says whether a geometric failure was near or hopeless.
+    """
+    n_arms = len(slot.arm_units)
+    right_size = [f for f in fragments if len(f.arm_units) == n_arms]
+    if not right_size:
+        available = sorted({len(f.arm_units) for f in fragments})
+        return {
+            "wall": "arm_count",
+            "slot_arms": n_arms,
+            "unit_arms": available,
+            "best_rmsd": None,
+        }
+    # permissive first: does anything fit at the sieve's own threshold?
+    if any(slot.has_compatible_symmetry(f, max_rmsd=max_rmsd) for f in right_size):
+        return {"wall": None, "slot_arms": n_arms, "best_rmsd": 0.0}
+    # nothing fits; find how far off the nearest right-sized unit is by
+    # re-testing at widening thresholds. The predicate is a boolean, so
+    # bisecting it is the only way to get a distance out of the shipped
+    # code path rather than a reimplementation of it.
+    low, high = max_rmsd, 4.0
+    if not any(slot.has_compatible_symmetry(f, max_rmsd=high) for f in right_size):
+        return {"wall": "geometry", "slot_arms": n_arms, "best_rmsd": None}
+    for _ in range(12):
+        middle = 0.5 * (low + high)
+        if any(slot.has_compatible_symmetry(f, max_rmsd=middle) for f in right_size):
+            high = middle
+        else:
+            low = middle
+    return {"wall": "geometry", "slot_arms": n_arms, "best_rmsd": round(high, 3)}
+
+
+def _net_verdict(topology, fragments, max_rmsd: float) -> dict:
+    """Attribute one candidate net: the wall met by its hardest slot type."""
+    per_slot = [
+        _slot_verdict(slot_type, fragments, max_rmsd) for slot_type in topology.mappings
+    ]
+    walls = [s["wall"] for s in per_slot if s["wall"]]
+    if not walls:
+        return {"wall": None, "slots": per_slot}
+    # geometry is the *softer* wall, so a net reports arm_count only when
+    # a slot type has no right-sized unit at all
+    wall = "arm_count" if "arm_count" in walls else "geometry"
+    near = [s["best_rmsd"] for s in per_slot if s.get("best_rmsd")]
+    return {
+        "wall": wall,
+        "n_slot_types": len(per_slot),
+        "n_blocked": len(walls),
+        "worst_rmsd": max(near) if near else None,
+        "slots": per_slot,
+    }
+
+
+def analyse_one(mofgen: Autografs, path: Path, max_rmsd: float) -> dict:
+    record: dict = {"outcome": None, "seconds": 0.0}
+    start = time.perf_counter()
+    try:
+        result = mofgen.deconstruct(str(path))
+    except AutografsError as error:
+        record["outcome"] = "deconstruction_failed"
+        record["error"] = f"{type(error).__name__}: {error}"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    nets = list(result.net_candidates or [])
+    record["net"] = nets
+    if not nets:
+        record["outcome"] = "unidentified"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    fragments = list(result.fragments.values())
+    record["n_fragments"] = len(fragments)
+    verdicts = {}
+    for name in nets:
+        topology = mofgen.topologies.get(name)
+        if topology is None:
+            continue
+        verdicts[name] = _net_verdict(topology, fragments, max_rmsd)
+    if not verdicts:
+        record["outcome"] = "no_blueprint"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    # the most favourable net decides: order is fit < geometry < arm_count
+    rank = {None: 0, "geometry": 1, "arm_count": 2}
+    best_net = min(verdicts, key=lambda n: rank[verdicts[n]["wall"]])
+    best = verdicts[best_net]
+    record["outcome"] = "mapped" if best["wall"] is None else best["wall"]
+    record["best_net"] = best_net
+    record["n_slot_types"] = best.get("n_slot_types")
+    record["n_blocked"] = best.get("n_blocked")
+    record["worst_rmsd"] = best.get("worst_rmsd")
+    record["slot_arms"] = [s["slot_arms"] for s in best["slots"]]
+    record["unit_arms"] = sorted({len(f.arm_units) for f in fragments})
+    record["seconds"] = time.perf_counter() - start
+    return record
+
+
+def _init_worker(topofile: str | None, max_rmsd: float) -> None:
+    _WORKER["mofgen"] = Autografs(topofile=topofile) if topofile else Autografs()
+    _WORKER["max_rmsd"] = max_rmsd
+
+
+def _run_worker(path: str) -> tuple[str, dict]:
+    name = Path(path).name
+    try:
+        return name, analyse_one(_WORKER["mofgen"], Path(path), _WORKER["max_rmsd"])
+    except Exception as error:  # noqa: BLE001 - one bad CIF must not kill a sweep
+        return name, {
+            "outcome": "driver_error",
+            "error": f"{type(error).__name__}: {error}",
+            "traceback": traceback.format_exc(limit=3),
+        }
+
+
+def run(
+    corpus: list[Path],
+    *,
+    max_rmsd: float = COMPATIBILITY_MAX_RMSD,
+    topofile: str | None = None,
+    n_jobs: int = 1,
+    checkpoint: Path | None = None,
+) -> dict:
+    records: dict[str, dict] = {}
+    if checkpoint and checkpoint.exists():
+        for line in checkpoint.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                entry = json.loads(line)
+                records[entry["name"]] = entry["record"]
+        print(f"resuming: {len(records)} already done")
+    todo = [p for p in corpus if p.name not in records]
+    handle = checkpoint.open("a", encoding="utf-8") if checkpoint else None
+    try:
+        if n_jobs > 1:
+            with ProcessPoolExecutor(
+                max_workers=n_jobs,
+                initializer=_init_worker,
+                initargs=(topofile, max_rmsd),
+            ) as pool:
+                for index, (name, record) in enumerate(
+                    pool.map(_run_worker, [str(p) for p in todo], chunksize=4), 1
+                ):
+                    records[name] = record
+                    _report(index, len(todo), name, record, handle)
+        else:
+            _init_worker(topofile, max_rmsd)
+            for index, path in enumerate(todo, 1):
+                name, record = _run_worker(str(path))
+                records[name] = record
+                _report(index, len(todo), name, record, handle)
+    finally:
+        if handle:
+            handle.close()
+    return {
+        "benchmark": "mapping_gap",
+        "max_rmsd": max_rmsd,
+        "n_structures": len(records),
+        "outcomes": dict(Counter(r["outcome"] for r in records.values())),
+        "structures": records,
+    }
+
+
+def _report(index: int, total: int, name: str, record: dict, handle) -> None:
+    extra = ""
+    if record.get("worst_rmsd"):
+        extra = f"  (nearest fit at rmsd {record['worst_rmsd']})"
+    print(f"[{index}/{total}] {name}: {record['outcome']}{extra}", flush=True)
+    if handle:
+        handle.write(json.dumps({"name": name, "record": record}, default=str) + "\n")
+        handle.flush()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("corpus", help="directory, glob, manifest, or single CIF")
+    parser.add_argument("-o", "--output", default="mapping-gap.json")
+    parser.add_argument(
+        "--only",
+        default=None,
+        help="JSON round-trip output; restrict to its no_mapping structures",
+    )
+    parser.add_argument("--max-rmsd", type=float, default=COMPATIBILITY_MAX_RMSD)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--n-jobs", type=int, default=1)
+    parser.add_argument("--checkpoint", default=None)
+    parser.add_argument("--topofile", default=None)
+    args = parser.parse_args()
+
+    corpus = _collect(args.corpus)
+    if args.only:
+        payload = json.loads(Path(args.only).read_text(encoding="utf-8"))
+        wanted = {
+            name
+            for name, record in payload["structures"].items()
+            if record.get("outcome") == "no_mapping"
+        }
+        corpus = [p for p in corpus if p.name in wanted]
+        print(f"restricted to {len(corpus)} no_mapping structures")
+    if args.limit is not None:
+        corpus = corpus[: args.limit]
+    if not corpus:
+        raise SystemExit(f"no structures matched {args.corpus!r}")
+    n_jobs = os.cpu_count() or 1 if args.n_jobs == -1 else args.n_jobs
+    payload = run(
+        corpus,
+        max_rmsd=args.max_rmsd,
+        topofile=args.topofile,
+        n_jobs=n_jobs,
+        checkpoint=Path(args.checkpoint) if args.checkpoint else None,
+    )
+    Path(args.output).write_text(json.dumps(payload, indent=1, default=str))
+    print(f"\n{payload['n_structures']} structures -> {args.output}")
+    for outcome, count in sorted(payload["outcomes"].items()):
+        print(f"  {outcome:<24} {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/rodtrip.py
+++ b/scripts/benchmarks/rodtrip.py
@@ -87,12 +87,20 @@ def rodtrip_one(mofgen: Autografs, source, max_rmsd: float) -> dict:
     record["n_rods"] = len(result.rod_units)
     record["n_fragments"] = len(result.fragments)
     record["net"] = result.net_candidates or None
+    record["topological_net"] = result.topological_candidates or None
+    record["poe_merged"] = result.poe_merged
     if not result.rod_units:
         record["outcome"] = "no_rod"
         record["seconds"] = time.perf_counter() - t0
         return record
     if not result.net_candidates:
-        record["outcome"] = "no_net"
+        # two different failures: the quotient graph matched nothing at
+        # all, or it matched nets whose every run the harvested rod
+        # cannot occupy and the #215 filter emptied the list. Pooling
+        # them as "no_net" over-claimed the identification miss.
+        record["outcome"] = (
+            "rod_incompatible" if result.topological_candidates else "no_net"
+        )
         record["seconds"] = time.perf_counter() - t0
         return record
 

--- a/scripts/benchmarks/roundtrip.py
+++ b/scripts/benchmarks/roundtrip.py
@@ -71,21 +71,49 @@ from autografs.exceptions import AutografsError
 MAX_MAPPINGS_PER_NET = 16
 
 
-def candidate_mappings(topology, fragments: dict):
+def candidate_mappings(topology, fragments: dict, max_rmsd: float | None = None):
     """Yield fragment-per-slot-type assignments compatible by geometry.
 
     Enumerated in graded order (see ``_mapping_order``) rather than
     ``itertools.product`` order, so the budget varies every slot type
     instead of only the last one.
+
+    ``max_rmsd`` is the threshold the *build* will be gated at, and the
+    sieve must use the same one. Sieving at the library default (0.35)
+    while building at 0.5 silently reclassified structures: 95 of the
+    census's 150 geometry-blocked ``no_mapping`` structures had a
+    nearest fit within the build's own gate and were never attempted.
+
+    A **2-connected slot type may be assigned nothing**. That is a
+    library capability (an emptied slot's two neighbours bond directly,
+    with the periodic offset chained through it) and it is what
+    edge-decorated nets require in practice -- HKUST-1 builds on
+    ``tbo`` with its 96 two-connected slots empty. Not offering it made
+    this driver's ``no_mapping`` bucket measure the driver: 458 corpus
+    structures, 9.4% of the whole set, had *every* blocked slot type
+    2-connected, so the benchmark refused to attempt a build that the
+    library can perform. Most reach this state by being identified on
+    the contracted tier, where the net is named only after its
+    2-connected slots are contracted away -- so the blueprint that
+    matched has slots the deconstruction never produces, by
+    construction.
+
+    ``None`` is appended **last**, after any fragment that does fit, so
+    the graded enumeration still tries a real decoration first and the
+    first combination is unchanged. Emptying a slot is a fallback, not
+    a preference, and results that did not need it are unaffected.
     """
     slot_types = list(topology.mappings)
-    options = []
+    threshold = {} if max_rmsd is None else {"max_rmsd": max_rmsd}
+    options: list[list] = []
     for slot_type in slot_types:
-        fitting = [
+        fitting: list = [
             fragment
             for fragment in fragments.values()
-            if fragment.has_compatible_symmetry(slot_type)
+            if fragment.has_compatible_symmetry(slot_type, **threshold)
         ]
+        if len(slot_type.atoms.indices_from_symbol("X")) == 2:
+            fitting.append(None)
         if not fitting:
             return
         options.append(fitting)
@@ -157,6 +185,13 @@ def _geometry(framework, result) -> dict:
         "min_contact": framework.min_contact(),
         "bond_residual": bond_residuals(framework),
         "empty_slots": sorted(framework.graph.graph.get("empty_slots", ())),
+        # under relax_embedding: the EFFECTIVE freedom after empty-slot
+        # pinning, which candidate the closure guard kept, and the
+        # per-candidate worst-bond scores. Recorded so the relaxation
+        # analysis can stratify on what the build actually did rather
+        # than on the blueprint's own n_free -- the variable that
+        # misattributed 105 never-ran builds to the guard.
+        "relaxation": framework.graph.graph.get("relaxation"),
     }
 
 
@@ -202,7 +237,7 @@ def roundtrip_one(
     saw_uncapped = False
     for net in result.net_candidates:
         topology = mofgen.topologies[net]
-        for mappings in candidate_mappings(topology, result.fragments):
+        for mappings in candidate_mappings(topology, result.fragments, max_rmsd):
             saw_mapping = True
             try:
                 framework = mofgen.build(

--- a/scripts/benchmarks/roundtrip.py
+++ b/scripts/benchmarks/roundtrip.py
@@ -200,17 +200,27 @@ def roundtrip_one(
     source,
     max_rmsd: float,
     relax_embedding: bool = False,
+    _fused=None,
 ) -> dict:
-    """Deconstruct one structure and attempt the verified rebuild."""
+    """Deconstruct one structure and attempt the verified rebuild.
+
+    ``_fused`` is the internal recursion handle for the parallel-bridge
+    fallback: a pre-computed fused Deconstruction to attempt instead of
+    deconstructing again (and a guard against a second fallback).
+    """
     record: dict = {"outcome": None, "net": None, "tier": None, "error": None}
     t0 = time.perf_counter()
-    try:
-        result = mofgen.deconstruct(source)
-    except (AutografsError, ValueError, KeyError, IndexError) as exc:
-        record["outcome"] = "deconstruction_failed"
-        record["error"] = f"{type(exc).__name__}: {exc}"
-        record["seconds"] = time.perf_counter() - t0
-        return record
+    _already_fused = _fused is not None
+    if _already_fused:
+        result = _fused
+    else:
+        try:
+            result = mofgen.deconstruct(source)
+        except (AutografsError, ValueError, KeyError, IndexError) as exc:
+            record["outcome"] = "deconstruction_failed"
+            record["error"] = f"{type(exc).__name__}: {exc}"
+            record["seconds"] = time.perf_counter() - t0
+            return record
     record["n_fragments"] = len(result.fragments)
     record["fold"] = result.n_periodic_components
     record["guests"] = result.guest_formulas
@@ -274,6 +284,28 @@ def roundtrip_one(
         record["outcome"] = "rebuild_failed"
     else:
         record["outcome"] = "no_mapping"
+        # fallback convention, mirroring the grouped-PoE tier: when the
+        # standard units admit no mapping, retry with parallel ditopic
+        # bridges fused into composite units - the dominant no_mapping
+        # mechanism is a doubled node the identifier reads at single
+        # multiplicity. A structure the standard convention answers
+        # never reaches this branch.
+        if not _already_fused:
+            try:
+                fused_result = mofgen.deconstruct(source, fuse_parallel_bridges=True)
+            except (AutografsError, ValueError, KeyError, IndexError):
+                fused_result = None
+            if fused_result is not None and fused_result.fused_bridges:
+                fused_record = roundtrip_one(
+                    mofgen,
+                    source,
+                    max_rmsd,
+                    relax_embedding,
+                    _fused=fused_result,
+                )
+                if fused_record["outcome"] != "no_mapping":
+                    fused_record["fused_bridges"] = fused_result.fused_bridges
+                    return fused_record
     record["seconds"] = time.perf_counter() - t0
     return record
 

--- a/scripts/benchmarks/selftemplate.py
+++ b/scripts/benchmarks/selftemplate.py
@@ -70,9 +70,7 @@ def selftemplate_one(mofgen: Autografs, source, max_rmsd: float) -> dict:
     record["n_fragment_types"] = len(result.fragments)
     record["fold"] = result.n_periodic_components
     if result.rod_units:
-        record["outcome"] = "skipped_rod"
-        record["seconds"] = time.perf_counter() - start
-        return record
+        return _rod_selftemplate(mofgen, result, record, start)
     # catenated structures are IN scope: the recipe holds every
     # component's units, so the erected blueprint is a disconnected
     # quotient whose nets share the one real cell at their true
@@ -116,6 +114,83 @@ def selftemplate_one(mofgen: Autografs, source, max_rmsd: float) -> dict:
     record["bond_residual"] = bond_residuals(framework)
     matched = (
         built.composition.reduced_formula == experimental.composition.reduced_formula
+    )
+    record["formula"] = built.composition.reduced_formula
+    record["experimental_formula"] = experimental.composition.reduced_formula
+    record["outcome"] = "closed_self" if matched else "composition_mismatch"
+    record["seconds"] = time.perf_counter() - start
+    return record
+
+
+def _rod_selftemplate(mofgen: Autografs, result, record: dict, start: float) -> dict:
+    """The rod arm: rebuild on the crystal's own slot run.
+
+    Single rod, single periodic component only (the multi-rod and
+    catenated-rod cases await their own increment). Closure gates on
+    composition and whole-supercell atom count - the builder stacks at
+    least two repeats - with per-atom packing recorded; exact net
+    verification is attempted and recorded, not gating, because the
+    rod-form verifier re-detects runs on the blueprint instead of
+    trusting the injected one and is known-conservative on distorted
+    self-blueprints (coverage plan, rod self-templates).
+    """
+    from autografs.extract_topology import rod_topology_from_deconstruction
+
+    if len(result.rod_units) != 1 or result.n_periodic_components != 1:
+        record["outcome"] = "skipped_multirod"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    try:
+        topology, run, lateral_mapping, fragment = rod_topology_from_deconstruction(
+            result
+        )
+    except (TopologyExtractionError, AutografsError, ValueError) as exc:
+        record["outcome"] = "no_blueprint"
+        record["error"] = f"{type(exc).__name__}: {exc}"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    laterals = {
+        index: copy.deepcopy(result.fragments[name])
+        for index, name in lateral_mapping.items()
+    }
+    from autografs.rod_build import build_rod_framework
+
+    try:
+        framework = build_rod_framework(
+            topology,
+            fragment,
+            laterals,
+            run=run,
+            min_distance=None,
+            bond_tolerance=10.0,
+            verify_net=False,
+        )
+    except AutografsError as exc:
+        record["outcome"] = "build_failed"
+        record["error"] = f"{type(exc).__name__}: {exc}"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    except Exception as exc:  # noqa: BLE001 - a build bug is data
+        record["outcome"] = "build_failed"
+        record["error"] = f"{type(exc).__name__}: {exc}"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    built = framework.structure
+    experimental = result.structure
+    record["rod"] = True
+    record["volume_ratio"] = (built.volume / len(built)) / (
+        experimental.volume / len(experimental)
+    )
+    record["min_contact"] = framework.min_contact()
+    record["bond_residual"] = bond_residuals(framework)
+    try:
+        framework.verify_net(topology)
+        record["net_verified"] = True
+    except AutografsError:
+        record["net_verified"] = False
+    matched = (
+        built.composition.reduced_formula == experimental.composition.reduced_formula
+        and len(built) % len(experimental) == 0
     )
     record["formula"] = built.composition.reduced_formula
     record["experimental_formula"] = experimental.composition.reduced_formula

--- a/scripts/benchmarks/selftemplate.py
+++ b/scripts/benchmarks/selftemplate.py
@@ -73,12 +73,10 @@ def selftemplate_one(mofgen: Autografs, source, max_rmsd: float) -> dict:
         record["outcome"] = "skipped_rod"
         record["seconds"] = time.perf_counter() - start
         return record
-    if result.n_periodic_components > 1:
-        # one blueprint would hold every catenated component; the build
-        # core places one connected net. Out of scope for this arm.
-        record["outcome"] = "skipped_catenated"
-        record["seconds"] = time.perf_counter() - start
-        return record
+    # catenated structures are IN scope: the recipe holds every
+    # component's units, so the erected blueprint is a disconnected
+    # quotient whose nets share the one real cell at their true
+    # relative offset, and the build places all of them together
     try:
         topology, mapping = topology_from_deconstruction(result)
     except TopologyExtractionError as exc:

--- a/scripts/benchmarks/selftemplate.py
+++ b/scripts/benchmarks/selftemplate.py
@@ -167,8 +167,11 @@ def _rod_selftemplate(mofgen: Autografs, result, record: dict, start: float) -> 
             # the self-blueprint is at the crystal's own size, so the
             # transverse scale starts at exactly 1 - the library-net
             # heuristic landed orders of magnitude off on real P1
-            # embeddings (measured: scale 183 where 1 was correct)
+            # embeddings (measured: scale 183 where 1 was correct) -
+            # and the band guards against the compressed pairing basin
+            # (measured: seeded-only sweep median |vr-1| 0.324)
             initial_scale=1.0,
+            scale_band=0.25,
         )
     except AutografsError as exc:
         record["outcome"] = "build_failed"

--- a/scripts/benchmarks/selftemplate.py
+++ b/scripts/benchmarks/selftemplate.py
@@ -1,0 +1,233 @@
+"""Self-templated round trips: rebuild each crystal from its OWN blueprint.
+
+The library round trip (``roundtrip.py``) asks whether a structure is
+expressible in the *cataloged* abstraction: its net must match a library
+blueprint and its harvested units must fit that blueprint's slots. This
+driver removes the library from the question entirely
+(coverage plan stage 3). ``topology_from_deconstruction`` erects the
+structure's own blueprint - one slot per building unit at its real
+position, one shared connection point per cut bond - and the rebuild
+maps every slot to its own unit's deduplicated representative fragment.
+
+What remains under test is the rigid-unit abstraction itself: can rigid
+representative building blocks, placed on the crystal's own net
+embedding with the cell re-optimized from covalent targets, regenerate
+the material? Failures are therefore attributable to unit rigidity and
+instance-to-representative variation, not to net identification,
+library coverage, slot-type capacity, or the idealized embedding.
+
+``verify_net`` runs against the self-blueprint - near-tautological by
+construction, kept as an internal consistency check whose failures
+expose representation limits (e.g. a linker bonding the same unit pair
+through two images, which the simple-graph min-image convention cannot
+hold) - and the decisive gates are composition and realized geometry.
+
+Usage:
+    python scripts/benchmarks/selftemplate.py CORPUS -o selftemplate.json \
+        --checkpoint selftemplate.jsonl --n-jobs 10
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import sys
+import time
+import traceback
+from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _corpus import collect as _collect  # noqa: E402
+from embedding import bond_residuals  # noqa: E402
+
+from autografs import Autografs  # noqa: E402
+from autografs.builder import build_framework  # noqa: E402
+from autografs.exceptions import (  # noqa: E402
+    AutografsError,
+    NetMismatchError,
+    TopologyExtractionError,
+)
+from autografs.extract_topology import topology_from_deconstruction  # noqa: E402
+
+_WORKER: dict = {}
+
+
+def selftemplate_one(mofgen: Autografs, source, max_rmsd: float) -> dict:
+    record: dict = {"outcome": None, "error": None, "seconds": 0.0}
+    start = time.perf_counter()
+    try:
+        result = mofgen.deconstruct(source)
+    except (AutografsError, ValueError, KeyError, IndexError) as exc:
+        record["outcome"] = "deconstruction_failed"
+        record["error"] = f"{type(exc).__name__}: {exc}"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    record["n_units"] = len(result.units)
+    record["n_fragment_types"] = len(result.fragments)
+    record["fold"] = result.n_periodic_components
+    if result.rod_units:
+        record["outcome"] = "skipped_rod"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    if result.n_periodic_components > 1:
+        # one blueprint would hold every catenated component; the build
+        # core places one connected net. Out of scope for this arm.
+        record["outcome"] = "skipped_catenated"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    try:
+        topology, mapping = topology_from_deconstruction(result)
+    except TopologyExtractionError as exc:
+        record["outcome"] = "no_blueprint"
+        record["error"] = f"{type(exc).__name__}: {exc}"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    record["n_slots"] = len(topology)
+    mappings = {
+        index: copy.deepcopy(result.fragments[name]) for index, name in mapping.items()
+    }
+    try:
+        framework = build_framework(
+            topology, mappings, max_rmsd=max_rmsd, verify_net=True
+        )
+    except NetMismatchError as exc:
+        record["outcome"] = "verify_failed"
+        record["error"] = f"{type(exc).__name__}: {exc}"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    except AutografsError as exc:
+        record["outcome"] = "build_failed"
+        record["error"] = f"{type(exc).__name__}: {exc}"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    except Exception as exc:  # noqa: BLE001 - a build bug is data
+        record["outcome"] = "build_failed"
+        record["error"] = f"{type(exc).__name__}: {exc}"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    built = framework.structure
+    experimental = result.structure
+    record["volume_ratio"] = (built.volume / len(built)) / (
+        experimental.volume / len(experimental)
+    )
+    record["min_contact"] = framework.min_contact()
+    record["bond_residual"] = bond_residuals(framework)
+    matched = (
+        built.composition.reduced_formula == experimental.composition.reduced_formula
+    )
+    record["formula"] = built.composition.reduced_formula
+    record["experimental_formula"] = experimental.composition.reduced_formula
+    record["outcome"] = "closed_self" if matched else "composition_mismatch"
+    record["seconds"] = time.perf_counter() - start
+    return record
+
+
+def _init_worker(topofile: str | None, max_rmsd: float) -> None:
+    _WORKER["mofgen"] = Autografs(topofile=topofile) if topofile else Autografs()
+    _WORKER["max_rmsd"] = max_rmsd
+
+
+def _run_worker(path: str) -> tuple[str, dict]:
+    name = Path(path).name
+    try:
+        return name, selftemplate_one(_WORKER["mofgen"], path, _WORKER["max_rmsd"])
+    except Exception as error:  # noqa: BLE001 - one bad CIF must not kill a sweep
+        return name, {
+            "outcome": "driver_error",
+            "error": f"{type(error).__name__}: {error}",
+            "traceback": traceback.format_exc(limit=3),
+        }
+
+
+def run(
+    corpus: list[Path],
+    *,
+    max_rmsd: float = 0.5,
+    topofile: str | None = None,
+    n_jobs: int = 1,
+    checkpoint: Path | None = None,
+) -> dict:
+    records: dict[str, dict] = {}
+    if checkpoint and checkpoint.exists():
+        for line in checkpoint.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                entry = json.loads(line)
+                records[entry["name"]] = entry["record"]
+        print(f"resuming: {len(records)} already done")
+    todo = [p for p in corpus if p.name not in records]
+    handle = checkpoint.open("a", encoding="utf-8") if checkpoint else None
+    try:
+        if n_jobs > 1:
+            from concurrent.futures import ProcessPoolExecutor
+
+            with ProcessPoolExecutor(
+                max_workers=n_jobs,
+                initializer=_init_worker,
+                initargs=(topofile, max_rmsd),
+            ) as pool:
+                for index, (name, record) in enumerate(
+                    pool.map(_run_worker, [str(p) for p in todo], chunksize=2), 1
+                ):
+                    records[name] = record
+                    _report(index, len(todo), name, record, handle)
+        else:
+            _init_worker(topofile, max_rmsd)
+            for index, path in enumerate(todo, 1):
+                name, record = _run_worker(str(path))
+                records[name] = record
+                _report(index, len(todo), name, record, handle)
+    finally:
+        if handle:
+            handle.close()
+    return {
+        "benchmark": "selftemplate",
+        "max_rmsd": max_rmsd,
+        "n_structures": len(records),
+        "outcomes": dict(Counter(r["outcome"] for r in records.values())),
+        "structures": records,
+    }
+
+
+def _report(index: int, total: int, name: str, record: dict, handle) -> None:
+    print(f"[{index}/{total}] {name}: {record['outcome']}", flush=True)
+    if handle:
+        handle.write(json.dumps({"name": name, "record": record}, default=str) + "\n")
+        handle.flush()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("corpus", help="directory, glob, manifest, or single CIF")
+    parser.add_argument("-o", "--output", default="selftemplate.json")
+    parser.add_argument("--max-rmsd", type=float, default=0.5)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--n-jobs", type=int, default=1)
+    parser.add_argument("--checkpoint", default=None)
+    parser.add_argument("--topofile", default=None)
+    args = parser.parse_args()
+
+    corpus = _collect(args.corpus)
+    if args.limit is not None:
+        corpus = corpus[: args.limit]
+    if not corpus:
+        raise SystemExit(f"no structures matched {args.corpus!r}")
+    n_jobs = os.cpu_count() or 1 if args.n_jobs == -1 else args.n_jobs
+    payload = run(
+        corpus,
+        max_rmsd=args.max_rmsd,
+        topofile=args.topofile,
+        n_jobs=n_jobs,
+        checkpoint=Path(args.checkpoint) if args.checkpoint else None,
+    )
+    Path(args.output).write_text(json.dumps(payload, indent=1, default=str))
+    print(f"\n{payload['n_structures']} structures -> {args.output}")
+    for outcome, count in sorted(payload["outcomes"].items()):
+        print(f"  {outcome:<24} {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmarks/selftemplate.py
+++ b/scripts/benchmarks/selftemplate.py
@@ -164,6 +164,11 @@ def _rod_selftemplate(mofgen: Autografs, result, record: dict, start: float) -> 
             min_distance=None,
             bond_tolerance=10.0,
             verify_net=False,
+            # the self-blueprint is at the crystal's own size, so the
+            # transverse scale starts at exactly 1 - the library-net
+            # heuristic landed orders of magnitude off on real P1
+            # embeddings (measured: scale 183 where 1 was correct)
+            initial_scale=1.0,
         )
     except AutografsError as exc:
         record["outcome"] = "build_failed"

--- a/scripts/benchmarks/unidentified_probe.py
+++ b/scripts/benchmarks/unidentified_probe.py
@@ -1,0 +1,238 @@
+"""What the unidentified structures look like, since the census cannot say.
+
+``roundtrip.py`` reports ``unidentified`` for a structure that
+deconstructs and then matches no library net, and records nothing else
+-- so the largest method-side bucket of the census is also its least
+attributed. Cross-referencing the rod scan removes the part with a known
+cause (1-periodic units must match on the contracted points-of-extension
+tier); this driver re-deconstructs the remainder and records what the
+identifier actually saw, so the bucket can be attributed instead of
+pooled:
+
+- the quotient graph's size and degree structure, contracted and not
+  (a vertex of degree 8+ in the contracted graph is the signature of
+  under-cutting or multi-bridged units, the same granularity artifact
+  the mapping-gap sweep isolates on the identified population);
+- whether ANY library net shares the reduced degree recipe, which
+  separates "the degree profile itself is unmatched" (a hard coverage
+  statement) from "candidates existed and every coordination sequence
+  disagreed";
+- per-subframework matches and fold, so interpenetration-consensus
+  failures are visible.
+
+Usage:
+    python scripts/benchmarks/unidentified_probe.py CORPUS \
+        --only e1.json --rod-scan e6.json -o unidentified-probe.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import traceback
+from collections import Counter
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _corpus import collect as _collect  # noqa: E402
+
+from autografs import Autografs  # noqa: E402
+from autografs.exceptions import AutografsError  # noqa: E402
+
+_WORKER: dict = {}
+
+
+def probe_one(mofgen: Autografs, path: Path) -> dict:
+    # the prefilter's own helpers, so "no net shares this degree recipe"
+    # is a statement about the shipped identifier and not a model of it
+    from autografs.net import (  # noqa: PLC0415
+        _degree_profile,
+        contract_quotient_edges,
+        net_signature,
+    )
+
+    record: dict = {"outcome": None, "seconds": 0.0}
+    start = time.perf_counter()
+    try:
+        result = mofgen.deconstruct(str(path))
+    except AutografsError as error:
+        record["outcome"] = "deconstruction_failed"
+        record["error"] = f"{type(error).__name__}: {error}"
+        record["seconds"] = time.perf_counter() - start
+        return record
+    edges = result.quotient_edges
+    degree: Counter = Counter()
+    n_edges = 0
+    for edge, count in edges.items():
+        degree[edge[0]] += count
+        degree[edge[1]] += count
+        n_edges += count
+    record["outcome"] = "identified" if result.net_candidates else "unidentified"
+    record["net"] = list(result.net_candidates or [])
+    record["n_units"] = len(result.units)
+    record["n_fragment_types"] = len(result.fragments)
+    record["kinds"] = dict(Counter(unit.kind for unit in result.units))
+    record["fold"] = result.n_periodic_components
+    record["rod_units"] = len(result.rod_units)
+    record["n_vertices"] = len(degree)
+    record["n_edges"] = n_edges
+    record["sub_matches"] = [sorted(m) for m in result.subframework_nets]
+    signature = net_signature(edges, contract=True)
+    record["sig_empty"] = not signature
+    if signature:
+        profile = _degree_profile(
+            [s[0] for s, multiplicity in signature for _ in range(multiplicity)]
+        )
+        record["profile"] = list(profile)
+        record["n_prefilter_candidates"] = sum(
+            1
+            for _name, payload in mofgen.topologies.raw_items()
+            if _degree_profile(
+                [slot["species"].count("X") for slot in payload.get("slots", [])]
+            )
+            == profile
+        )
+    contracted = contract_quotient_edges(edges, contract=True)
+    cdegree: Counter = Counter()
+    for edge, count in contracted.items():
+        cdegree[edge[0]] += count
+        cdegree[edge[1]] += count
+    record["contracted_vertices"] = len(cdegree)
+    record["contracted_max_degree"] = max(cdegree.values(), default=0)
+    record["seconds"] = time.perf_counter() - start
+    return record
+
+
+def _init_worker(topofile: str | None) -> None:
+    _WORKER["mofgen"] = Autografs(topofile=topofile) if topofile else Autografs()
+
+
+def _run_worker(path: str) -> tuple[str, dict]:
+    name = Path(path).name
+    try:
+        return name, probe_one(_WORKER["mofgen"], Path(path))
+    except Exception as error:  # noqa: BLE001 - one bad CIF must not kill a sweep
+        return name, {
+            "outcome": "driver_error",
+            "error": f"{type(error).__name__}: {error}",
+            "traceback": traceback.format_exc(limit=3),
+        }
+
+
+def run(
+    corpus: list[Path],
+    *,
+    topofile: str | None = None,
+    n_jobs: int = 1,
+    checkpoint: Path | None = None,
+) -> dict:
+    records: dict[str, dict] = {}
+    if checkpoint and checkpoint.exists():
+        for line in checkpoint.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                entry = json.loads(line)
+                records[entry["name"]] = entry["record"]
+        print(f"resuming: {len(records)} already done")
+    todo = [p for p in corpus if p.name not in records]
+    handle = checkpoint.open("a", encoding="utf-8") if checkpoint else None
+    try:
+        if n_jobs > 1:
+            with ProcessPoolExecutor(
+                max_workers=n_jobs,
+                initializer=_init_worker,
+                initargs=(topofile,),
+            ) as pool:
+                for index, (name, record) in enumerate(
+                    pool.map(_run_worker, [str(p) for p in todo], chunksize=4), 1
+                ):
+                    records[name] = record
+                    _report(index, len(todo), name, record, handle)
+        else:
+            _init_worker(topofile)
+            for index, path in enumerate(todo, 1):
+                name, record = _run_worker(str(path))
+                records[name] = record
+                _report(index, len(todo), name, record, handle)
+    finally:
+        if handle:
+            handle.close()
+    return {
+        "benchmark": "unidentified_probe",
+        "n_structures": len(records),
+        "outcomes": dict(Counter(r["outcome"] for r in records.values())),
+        "structures": records,
+    }
+
+
+def _report(index: int, total: int, name: str, record: dict, handle) -> None:
+    print(f"[{index}/{total}] {name}: {record['outcome']}", flush=True)
+    if handle:
+        handle.write(json.dumps({"name": name, "record": record}, default=str) + "\n")
+        handle.flush()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("corpus", help="directory, glob, manifest, or single CIF")
+    parser.add_argument("-o", "--output", default="unidentified-probe.json")
+    parser.add_argument(
+        "--only",
+        default=None,
+        help="JSON round-trip output; restrict to its unidentified structures",
+    )
+    parser.add_argument(
+        "--rod-scan",
+        default=None,
+        help="JSON rod round-trip output; drop structures it found rods in "
+        "(their identification failure has a known, separate cause)",
+    )
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--n-jobs", type=int, default=1)
+    parser.add_argument("--checkpoint", default=None)
+    parser.add_argument("--topofile", default=None)
+    args = parser.parse_args()
+
+    corpus = _collect(args.corpus)
+    if args.only:
+        payload = json.loads(Path(args.only).read_text(encoding="utf-8"))
+        wanted = {
+            name
+            for name, record in payload["structures"].items()
+            if record.get("outcome") == "unidentified"
+        }
+        corpus = [p for p in corpus if p.name in wanted]
+        print(f"restricted to {len(corpus)} unidentified structures")
+    if args.rod_scan:
+        payload = json.loads(Path(args.rod_scan).read_text(encoding="utf-8"))
+        rods = {
+            name
+            for name, record in payload["structures"].items()
+            if (record.get("n_rods") or 0) > 0
+        }
+        before = len(corpus)
+        corpus = [p for p in corpus if p.name not in rods]
+        print(f"dropped {before - len(corpus)} rod-containing structures")
+    if args.limit is not None:
+        corpus = corpus[: args.limit]
+    if not corpus:
+        raise SystemExit(f"no structures matched {args.corpus!r}")
+    n_jobs = os.cpu_count() or 1 if args.n_jobs == -1 else args.n_jobs
+    payload = run(
+        corpus,
+        topofile=args.topofile,
+        n_jobs=n_jobs,
+        checkpoint=Path(args.checkpoint) if args.checkpoint else None,
+    )
+    Path(args.output).write_text(json.dumps(payload, indent=1, default=str))
+    print(f"\n{payload['n_structures']} structures -> {args.output}")
+    for outcome, count in sorted(payload["outcomes"].items()):
+        print(f"  {outcome:<24} {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/autografs/builder.py
+++ b/src/autografs/builder.py
@@ -1287,7 +1287,9 @@ class Autografs:
         return out_dict
 
     def deconstruct(
-        self, source: Structure | str | Path
+        self,
+        source: Structure | str | Path,
+        fuse_parallel_bridges: bool = False,
     ) -> autografs.deconstruct.Deconstruction:
         """Deconstruct a structure into SBUs and identify its net.
 
@@ -1316,7 +1318,11 @@ class Autografs:
         ['pcu']
         >>> result.write_xyz("harvested_sbus.xyz")
         """
-        return autografs.deconstruct.deconstruct(source, topologies=self.topologies)
+        return autografs.deconstruct.deconstruct(
+            source,
+            topologies=self.topologies,
+            fuse_parallel_bridges=fuse_parallel_bridges,
+        )
 
     def harvest(
         self,

--- a/src/autografs/builder.py
+++ b/src/autografs/builder.py
@@ -81,18 +81,79 @@ NELDER_MEAD_MAXITER = 100
 CLOSURE_REGRESSION_TOLERANCE = 0.2
 
 
-def _refine(plan, x0, objective=None):
+# Initial-simplex step for slot-displacement coordinates, in Angstroms
+# (the displacement bases are metric-orthonormalized, so a step IS a
+# distance). scipy seeds coordinates that start at exactly zero with
+# zdelt = 0.00025 - four orders of magnitude below both the cell
+# coordinates' steps and NELDER_MEAD_XATOL - and every displacement
+# starts at exactly zero, so by default the displacement block of the
+# simplex is born nearly degenerate and Nelder-Mead explores it slowly
+# or not at all.
+#
+# Deliberately applied ONLY to the closure-only guard reference, not to
+# the main relaxed solve. Seeding the main solve lets it reach the
+# relaxed objective's true optimum, and on shape-mismatched nets that
+# optimum IS the #197 pathology (measured here: pts x2.88 cell, etb-e
+# x1.58, guard-passing closure) - the shipped DIRECTION_WEIGHT was
+# calibrated against the hobbled explorer, so un-hobbling it without
+# recalibrating the weight re-opens the very failure #197 closed. The
+# closure-only reference is safe to seed: it starts AT the fixed-slot
+# solution and minimizes pure closure, so it can only refine that
+# solution locally, and unseeded it under-converged so badly it lost to
+# a solution its feasible set strictly contains.
+DISPLACEMENT_SIMPLEX_STEP = 0.25
+
+# Whether the MAIN relaxed solve gets the displacement-seeded simplex.
+# Off, by measurement, and not pending a better weight: the seeded
+# sweep (scripts/benchmarks/calibrate_direction_weight.py, first 600
+# CoRE MOF 2025, weights 0.1-2.0) found that at EVERY weight the seeded
+# explorer's optimum on shape-mismatched nets is the #197 pathology
+# (pts x2.9, tbo x2.3, at guard-passing closure - the relaxed candidate
+# closes acceptably, so no closure budget catches it), and no volume
+# screen separates that from genuine corrections (the corpus's largest
+# real win inflates x1.69; the etb-e pathology sits at x1.56). The
+# working design splits the explorers instead: unseeded for the relaxed
+# objective, seeded-from-the-fixed-solution for the closure-only
+# reference. The calibration driver flips this per arm.
+SEED_MAIN_SOLVE = False
+
+
+def _displacement_simplex(plan, x0) -> np.ndarray | None:
+    """A simplex whose displacement steps are bond-scale, not zdelt."""
+    if not plan.n_slot_free:
+        return None
+    x0 = np.asarray(x0, dtype=float)
+    n_cell = plan.cell_param.n_free
+    vertices = [x0]
+    for index in range(x0.size):
+        vertex = x0.copy()
+        if index < n_cell:
+            # scipy's own rule for the cell block, reproduced so the
+            # explicit simplex does not change behaviour there
+            vertex[index] += 0.05 * vertex[index] if vertex[index] else 0.00025
+        else:
+            vertex[index] += DISPLACEMENT_SIMPLEX_STEP
+        vertices.append(vertex)
+    return np.asarray(vertices)
+
+
+def _refine(plan, x0, objective=None, seed_displacements=False):
     """Nelder-Mead over a plan's free parameters."""
     n_free = plan.cell_param.n_free + plan.n_slot_free
+    options = {
+        "xatol": NELDER_MEAD_XATOL,
+        "fatol": NELDER_MEAD_FATOL,
+        "maxiter": NELDER_MEAD_MAXITER * n_free,
+    }
+    if seed_displacements:
+        simplex = _displacement_simplex(plan, x0)
+        if simplex is not None:
+            options["initial_simplex"] = simplex
     result = minimize(
         plan.residual if objective is None else objective,
         x0,
         method="Nelder-Mead",
-        options={
-            "xatol": NELDER_MEAD_XATOL,
-            "fatol": NELDER_MEAD_FATOL,
-            "maxiter": NELDER_MEAD_MAXITER * n_free,
-        },
+        options=options,
     )
     return result.x
 
@@ -185,13 +246,14 @@ def build_framework(
         empty_slots=empty_slots,
     )
     x0 = plan.initial_parameters()
+    relaxation_report: dict | None = None
     if refine_cell and plan.has_pairs:
         # Nelder-Mead on the bond-length pair residual over the
         # crystal system's free parameters only (a cubic net
         # optimizes a single length) plus, under embedding
         # relaxation, the slot displacements; the objective is pure
         # numpy, no object copies per evaluation
-        best_parameters = _refine(plan, x0)
+        best_parameters = _refine(plan, x0, seed_displacements=SEED_MAIN_SOLVE)
         if plan.n_slot_free:
             # freeing the slots must not COST closure (#197). The
             # relaxed objective carries the anchor-direction terms as
@@ -214,10 +276,25 @@ def build_framework(
             # of #174 (measured on the corpus: bond residual 0.091 ->
             # 0.214 A for a 5x better volume ratio), so only a
             # regression past CLOSURE_REGRESSION_TOLERANCE is refused.
+            fixed_parameters = _refine_cell_only(plan, x0)
             candidates = [
                 ("relaxed", best_parameters),
-                ("closure-only", _refine(plan, x0, objective=plan.closure_residual)),
-                ("fixed-slot", _refine_cell_only(plan, x0)),
+                # started from the FIXED-SLOT solution, not x0: its
+                # feasible set contains that solution (displacements at
+                # zero are admissible), so from this start it can only
+                # match or beat the reference. From x0 it routinely
+                # under-converged and lost to the reference it strictly
+                # contains, which quietly disarmed this candidate.
+                (
+                    "closure-only",
+                    _refine(
+                        plan,
+                        fixed_parameters,
+                        objective=plan.closure_residual,
+                        seed_displacements=True,
+                    ),
+                ),
+                ("fixed-slot", fixed_parameters),
             ]
             scored = [
                 (name, params, float(plan.closure_deviations(params).max()))
@@ -225,15 +302,21 @@ def build_framework(
             ]
             relaxed_worst = scored[0][2]
             budget = min(worst for _, _, worst in scored) + CLOSURE_REGRESSION_TOLERANCE
+            kept = "relaxed"
             if relaxed_worst > budget:
-                name, best_parameters, worst = min(scored[1:], key=lambda s: s[2])
+                kept, best_parameters, worst = min(scored[1:], key=lambda s: s[2])
                 logger.debug(
                     f"Embedding relaxation on {topology.name!r} closed to "
                     f"{relaxed_worst:.3f} A, past the "
                     f"{CLOSURE_REGRESSION_TOLERANCE:.2f} A budget over the "
-                    f"best reference; keeping the {name} solution "
+                    f"best reference; keeping the {kept} solution "
                     f"({worst:.3f} A)."
                 )
+            relaxation_report = {
+                "n_slot_free": plan.n_slot_free,
+                "kept": kept,
+                "closure_scores": {name: worst for name, _, worst in scored},
+            }
     else:
         if verbose:
             logger.info("\t[x] No cell refinement performed.")
@@ -281,6 +364,19 @@ def build_framework(
         # verify_net contracts these on the blueprint side, and
         # framework_io / replicated_graph keep the marker alive
         graph.graph["empty_slots"] = list(empty_slots)
+    if relax_embedding:
+        # diagnostic, not a schema commitment: which candidate the
+        # closure guard kept and at what worst-bond score, plus the
+        # EFFECTIVE freedom after empty-slot pinning. n_slot_free == 0
+        # means relaxation was requested and disabled -- without this
+        # marker that build is indistinguishable from a guard rejection,
+        # and a corpus analysis stratified on the blueprint's own count
+        # misattributed exactly that population (the paper's #174 arm).
+        graph.graph["relaxation"] = relaxation_report or {
+            "n_slot_free": plan.n_slot_free,
+            "kept": "fixed-slot" if plan.n_slot_free == 0 else "unrefined",
+            "closure_scores": None,
+        }
     framework = Framework(graph, name=topology.name)
     if min_distance is not None:
         contact = framework.min_contact(cutoff=min_distance)

--- a/src/autografs/cgd.py
+++ b/src/autografs/cgd.py
@@ -316,6 +316,86 @@ def orbit_equivalence_classes(
     return classes
 
 
+def epinet_entries(text: str) -> str:
+    """One EPINET ``.cgd`` file rewritten into the RCSR dialect.
+
+    EPINET's per-net files differ from RCSR's in four ways: a
+    ``PERIODIC_GRAPH`` block precedes the crystal data; several
+    ``CRYSTAL`` blocks describe the same net (a maximal-symmetry
+    barycentric embedding plus relaxed variants); blocks are keyed
+    ``ID``/``ATOM`` where RCSR writes ``NAME``/``NODE``; and payload
+    rows continue a keyword on tab-led lines instead of repeating it.
+    This picks the ``*_maximal`` embedding (the analogue of the RCSR
+    convention the builder consumes) and emits one RCSR-dialect entry
+    that ``read_cgd_data`` parses unchanged. Returns an empty string
+    when no crystal block is found.
+    """
+    keywords = {"ID", "GROUP", "CELL", "ATOM", "EDGE"}
+    blocks: list[dict] = []
+    block: dict | None = None
+    key: str | None = None
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        if stripped == "CRYSTAL":
+            block = {"ID": [], "GROUP": [], "CELL": [], "ATOM": [], "EDGE": []}
+            blocks.append(block)
+            key = None
+            continue
+        if stripped == "END":
+            block = None
+            key = None
+            continue
+        if block is None:
+            continue  # PERIODIC_GRAPH block and anything else
+        tokens = stripped.split()
+        if tokens[0].upper() in keywords:
+            key = tokens[0].upper()
+            payload = tokens[1:]
+        else:
+            payload = tokens
+        if key is not None and payload:
+            block[key].append(payload)
+    if not blocks:
+        return ""
+    chosen = next(
+        (
+            candidate
+            for candidate in blocks
+            if candidate["ID"] and candidate["ID"][0][0].endswith("_maximal")
+        ),
+        blocks[0],
+    )
+    if not (chosen["ID"] and chosen["GROUP"] and chosen["CELL"]):
+        return ""
+    name = chosen["ID"][0][0].removesuffix("_maximal")
+    lines = [
+        "CRYSTAL",
+        f"  NAME {name}",
+        f"  GROUP {chosen['GROUP'][0][0]}",
+        f"  CELL {' '.join(chosen['CELL'][0])}",
+    ]
+    lines += [f"  NODE {' '.join(row)}" for row in chosen["ATOM"]]
+    lines += [f"  EDGE {' '.join(row)}" for row in chosen["EDGE"]]
+    # EPINET writes no EDGE_CENTER lines, but the importer's slot
+    # stitching depends on them: a node's quarter-point dummy pairs
+    # with a 2-connected edge-center slot's coincident dummy, and
+    # without the center the two facing node dummies sit half an edge
+    # apart and pair with nothing (zero quotient edges). Emitting the
+    # midpoints also lands EPINET nets in the same edge-decorated
+    # convention as every RCSR import.
+    for row in chosen["EDGE"]:
+        half = len(row) // 2
+        ends = np.array(
+            [[float(x) for x in row[:half]], [float(x) for x in row[half:]]]
+        )
+        midpoint = ends.mean(axis=0)
+        lines.append(f"  EDGE_CENTER {' '.join(f'{x:.6f}' for x in midpoint)}")
+    lines.append("END")
+    return "\n".join(lines)
+
+
 def read_cgd_data(cgd: str, max_sites: int = MAX_FRAGMENT_SITES) -> dict[str, Topology]:
     """Convert the entries of a CGD file into Topology objects."""
     topologies: dict[str, Topology] = {}
@@ -410,6 +490,23 @@ def main(argv: list[str] | None = None) -> None:
         ),
     )
     parser.add_argument(
+        "--use_epinet",
+        action="store_true",
+        help=(
+            "fetch the EPINET s-net CGD files (license gate, slow polite "
+            "sweep to a local cache) and convert their maximal-symmetry "
+            "embeddings into topologies under their sqc names. EPINET is "
+            "CC BY-NC-ND: the resulting library file is for YOUR local, "
+            "non-commercial use and must not be redistributed."
+        ),
+    )
+    parser.add_argument(
+        "--epinet-max-id",
+        type=int,
+        default=None,
+        help="highest sqc id to sweep (default: the full catalogue).",
+    )
+    parser.add_argument(
         "--accept-licenses",
         action="store_true",
         help="accept external sources' terms non-interactively (batch use).",
@@ -453,6 +550,26 @@ def main(argv: list[str] | None = None) -> None:
             accept_licenses=args.accept_licenses,
         )
         topologies.update(topologies_from_tetrahedral_cifs(cifs))
+    if args.use_epinet:
+        from autografs.fetch import EPINET_MAX_ID, fetch_epinet_cgds
+
+        cgds = fetch_epinet_cgds(
+            cache_dir=Path(args.cache_dir) if args.cache_dir else None,
+            accept_licenses=args.accept_licenses,
+            max_id=args.epinet_max_id or EPINET_MAX_ID,
+        )
+        logger.info(f"Converting {len(cgds)} EPINET s-nets (maximal embeddings).")
+        entries = "\n".join(
+            entry
+            for path in sorted(cgds.values())
+            if (entry := epinet_entries(path.read_text(encoding="utf-8")))
+        )
+        topologies.update(read_cgd_data(entries, max_sites=args.max_connectivity))
+        logger.warning(
+            "The output library now contains EPINET-derived entries "
+            "(CC BY-NC-ND): keep it LOCAL and non-commercial - do not "
+            "redistribute it or bundle it into anything you share."
+        )
 
     if args.output.endswith((".json", ".json.gz")):
         topology_io.save_topologies(topologies, args.output)

--- a/src/autografs/deconstruct.py
+++ b/src/autografs/deconstruct.py
@@ -87,6 +87,7 @@ if TYPE_CHECKING:
     from autografs.topology import Topology
 
 __all__ = [
+    "BlueprintRecipe",
     "BuildingUnit",
     "Deconstruction",
     "RodUnit",
@@ -135,6 +136,34 @@ class BuildingUnit:
     kind: str
     atom_indices: list[int]
     n_connections: int
+
+
+@dataclass
+class BlueprintRecipe:
+    """The geometric recipe a self-templated blueprint is built from.
+
+    Everything ``extract_topology.topology_from_deconstruction`` needs
+    to erect the structure's OWN blueprint - one slot per building
+    unit at its real position, one shared connection point per cut
+    bond - without re-perceiving anything. Fractional coordinates are
+    in each unit's home-cell gauge (the ``_unit_images`` convention
+    shared with autografs.net), so the fractional difference between a
+    cut's two midpoint expressions is exactly the cut's integer
+    voltage.
+
+    Attributes
+    ----------
+    centers : list[tuple[float, float, float]]
+        Home-cell fractional centroid per finite unit, indexed like
+        ``Deconstruction.units``.
+    cuts : list[tuple[int, int, tuple, tuple]]
+        One entry per cut bond: ``(unit_a, unit_b, midpoint_in_a,
+        midpoint_in_b)``, the same physical bond midpoint expressed in
+        each end's home gauge (fractional).
+    """
+
+    centers: list[tuple[float, float, float]]
+    cuts: list[tuple[int, int, tuple, tuple]]
 
 
 @dataclass
@@ -256,6 +285,11 @@ class Deconstruction:
         Number of parallel-bridge bundles fused into composite units
         (0 unless ``fuse_parallel_bridges`` was requested and parallel
         ditopic bridges were found; see ``_fuse_parallel_bridges``).
+    blueprint : BlueprintRecipe or None
+        The geometric recipe for the structure's own blueprint
+        (self-templated round trips, coverage plan stage 3). None when
+        the structure contains rod units, whose blueprint form needs
+        slot runs rather than point slots.
     """
 
     structure: Structure
@@ -270,6 +304,7 @@ class Deconstruction:
     topological_candidates: list[str] = field(default_factory=list)
     poe_merged: bool = False
     fused_bridges: int = 0
+    blueprint: BlueprintRecipe | None = None
 
     @property
     def is_catenated(self) -> bool:
@@ -1495,6 +1530,33 @@ def deconstruct(
         cuts, atom_to_unit, unwraps, unit_images, poe_vertex, poe_images, rod_links
     )
 
+    # the self-templated blueprint recipe (coverage plan stage 3): unit
+    # centroids and cut midpoints in each unit's home gauge, so the
+    # structure's own blueprint can be erected without re-perception.
+    # Rod frameworks need slot runs, not point slots - no recipe yet.
+    blueprint_recipe: BlueprintRecipe | None = None
+    if not rods:
+        recipe_centers = []
+        for k, unit in enumerate(units):
+            centroid = np.mean([frac[i] + unwraps[k][i] for i in sorted(unit)], axis=0)
+            home = centroid - unit_images[k]
+            recipe_centers.append((float(home[0]), float(home[1]), float(home[2])))
+        recipe_cuts = []
+        for u, v, jimage in cuts:
+            shift = np.asarray(jimage, dtype=float)
+            ka, kb = atom_to_unit[u], atom_to_unit[v]
+            mid_a = (frac[u] + frac[v] + shift) / 2.0 + unwraps[ka][u] - unit_images[ka]
+            mid_b = (frac[u] + frac[v] - shift) / 2.0 + unwraps[kb][v] - unit_images[kb]
+            recipe_cuts.append(
+                (
+                    ka,
+                    kb,
+                    (float(mid_a[0]), float(mid_a[1]), float(mid_a[2])),
+                    (float(mid_b[0]), float(mid_b[1]), float(mid_b[2])),
+                )
+            )
+        blueprint_recipe = BlueprintRecipe(centers=recipe_centers, cuts=recipe_cuts)
+
     subframework_nets: list[NetMatches] = []
     net_candidates: list[str] = []
     topological_candidates: list[str] = []
@@ -1574,4 +1636,5 @@ def deconstruct(
         topological_candidates=topological_candidates,
         poe_merged=poe_merged,
         fused_bridges=fused_bridges,
+        blueprint=blueprint_recipe,
     )

--- a/src/autografs/deconstruct.py
+++ b/src/autografs/deconstruct.py
@@ -153,17 +153,29 @@ class BlueprintRecipe:
 
     Attributes
     ----------
-    centers : list[tuple[float, float, float]]
+    centers : list[tuple[float, float, float] or None]
         Home-cell fractional centroid per finite unit, indexed like
-        ``Deconstruction.units``.
+        ``Deconstruction.units`` when the structure is rod-free. When
+        rods are present the indexing follows the raw unit partition
+        (rods included), and a rod unit's entry is None - an infinite
+        unit has no centroid; its geometry lives in ``rod_poe``.
     cuts : list[tuple[int, int, tuple, tuple]]
         One entry per cut bond: ``(unit_a, unit_b, midpoint_in_a,
         midpoint_in_b)``, the same physical bond midpoint expressed in
-        each end's home gauge (fractional).
+        each end's home gauge (fractional). For a rod end the gauge is
+        that PoE atom's own home image (the ``_unit_quotient``
+        convention), so voltages still fall out of fractional
+        differences.
+    rod_poe : dict[int, list[tuple[int, tuple]]] or None
+        Per rod unit index: the points of extension as
+        ``(atom index, home-gauge fractional position)`` in axial
+        order - the node-slot chain a self-derived run is built from.
+        None for rod-free structures.
     """
 
-    centers: list[tuple[float, float, float]]
+    centers: list[tuple[float, float, float] | None]
     cuts: list[tuple[int, int, tuple, tuple]]
+    rod_poe: dict[int, list[tuple[int, tuple]]] | None = None
 
 
 @dataclass
@@ -287,9 +299,11 @@ class Deconstruction:
         ditopic bridges were found; see ``_fuse_parallel_bridges``).
     blueprint : BlueprintRecipe or None
         The geometric recipe for the structure's own blueprint
-        (self-templated round trips, coverage plan stage 3). None when
-        the structure contains rod units, whose blueprint form needs
-        slot runs rather than point slots.
+        (self-templated round trips, coverage plan stage 3). Always
+        recorded; rod units contribute their points of extension
+        (``rod_poe``) instead of a centroid. The point-slot
+        constructor (``topology_from_deconstruction``) consumes the
+        rod-free case; the rod case awaits the slot-run constructor.
     """
 
     structure: Structure
@@ -1531,31 +1545,58 @@ def deconstruct(
     )
 
     # the self-templated blueprint recipe (coverage plan stage 3): unit
-    # centroids and cut midpoints in each unit's home gauge, so the
+    # centroids and cut midpoints in each end's home gauge, so the
     # structure's own blueprint can be erected without re-perception.
-    # Rod frameworks need slot runs, not point slots - no recipe yet.
-    blueprint_recipe: BlueprintRecipe | None = None
-    if not rods:
-        recipe_centers = []
-        for k, unit in enumerate(units):
-            centroid = np.mean([frac[i] + unwraps[k][i] for i in sorted(unit)], axis=0)
-            home = centroid - unit_images[k]
-            recipe_centers.append((float(home[0]), float(home[1]), float(home[2])))
-        recipe_cuts = []
-        for u, v, jimage in cuts:
-            shift = np.asarray(jimage, dtype=float)
-            ka, kb = atom_to_unit[u], atom_to_unit[v]
-            mid_a = (frac[u] + frac[v] + shift) / 2.0 + unwraps[ka][u] - unit_images[ka]
-            mid_b = (frac[u] + frac[v] - shift) / 2.0 + unwraps[kb][v] - unit_images[kb]
-            recipe_cuts.append(
-                (
-                    ka,
-                    kb,
-                    (float(mid_a[0]), float(mid_a[1]), float(mid_a[2])),
-                    (float(mid_b[0]), float(mid_b[1]), float(mid_b[2])),
-                )
+    # Rod units contribute their points of extension instead of a
+    # centroid, in the per-atom PoE gauge the quotient already uses.
+    def _end_image(atom: int) -> np.ndarray:
+        if atom in poe_images:
+            return poe_images[atom]
+        return unit_images[atom_to_unit[atom]]
+
+    recipe_centers: list[tuple[float, float, float] | None] = []
+    for k, unit in enumerate(units):
+        if k in rod_indices:
+            recipe_centers.append(None)
+            continue
+        centroid = np.mean([frac[i] + unwraps[k][i] for i in sorted(unit)], axis=0)
+        home = centroid - unit_images[k]
+        recipe_centers.append((float(home[0]), float(home[1]), float(home[2])))
+    recipe_cuts = []
+    for u, v, jimage in cuts:
+        shift = np.asarray(jimage, dtype=float)
+        ka, kb = atom_to_unit[u], atom_to_unit[v]
+        mid_a = (frac[u] + frac[v] + shift) / 2.0 + unwraps[ka][u] - _end_image(u)
+        mid_b = (frac[u] + frac[v] - shift) / 2.0 + unwraps[kb][v] - _end_image(v)
+        recipe_cuts.append(
+            (
+                ka,
+                kb,
+                (float(mid_a[0]), float(mid_a[1]), float(mid_a[2])),
+                (float(mid_b[0]), float(mid_b[1]), float(mid_b[2])),
             )
-        blueprint_recipe = BlueprintRecipe(centers=recipe_centers, cuts=recipe_cuts)
+        )
+    recipe_rod_poe: dict[int, list[tuple[int, tuple]]] | None = None
+    if rods:
+        recipe_rod_poe = {}
+        for k in sorted(rod_indices):
+            entries = []
+            for atom in rod_poe[k]:
+                home_frac = frac[atom] + unwraps[k][atom] - poe_images[atom]
+                entries.append(
+                    (
+                        atom,
+                        (
+                            float(home_frac[0]),
+                            float(home_frac[1]),
+                            float(home_frac[2]),
+                        ),
+                    )
+                )
+            recipe_rod_poe[k] = entries
+    blueprint_recipe = BlueprintRecipe(
+        centers=recipe_centers, cuts=recipe_cuts, rod_poe=recipe_rod_poe
+    )
 
     subframework_nets: list[NetMatches] = []
     net_candidates: list[str] = []

--- a/src/autografs/deconstruct.py
+++ b/src/autografs/deconstruct.py
@@ -237,6 +237,21 @@ class Deconstruction:
         fragment, so they appear here instead of ``fragments`` /
         ``units``; in ``quotient_edges`` each rod is replaced by its
         points of extension (see RodUnit).
+    topological_candidates : list[str]
+        The identification consensus BEFORE the rod-compatibility
+        filter (#215). Identical to ``net_candidates`` for finite
+        frameworks; for rod frameworks it may name nets whose channels
+        the harvested rod cannot occupy - a statement about the
+        quotient graph alone, kept so "matched but rod-incompatible"
+        is distinguishable from "matched nothing".
+    poe_merged : bool
+        True when the candidates came from the grouped
+        points-of-extension convention: cut endpoints of one rod at
+        the same axial height merged into a single PoE vertex
+        (O'Keeffe's convention for e.g. paddlewheel chains). Tried
+        only as a fallback when the per-atom convention identifies
+        nothing that survives the rod filter, so existing assignments
+        never silently move.
     """
 
     structure: Structure
@@ -248,6 +263,8 @@ class Deconstruction:
     subframework_nets: list[NetMatches] = field(default_factory=list)
     guest_formulas: list[str] = field(default_factory=list)
     rod_units: list[RodUnit] = field(default_factory=list)
+    topological_candidates: list[str] = field(default_factory=list)
+    poe_merged: bool = False
 
     @property
     def is_catenated(self) -> bool:
@@ -1007,6 +1024,80 @@ def _rod_compatible_nets(
     return kept
 
 
+# Cut endpoints on one rod within this axial distance (Angstroms) are
+# one point of extension under the grouped convention: a paddlewheel
+# ring's four carboxylate carbons sit at one height and O'Keeffe counts
+# them as one PoE, while the per-atom convention gives them four
+# vertices and a quotient no library net matches. Measured on a sample
+# of unidentified rod structures, grouping is insensitive between 0.5
+# and 1.0 A; the value keeps genuinely consecutive PoE (>1 A apart on
+# every rod inspected) distinct.
+POE_MERGE_TOLERANCE = 0.5
+
+
+def _merged_poe_maps(
+    frac: np.ndarray,
+    lattice_matrix: np.ndarray,
+    unwraps: list[dict[int, np.ndarray]],
+    rods: list[RodUnit],
+    rod_unit_indices: list[int],
+    next_vertex: int,
+) -> tuple[dict[int, int], dict[int, np.ndarray], list[tuple[int, int, np.ndarray]]]:
+    """Per-atom PoE maps under the grouped (same-axial-height) convention.
+
+    Returns ``(poe_vertex, poe_images, rod_links)`` in the exact shape
+    ``_unit_quotient`` consumes. Groups are clustered along the axis at
+    ``POE_MERGE_TOLERANCE``; a cluster straddling the repeat boundary is
+    folded onto the first group one lattice generator back, so the wrap
+    link never counts one chemical position twice.
+    """
+    poe_vertex: dict[int, int] = {}
+    poe_images: dict[int, np.ndarray] = {}
+    rod_links: list[tuple[int, int, np.ndarray]] = []
+    for k, rod in zip(rod_unit_indices, rods, strict=True):
+        generator = np.asarray(rod.generator, dtype=int)
+        axis_hat = np.asarray(rod.axis, dtype=float)
+        heights = [
+            float(((frac[atom] + unwraps[k][atom]) @ lattice_matrix) @ axis_hat)
+            for atom in rod.poe_indices
+        ]
+        groups: list[dict] = []
+        for atom, z in zip(rod.poe_indices, heights, strict=True):
+            if groups and z - groups[-1]["z"] <= POE_MERGE_TOLERANCE:
+                groups[-1]["atoms"].append((atom, False))
+            else:
+                groups.append({"z": z, "atoms": [(atom, False)]})
+        if (
+            len(groups) > 1
+            and (heights[0] + rod.repeat_length) - groups[-1]["z"]
+            <= POE_MERGE_TOLERANCE
+        ):
+            for atom, _ in groups[-1]["atoms"]:
+                groups[0]["atoms"].append((atom, True))
+            groups.pop()
+        representatives = []
+        for group in groups:
+            positions = []
+            for atom, wrapped in group["atoms"]:
+                position = frac[atom] + unwraps[k][atom]
+                if wrapped:
+                    position = position - generator
+                positions.append(position)
+            image, _ = _split_image(np.mean(positions, axis=0))
+            for atom, _wrapped in group["atoms"]:
+                poe_vertex[atom] = next_vertex
+                poe_images[atom] = image
+            next_vertex += 1
+            representatives.append(group["atoms"][0][0])
+        if len(representatives) == 1:
+            rod_links.append((representatives[0], representatives[0], generator))
+        else:
+            for a, b in zip(representatives, representatives[1:], strict=False):
+                rod_links.append((a, b, np.zeros(3, dtype=int)))
+            rod_links.append((representatives[-1], representatives[0], generator))
+    return poe_vertex, poe_images, rod_links
+
+
 def _identify_subframeworks(
     subframework_edges: list[Counter[Edge]],
     topologies: Mapping[str, Topology],
@@ -1211,27 +1302,69 @@ def deconstruct(
 
     subframework_nets: list[NetMatches] = []
     net_candidates: list[str] = []
+    topological_candidates: list[str] = []
+    poe_merged = False
     if topologies is not None:
-        subframework_nets, net_candidates = _identify_subframeworks(
-            [
-                _unit_quotient(
-                    cuts,
-                    atom_to_unit,
-                    unwraps,
-                    unit_images,
-                    poe_vertex,
-                    poe_images,
-                    rod_links,
-                    atoms=component,
-                )
-                for component in periodic_components
-            ],
-            topologies,
+
+        def _identify_with(
+            vertex_map: dict[int, int],
+            image_map: dict[int, np.ndarray],
+            links: list[tuple[int, int, np.ndarray]],
+        ) -> tuple[list[NetMatches], list[str]]:
+            return _identify_subframeworks(
+                [
+                    _unit_quotient(
+                        cuts,
+                        atom_to_unit,
+                        unwraps,
+                        unit_images,
+                        vertex_map,
+                        image_map,
+                        links,
+                        atoms=component,
+                    )
+                    for component in periodic_components
+                ],
+                topologies,
+            )
+
+        subframework_nets, net_candidates = _identify_with(
+            poe_vertex, poe_images, rod_links
         )
+        topological_candidates = list(net_candidates)
         if rods:
             net_candidates = _rod_compatible_nets(
                 structure, rods, net_candidates, topologies
             )
+            if not net_candidates:
+                # fallback tier: the per-atom PoE convention found
+                # nothing the rod filter accepts, so retry with cut
+                # endpoints grouped by axial height (a paddlewheel
+                # ring's four carboxylate carbons become ONE point of
+                # extension, which is how O'Keeffe counts them).
+                # Fallback only - a structure the primary convention
+                # answers, buildably, never moves.
+                merged_maps = _merged_poe_maps(
+                    frac,
+                    structure.lattice.matrix,
+                    unwraps,
+                    rods,
+                    sorted(rod_indices),
+                    len(units),
+                )
+                if len(merged_maps[0]) > len(set(merged_maps[0].values())):
+                    merged_nets, merged_candidates = _identify_with(*merged_maps)
+                    if merged_candidates:
+                        subframework_nets = merged_nets
+                        topological_candidates = list(merged_candidates)
+                        poe_merged = True
+                        logger.info(
+                            "\t[x] grouped points-of-extension tier "
+                            f"matched: {', '.join(merged_candidates)}."
+                        )
+                        net_candidates = _rod_compatible_nets(
+                            structure, rods, merged_candidates, topologies
+                        )
 
     return Deconstruction(
         structure=structure,
@@ -1243,4 +1376,6 @@ def deconstruct(
         n_periodic_components=n_periodic,
         subframework_nets=subframework_nets,
         guest_formulas=sorted(guest_formulas),
+        topological_candidates=topological_candidates,
+        poe_merged=poe_merged,
     )

--- a/src/autografs/deconstruct.py
+++ b/src/autografs/deconstruct.py
@@ -252,6 +252,10 @@ class Deconstruction:
         only as a fallback when the per-atom convention identifies
         nothing that survives the rod filter, so existing assignments
         never silently move.
+    fused_bridges : int
+        Number of parallel-bridge bundles fused into composite units
+        (0 unless ``fuse_parallel_bridges`` was requested and parallel
+        ditopic bridges were found; see ``_fuse_parallel_bridges``).
     """
 
     structure: Structure
@@ -265,6 +269,7 @@ class Deconstruction:
     rod_units: list[RodUnit] = field(default_factory=list)
     topological_candidates: list[str] = field(default_factory=list)
     poe_merged: bool = False
+    fused_bridges: int = 0
 
     @property
     def is_catenated(self) -> bool:
@@ -881,6 +886,174 @@ def _extract_fragments(
     return fragments, built_units
 
 
+def _cut_voltage(
+    cut: tuple[int, int, tuple[int, int, int]],
+    atom_to_unit: dict[int, int],
+    unwraps: list[dict[int, np.ndarray]],
+    unit_images: dict[int, np.ndarray],
+) -> np.ndarray:
+    """Voltage of one cut, oriented u -> v, in the _unit_quotient gauge."""
+    u, v, jimage = cut
+    shift = np.asarray(jimage, dtype=int) + (
+        unwraps[atom_to_unit[u]][u] - unwraps[atom_to_unit[v]][v]
+    )
+    return np.asarray(
+        unit_images[atom_to_unit[v]] + shift - unit_images[atom_to_unit[u]]
+    )
+
+
+def _fuse_parallel_bridges(
+    structure: Structure,
+    units: list[set[int]],
+    cuts: list[tuple[int, int, tuple[int, int, int]]],
+    atom_to_unit: dict[int, int],
+    unwraps: list[dict[int, np.ndarray]],
+    rod_indices: set[int],
+    generators: dict[int, np.ndarray],
+) -> tuple[
+    list[set[int]],
+    list[tuple[int, int, tuple[int, int, int]]],
+    dict[int, int],
+    list[dict[int, np.ndarray]],
+    set[int],
+    dict[int, np.ndarray],
+    int,
+]:
+    """Fuse parallel ditopic bridges into composite building units.
+
+    A pair of identical ditopic linkers bridging the same two units
+    through the same net voltage is one edge of the crystal's net -
+    identification's coordination-sequence walk counts it once - but
+    the mapper counts every dummy on the doubled node, so the structure
+    falls between the two conventions (measured on the census: the
+    dominant ``no_mapping`` mechanism, 133 structures failing at
+    exactly twice every blocked slot's arm count). Fusing the bundle
+    into one composite unit with one connection per end restores
+    agreement: the node's fragment carries one arm per bundle, the
+    composite carries both molecules (so composition stays exact), and
+    the rebuilt framework realizes one bond per merged end - a
+    documented convention, not an oversight.
+
+    Only metal-free, exactly-ditopic units of identical composition
+    bridging the same finite unit pair at the same contracted voltage
+    are fused. Everything else - including rod-adjacent bridges - is
+    left alone. Returns the rewritten
+    ``(units, cuts, atom_to_unit, unwraps, rod_indices, generators,
+    n_bundles)``; when no bundle exists the inputs come back unchanged
+    with ``n_bundles = 0``.
+    """
+    frac = structure.frac_coords
+    unit_images = _unit_images(frac, units, unwraps, rod_indices)
+
+    # per-unit cut inventory
+    unit_cuts: dict[int, list[int]] = defaultdict(list)
+    for index, (u, v, _jimage) in enumerate(cuts):
+        unit_cuts[atom_to_unit[u]].append(index)
+        unit_cuts[atom_to_unit[v]].append(index)
+
+    def linker_end(cut_index: int, linker: int) -> tuple[int, int, int, np.ndarray]:
+        """(linker atom, partner atom, partner unit, voltage linker->partner)."""
+        u, v, jimage = cuts[cut_index]
+        if atom_to_unit[u] == linker:
+            voltage = _cut_voltage(cuts[cut_index], atom_to_unit, unwraps, unit_images)
+            return u, v, atom_to_unit[v], voltage
+        voltage = -_cut_voltage(cuts[cut_index], atom_to_unit, unwraps, unit_images)
+        return v, u, atom_to_unit[u], voltage
+
+    def partner_of(cut_index: int, linker: int) -> int:
+        u, v, _jimage = cuts[cut_index]
+        return atom_to_unit[v] if atom_to_unit[u] == linker else atom_to_unit[u]
+
+    bundles: dict[tuple, list[int]] = defaultdict(list)
+    for k, unit in enumerate(units):
+        if k in rod_indices or len(unit_cuts[k]) != 2:
+            continue
+        if any(_is_metal(structure, atom) for atom in unit):
+            continue
+        # rod partners carry per-atom images, not a unit home image, so
+        # the voltage bookkeeping below does not apply to them
+        if any(partner_of(index, k) in rod_indices for index in unit_cuts[k]):
+            continue
+        ends = [linker_end(index, k) for index in unit_cuts[k]]
+        # contracted edge this linker decorates, canonicalized so the
+        # two traversal directions give one key; composition joins the
+        # key so only identical molecules fuse
+        (_, _, unit_a, voltage_a), (_, _, unit_b, voltage_b) = ends
+        edge = _canonical(unit_a, unit_b, voltage_b - voltage_a)
+        formula = tuple(
+            sorted(Counter(structure[i].specie.symbol for i in unit).items())
+        )
+        bundles[(edge, formula)].append(k)
+
+    fused = {key: members for key, members in bundles.items() if len(members) > 1}
+    if not fused:
+        return units, cuts, atom_to_unit, unwraps, rod_indices, generators, 0
+
+    removed: set[int] = set()
+    dropped_cuts: set[int] = set()
+    new_units = [set(unit) for unit in units]
+    new_unwraps = [dict(unwrap) for unwrap in unwraps]
+
+    def anchor_shift(linker: int, anchor_unit: int) -> np.ndarray:
+        """Gauge shift taking the linker's unwrap into the anchor's."""
+        for index in unit_cuts[linker]:
+            atom, partner, partner_unit, _voltage = linker_end(index, linker)
+            if partner_unit == anchor_unit:
+                u, _v, jimage = cuts[index]
+                step = np.asarray(jimage, dtype=int)
+                # pymatgen bond semantics: v at image (X + jimage)
+                # bonds u at image X, so anchoring on the partner's
+                # unwrapped image places the linker atom one step
+                # against (or along) the stored offset
+                if atom == u:
+                    image = new_unwraps[partner_unit][partner] - step
+                else:
+                    image = new_unwraps[partner_unit][partner] + step
+                return np.asarray(image - unwraps[linker][atom])
+        raise DeconstructionError(
+            "parallel-bridge fusion lost its anchor cut"
+        )  # pragma: no cover - bundle members bridge the anchor by construction
+
+    for (edge, _formula), members in sorted(fused.items(), key=lambda kv: kv[1]):
+        survivor, *merged = sorted(members)
+        anchor_unit = edge[0]
+        base = anchor_shift(survivor, anchor_unit)
+        for linker in merged:
+            shift = anchor_shift(linker, anchor_unit) - base
+            for atom in units[linker]:
+                new_units[survivor].add(atom)
+                new_unwraps[survivor][atom] = unwraps[linker][atom] + shift
+            removed.add(linker)
+            dropped_cuts.update(unit_cuts[linker])
+        logger.info(
+            f"\t[x] fused {len(members)} parallel ditopic bridges into one "
+            f"composite unit ({len(new_units[survivor])} atoms)."
+        )
+
+    keep = [k for k in range(len(new_units)) if k not in removed]
+    remap = {old: new for new, old in enumerate(keep)}
+    units_out = [new_units[k] for k in keep]
+    unwraps_out = [new_unwraps[k] for k in keep]
+    atom_to_unit_out = {
+        atom: remap[k]
+        for k, unit in enumerate(new_units)
+        if k in remap
+        for atom in unit
+    }
+    cuts_out = [cut for index, cut in enumerate(cuts) if index not in dropped_cuts]
+    rod_out = {remap[k] for k in rod_indices}
+    generators_out = {remap[k]: g for k, g in generators.items()}
+    return (
+        units_out,
+        cuts_out,
+        atom_to_unit_out,
+        unwraps_out,
+        rod_out,
+        generators_out,
+        len(fused),
+    )
+
+
 def _unit_images(
     frac: np.ndarray,
     units: list[set[int]],
@@ -1130,6 +1303,7 @@ def _identify_subframeworks(
 def deconstruct(
     source: Structure | str | Path,
     topologies: Mapping[str, Topology] | None = None,
+    fuse_parallel_bridges: bool = False,
 ) -> Deconstruction:
     """Deconstruct a periodic structure into SBUs and its net.
 
@@ -1142,6 +1316,13 @@ def deconstruct(
         Topology library to identify the net against (e.g.
         Autografs.topologies). When None, net identification is
         skipped and ``net_candidates`` stays empty.
+    fuse_parallel_bridges : bool, optional
+        Fuse parallel ditopic bridges - identical linkers joining the
+        same unit pair through the same net voltage - into one
+        composite building unit with one connection per end (see
+        ``_fuse_parallel_bridges``). Off by default: it changes what a
+        building unit is, so callers opt in (the round-trip census uses
+        it as a fallback when the standard units admit no mapping).
 
     Returns
     -------
@@ -1201,6 +1382,20 @@ def deconstruct(
                 "layer); only molecular and rod (1-periodic) building "
                 "units are supported."
             )
+
+    fused_bridges = 0
+    if fuse_parallel_bridges:
+        (
+            units,
+            cuts,
+            atom_to_unit,
+            unwraps,
+            rod_indices,
+            generators,
+            fused_bridges,
+        ) = _fuse_parallel_bridges(
+            structure, units, cuts, atom_to_unit, unwraps, rod_indices, generators
+        )
 
     fragments, built_units = _extract_fragments(
         structure, units, node_atoms, cuts, atom_to_unit, unwraps, rod_indices
@@ -1378,4 +1573,5 @@ def deconstruct(
         guest_formulas=sorted(guest_formulas),
         topological_candidates=topological_candidates,
         poe_merged=poe_merged,
+        fused_bridges=fused_bridges,
     )

--- a/src/autografs/extract_topology.py
+++ b/src/autografs/extract_topology.py
@@ -49,7 +49,11 @@ from autografs.topology import Topology
 if TYPE_CHECKING:
     from autografs.deconstruct import Deconstruction
 
-__all__ = ["topology_from_deconstruction", "topology_from_tetrahedral"]
+__all__ = [
+    "rod_topology_from_deconstruction",
+    "topology_from_deconstruction",
+    "topology_from_tetrahedral",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -319,3 +323,159 @@ def topology_from_deconstruction(
         ),
         mapping,
     )
+
+
+def rod_topology_from_deconstruction(result: Deconstruction, name: str = "self-rod"):
+    """The rod structure's own blueprint, its run, and its mappings.
+
+    The slot-run counterpart of ``topology_from_deconstruction``
+    (coverage plan, rod self-templates): the single rod's points of
+    extension become node slots along the crystal's own axis, finite
+    units become lateral slots, and the run handed back is built
+    directly from the rod's measured geometry - no run detection, no
+    library. ``build_rod_framework(topology, rod_fragment, laterals,
+    run=run)`` then reuses the validated rod builder unchanged.
+
+    Returns
+    -------
+    tuple
+        ``(topology, run, lateral_mapping)`` where ``run`` is a
+        ``SlotRun`` (screwless rod) or ``HelicalRun`` (its screw from
+        the rod's own canonical repeat) and ``lateral_mapping`` maps
+        lateral slot index -> fragment name (the identity assignment).
+
+    Raises
+    ------
+    TopologyExtractionError
+        For structures without exactly one rod and one periodic
+        component (the multi-rod and catenated-rod cases await their
+        own increment), or when a cut cannot be attributed to a point
+        of extension unambiguously.
+    """
+    from autografs.net import HelicalRun, SlotRun
+    from autografs.rods import rod_fragment as _rod_fragment
+
+    recipe = result.blueprint
+    if recipe is None or not recipe.rod_poe:
+        raise TopologyExtractionError("No rod recipe on this deconstruction.")
+    if len(result.rod_units) != 1 or result.n_periodic_components != 1:
+        raise TopologyExtractionError(
+            "Rod self-templates currently take exactly one rod and one "
+            "periodic component."
+        )
+    (rod_index, poe_entries), *_ = recipe.rod_poe.items()
+    rod_unit = result.rod_units[0]
+    lattice = result.structure.lattice
+
+    # attribute each rod-end cut to its point of extension: the
+    # midpoint sits half a bond from its own anchor and full bond
+    # lengths from any other PoE atom, so nearest-position wins; an
+    # ambiguous case is refused, not guessed
+    poe_carts = {
+        atom: lattice.get_cartesian_coords(np.asarray(pos, dtype=float))
+        for atom, pos in poe_entries
+    }
+    unit_is_rod = [center is None for center in recipe.centers]
+
+    def poe_of(mid_frac: tuple) -> int:
+        mid = lattice.get_cartesian_coords(np.asarray(mid_frac, dtype=float))
+        ranked = sorted(
+            poe_carts, key=lambda atom: float(np.linalg.norm(poe_carts[atom] - mid))
+        )
+        if len(ranked) > 1:
+            best = float(np.linalg.norm(poe_carts[ranked[0]] - mid))
+            runner = float(np.linalg.norm(poe_carts[ranked[1]] - mid))
+            if runner - best < 0.2:
+                raise TopologyExtractionError(
+                    f"Ambiguous cut-to-PoE attribution ({best:.2f} vs {runner:.2f} A)."
+                )
+        return ranked[0]
+
+    poe_cuts: dict[int, list[tuple[int, tuple]]] = {atom: [] for atom, _ in poe_entries}
+    lateral_cuts: dict[int, list[tuple[int, tuple]]] = {}
+    for cut_index, (unit_a, unit_b, mid_a, mid_b) in enumerate(recipe.cuts):
+        for unit, mid in ((unit_a, mid_a), (unit_b, mid_b)):
+            if unit_is_rod[unit]:
+                poe_cuts[poe_of(mid)].append((cut_index, mid))
+            else:
+                lateral_cuts.setdefault(unit, []).append((cut_index, mid))
+
+    slots: list[Fragment] = []
+    lateral_mapping: dict[int, str] = {}
+    # recipe indices follow the RAW unit partition (rod included);
+    # result.units is the compacted finite list in the same order
+    finite_raw = [index for index, is_rod in enumerate(unit_is_rod) if not is_rod]
+    for k, building_unit in zip(finite_raw, result.units, strict=True):
+        connections = lateral_cuts.get(k, [])
+        if not connections:
+            raise TopologyExtractionError(
+                f"Lateral unit {k} ({building_unit.name}) carries no cut bond."
+            )
+        center = np.asarray(recipe.centers[k], dtype=float)
+        species = [get_el_sp(len(connections))] + ["X"] * len(connections)
+        frac_coords = [center] + [
+            np.asarray(mid, dtype=float) for _index, mid in connections
+        ]
+        carts = [lattice.get_cartesian_coords(fc) for fc in frac_coords]
+        tags = [0] + [cut_index + 1 for cut_index, _mid in connections]
+        slots.append(
+            Fragment(
+                atoms=Molecule(species, carts, site_properties={"tags": tags}),
+                name=f"slot_{k}",
+            )
+        )
+        lateral_mapping[len(slots) - 1] = building_unit.name
+
+    run_slots: list[int] = []
+    for atom, pos in poe_entries:
+        connections = poe_cuts[atom]
+        if not connections:
+            raise TopologyExtractionError(f"Point of extension {atom} carries no cut.")
+        center = lattice.get_cartesian_coords(np.asarray(pos, dtype=float))
+        species = [get_el_sp(len(connections))] + ["X"] * len(connections)
+        carts = [center] + [
+            lattice.get_cartesian_coords(np.asarray(mid, dtype=float))
+            for _index, mid in connections
+        ]
+        tags = [0] + [cut_index + 1 for cut_index, _mid in connections]
+        slots.append(
+            Fragment(
+                atoms=Molecule(species, carts, site_properties={"tags": tags}),
+                name=f"poe_{atom}",
+            )
+        )
+        run_slots.append(len(slots) - 1)
+
+    topology = Topology(
+        name=name,
+        slots=slots,
+        cell=lattice,
+        equivalence_classes=list(range(len(slots))),
+        spacegroup_number=1,
+        is_2d=False,
+    )
+
+    fragment = _rod_fragment(result.structure, rod_unit, name="self_rod")
+    direction = (
+        int(rod_unit.generator[0]),
+        int(rod_unit.generator[1]),
+        int(rod_unit.generator[2]),
+    )
+    period = float(rod_unit.repeat_length)
+    if fragment.repeat.screw_order > 1:
+        axis_point = np.mean([poe_carts[atom] for atom, _ in poe_entries], axis=0)
+        run: SlotRun | HelicalRun = HelicalRun(
+            direction=direction,
+            slots=tuple(run_slots),
+            period=period,
+            screw_angle=float(fragment.repeat.screw_angle),
+            screw_order=int(fragment.repeat.screw_order),
+            axis_point=(
+                float(axis_point[0]),
+                float(axis_point[1]),
+                float(axis_point[2]),
+            ),
+        )
+    else:
+        run = SlotRun(direction=direction, slots=tuple(run_slots), period=period)
+    return topology, run, lateral_mapping, fragment

--- a/src/autografs/extract_topology.py
+++ b/src/autografs/extract_topology.py
@@ -18,26 +18,38 @@ shared with the CGD path rather than re-implemented.
 
 Interrupted frameworks (terminal OH/F on a T site, IZA dash codes) are
 rejected: a T atom with fewer than four bridges has no 4-c vertex, and
-the extracted net would not be the framework type. General MOF
-topology extraction (from arbitrary deconstructions) is a separate,
-harder problem and deliberately out of scope here.
+the extracted net would not be the framework type.
+
+``topology_from_deconstruction`` is the general path (coverage plan
+stage 3): any finite deconstruction's own blueprint, one slot per
+building unit at its real position, one shared connection point per
+cut bond - the self-templated round trip's template. Unlike the
+tetrahedral path it makes no idealization at all: the blueprint IS the
+crystal's embedding, so a rebuild against it tests whether rigid
+representative units regenerate the material, with the idealized
+embedding removed from the question entirely.
 """
 
 from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 from pymatgen.core.periodic_table import get_el_sp
-from pymatgen.core.structure import Structure
+from pymatgen.core.structure import Molecule, Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 from autografs.cgd import analyze, orbit_equivalence_classes
 from autografs.exceptions import TopologyExtractionError
+from autografs.fragment import Fragment
 from autografs.topology import Topology
 
-__all__ = ["topology_from_tetrahedral"]
+if TYPE_CHECKING:
+    from autografs.deconstruct import Deconstruction
+
+__all__ = ["topology_from_deconstruction", "topology_from_tetrahedral"]
 
 logger = logging.getLogger(__name__)
 
@@ -200,3 +212,108 @@ def topologies_from_tetrahedral_cifs(
     for name, reason in sorted(failures.items()):
         logger.info(f"    - {name}: {reason}")
     return converted
+
+
+def topology_from_deconstruction(
+    result: Deconstruction, name: str = "self"
+) -> tuple[Topology, dict[int, str]]:
+    """The structure's own blueprint, plus its identity slot mapping.
+
+    Erects a Topology directly from a deconstruction's
+    ``BlueprintRecipe``: one slot per building unit, centered at the
+    unit's real (home-gauge) centroid, with one X dummy per cut bond at
+    the real bond midpoint. Each cut's two dummy expressions - the same
+    physical point in each end's gauge - share one tag, which is
+    exactly the pairing convention ``alignment.prepare_build`` consumes,
+    and their fractional difference is the cut's integer voltage by
+    construction.
+
+    Slot center species encode the connectivity (Z = number of
+    connections, the CGD ``NODE`` convention). The spacegroup is set to
+    1 (triclinic): a real crystal's symmetry is approximate, and P1
+    gives the cell optimizer full freedom rather than a constraint the
+    embedding may not satisfy; crystallographic orbits are attempted on
+    the erected net and fall back to one class per slot.
+
+    Returns ``(topology, mapping)`` where ``mapping`` is the identity
+    assignment ``{slot index: fragment name}`` - each slot takes its
+    own unit's (deduplicated, representative) fragment.
+
+    Raises
+    ------
+    TopologyExtractionError
+        When the deconstruction has no blueprint recipe (rod-containing
+        structures) or a unit exceeds the library's connectivity range.
+    """
+    recipe = result.blueprint
+    if recipe is None:
+        raise TopologyExtractionError(
+            "No blueprint recipe: rod-containing deconstructions have "
+            "no point-slot blueprint form (yet)."
+        )
+    lattice = result.structure.lattice
+    per_unit_cuts: dict[int, list[tuple[int, tuple]]] = {}
+    for cut_index, (unit_a, unit_b, mid_a, mid_b) in enumerate(recipe.cuts):
+        per_unit_cuts.setdefault(unit_a, []).append((cut_index, mid_a))
+        per_unit_cuts.setdefault(unit_b, []).append((cut_index, mid_b))
+
+    slots: list[Fragment] = []
+    mapping: dict[int, str] = {}
+    for k, unit in enumerate(result.units):
+        connections = per_unit_cuts.get(k, [])
+        if not connections:
+            raise TopologyExtractionError(
+                f"Unit {k} ({unit.name}) carries no cut bond; a "
+                "disconnected unit has no slot."
+            )
+        if len(connections) > 118:
+            raise TopologyExtractionError(
+                f"Unit {k} carries {len(connections)} connections; no "
+                "element encodes that connectivity."
+            )
+        center = np.asarray(recipe.centers[k], dtype=float)
+        species = [get_el_sp(len(connections))] + ["X"] * len(connections)
+        frac_coords = [center] + [
+            np.asarray(mid, dtype=float) for _index, mid in connections
+        ]
+        carts = [lattice.get_cartesian_coords(fc) for fc in frac_coords]
+        tags = [0] + [cut_index + 1 for cut_index, _mid in connections]
+        molecule = Molecule(species, carts, site_properties={"tags": tags})
+        slots.append(Fragment(atoms=molecule, name=f"slot_{k}"))
+        mapping[k] = unit.name
+
+    # orbits on the erected net, so symmetric self-templates group
+    # their slots; a distorted P1 crystal degrades gracefully to one
+    # class per slot
+    all_species: list = []
+    all_frac: list[np.ndarray] = []
+    for slot in slots:
+        for site in slot.atoms:
+            all_species.append(site.specie)
+            all_frac.append(lattice.get_fractional_coords(site.coords))
+    try:
+        erected = Structure(
+            lattice, all_species, np.array(all_frac), coords_are_cartesian=False
+        )
+        centers_idx = []
+        offset = 0
+        for slot in slots:
+            centers_idx.append(offset)
+            offset += len(slot.atoms)
+        classes = orbit_equivalence_classes(erected, centers_idx)
+    except Exception:  # noqa: BLE001 - orbits are an optimization only
+        classes = []
+    if len(classes) != len(slots):
+        classes = list(range(len(slots)))
+
+    return (
+        Topology(
+            name=name,
+            slots=slots,
+            cell=lattice,
+            equivalence_classes=classes,
+            spacegroup_number=1,
+            is_2d=False,
+        ),
+        mapping,
+    )

--- a/src/autografs/extract_topology.py
+++ b/src/autografs/extract_topology.py
@@ -246,10 +246,12 @@ def topology_from_deconstruction(
         structures) or a unit exceeds the library's connectivity range.
     """
     recipe = result.blueprint
-    if recipe is None:
+    if recipe is None or result.rod_units:
         raise TopologyExtractionError(
-            "No blueprint recipe: rod-containing deconstructions have "
-            "no point-slot blueprint form (yet)."
+            "Rod-containing deconstructions need a slot-run blueprint "
+            "(the recipe carries the rod's points of extension in "
+            "rod_poe; the run-consuming constructor is the next "
+            "increment of the coverage plan)."
         )
     lattice = result.structure.lattice
     per_unit_cuts: dict[int, list[tuple[int, tuple]]] = {}

--- a/src/autografs/extract_topology.py
+++ b/src/autografs/extract_topology.py
@@ -426,13 +426,47 @@ def rod_topology_from_deconstruction(result: Deconstruction, name: str = "self-r
         )
         lateral_mapping[len(slots) - 1] = building_unit.name
 
+    # one node slot per CHEMICAL repeat, not per PoE atom. The builder's
+    # node convention filters slots with two or fewer connection points
+    # (a run "node" must out-connect an edge center), and a real rod's
+    # individual points of extension usually carry one or two cuts each
+    # - per-atom slots emptied every run and the repeat arithmetic
+    # divided by zero (measured: 181 of the 215 single-rod corpus
+    # attempts). Binning the PoE atoms by axial position into one bin
+    # per chemical repeat aggregates each repeat's cuts into one slot,
+    # which simultaneously clears the filter and makes the node count
+    # equal screw_order, the helical builder's expectation.
+    fragment = _rod_fragment(result.structure, rod_unit, name="self_rod")
+    n_bins = max(1, int(fragment.repeat.screw_order))
+    axis_hat = np.asarray(rod_unit.axis, dtype=float)
+    heights = {
+        atom: float(np.dot(poe_carts[atom], axis_hat)) for atom, _pos in poe_entries
+    }
+    z_min = min(heights.values())
+    chemical = float(rod_unit.repeat_length) / n_bins
+    bins: list[list[int]] = [[] for _ in range(n_bins)]
+    for atom, _pos in poe_entries:
+        index = int(np.floor((heights[atom] - z_min) / chemical + 1e-6))
+        bins[min(max(index, 0), n_bins - 1)].append(atom)
+
     run_slots: list[int] = []
-    for atom, pos in poe_entries:
-        connections = poe_cuts[atom]
-        if not connections:
-            raise TopologyExtractionError(f"Point of extension {atom} carries no cut.")
-        center = lattice.get_cartesian_coords(np.asarray(pos, dtype=float))
-        species = [get_el_sp(len(connections))] + ["X"] * len(connections)
+    for bin_index, members in enumerate(bins):
+        if not members:
+            raise TopologyExtractionError(
+                f"Chemical repeat {bin_index} holds no point of "
+                "extension; the axial binning does not describe this rod."
+            )
+        connections = [
+            (cut_index, mid) for atom in members for cut_index, mid in poe_cuts[atom]
+        ]
+        if len(connections) <= 2:
+            raise TopologyExtractionError(
+                f"Chemical repeat {bin_index} carries "
+                f"{len(connections)} connection(s); the rod builder's "
+                "node convention needs more than two per repeat."
+            )
+        center = np.mean([poe_carts[atom] for atom in members], axis=0)
+        species = [get_el_sp(min(len(connections), 118))] + ["X"] * len(connections)
         carts = [center] + [
             lattice.get_cartesian_coords(np.asarray(mid, dtype=float))
             for _index, mid in connections
@@ -441,7 +475,7 @@ def rod_topology_from_deconstruction(result: Deconstruction, name: str = "self-r
         slots.append(
             Fragment(
                 atoms=Molecule(species, carts, site_properties={"tags": tags}),
-                name=f"poe_{atom}",
+                name=f"repeat_{bin_index}",
             )
         )
         run_slots.append(len(slots) - 1)
@@ -455,7 +489,6 @@ def rod_topology_from_deconstruction(result: Deconstruction, name: str = "self-r
         is_2d=False,
     )
 
-    fragment = _rod_fragment(result.structure, rod_unit, name="self_rod")
     direction = (
         int(rod_unit.generator[0]),
         int(rod_unit.generator[1]),

--- a/src/autografs/fetch.py
+++ b/src/autografs/fetch.py
@@ -73,6 +73,40 @@ IZA_SOURCE = Source(
 )
 
 
+EPINET_SOURCE = Source(
+    key="epinet",
+    title="EPINET: Euclidean Patterns in Non-Euclidean Tilings",
+    homepage="https://epinet.anu.edu.au",
+    notice=(
+        "The s-net geometry files about to be downloaded come from the\n"
+        "EPINET database (S. Ramsden, V. Robins, S. Hyde and\n"
+        "collaborators, hosted at the Australian National University).\n"
+        "\n"
+        "EPINET's content is licensed under Creative Commons\n"
+        "Attribution-NonCommercial-NoDerivatives 4.0 (CC BY-NC-ND).\n"
+        "That license does NOT permit redistribution of derived\n"
+        "copies: the files are fetched to YOUR machine for YOUR own\n"
+        "non-commercial use, and any topology library you convert them\n"
+        "into must stay local - AuToGraFS ships nothing derived from\n"
+        "EPINET, and neither should you. Published work should cite\n"
+        "EPINET; see https://epinet.anu.edu.au for the terms and the\n"
+        "preferred citation."
+    ),
+)
+
+EPINET_CGD_URL = "https://epinet.anu.edu.au/snet_cgd_files/{name}.cgd"
+
+# the catalogue holds ~14,532 s-nets with identifiers observed up to
+# sqc14645 (numbering is sparse); the default sweep ceiling leaves a
+# margin, and absent ids are negatively cached so re-runs skip them
+EPINET_MAX_ID = 14700
+
+# EPINET appears dormant (no visible maintenance since ~2019), so the
+# full-catalogue fetch is extra polite: one file per second, a single
+# connection, resumable
+EPINET_REQUEST_DELAY = 1.0
+
+
 def require_acceptance(source: Source, accept: bool = False) -> None:
     """Show a source's terms and require explicit acceptance.
 
@@ -170,6 +204,89 @@ def fetch_files(
             tmp.write_bytes(response.content)
             os.replace(tmp, target)
             available[filename] = target
+            time.sleep(delay)
+    return available
+
+
+def fetch_epinet_cgds(
+    cache_dir: Path | None = None,
+    accept_licenses: bool = False,
+    max_id: int = EPINET_MAX_ID,
+    delay: float = EPINET_REQUEST_DELAY,
+) -> dict[str, Path]:
+    """The EPINET s-net CGD files, fetched to the local cache.
+
+    EPINET exposes no bulk endpoint - one ``.cgd`` per net page - so
+    this sweeps ``sqc1..sqc<max_id>`` politely (one request per
+    ``delay`` seconds, single connection, resumable). The numbering is
+    sparse: an id that answers 404 is recorded in ``absent.txt`` in the
+    cache directory and never re-requested, while transient failures
+    (timeouts, 5xx) stay retryable on the next run. A full first fetch
+    takes hours by design; interrupt and re-run freely.
+
+    The cache is for LOCAL use only: EPINET's CC BY-NC-ND terms do not
+    permit redistributing the files or anything converted from them
+    (see ``EPINET_SOURCE`` and the acceptance gate).
+
+    Returns
+    -------
+    dict[str, Path]
+        Cached CGD path per s-net name (``sqc168`` -> ``.../sqc168.cgd``).
+    """
+    require_acceptance(EPINET_SOURCE, accept=accept_licenses)
+    cache = Path(cache_dir) if cache_dir else default_cache_dir("epinet")
+    cache.mkdir(parents=True, exist_ok=True)
+    absent_file = cache / "absent.txt"
+    absent: set[str] = set()
+    if absent_file.is_file():
+        absent = set(absent_file.read_text(encoding="utf-8").split())
+
+    available: dict[str, Path] = {}
+    todo: list[str] = []
+    for index in range(1, max_id + 1):
+        name = f"sqc{index}"
+        target = cache / f"{name}.cgd"
+        if target.is_file() and target.stat().st_size > 0:
+            available[name] = target
+        elif name not in absent:
+            todo.append(name)
+    if not todo:
+        logger.info(
+            f"All {len(available)} EPINET files already cached in {cache} "
+            f"({len(absent)} ids known absent)."
+        )
+        return available
+    logger.info(
+        f"Fetching up to {len(todo)} EPINET files ({len(available)} cached, "
+        f"{len(absent)} known absent) into {cache}; this is deliberately "
+        f"slow ({delay:.1f} s/request) and resumable."
+    )
+    with requests.Session() as session:
+        session.headers["User-Agent"] = USER_AGENT
+        for name in tqdm(todo, unit="net"):
+            target = cache / f"{name}.cgd"
+            try:
+                response = session.get(EPINET_CGD_URL.format(name=name), timeout=60)
+            except requests.RequestException as exc:
+                logger.warning(f"Failed to fetch {name}: {exc}")
+                time.sleep(delay)
+                continue
+            if response.status_code == 404:
+                absent.add(name)
+                # persist immediately: absence knowledge is what makes
+                # the sparse sweep resumable at all
+                absent_file.write_text(
+                    "\n".join(sorted(absent)) + "\n", encoding="utf-8"
+                )
+            elif response.ok and response.content.strip():
+                tmp = target.with_suffix(target.suffix + ".tmp")
+                tmp.write_bytes(response.content)
+                os.replace(tmp, target)
+                available[name] = target
+            else:
+                logger.warning(
+                    f"Unexpected response for {name}: HTTP {response.status_code}"
+                )
             time.sleep(delay)
     return available
 

--- a/src/autografs/rod_build.py
+++ b/src/autografs/rod_build.py
@@ -98,7 +98,7 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import networkx
 import numpy as np
@@ -608,6 +608,7 @@ class _RodBuild:
     """
 
     initial_scale: float | None = None
+    frozen_scale: float | None = None
 
     def __init__(
         self,
@@ -1241,11 +1242,20 @@ class _RodBuild:
         """(scale, theta per family, z0 per family) from a flat vector.
 
         Reads the head only; any trailing lateral-displacement block
-        (embedding relaxation) is left to ``lateral_shifts``.
+        (embedding relaxation) is left to ``lateral_shifts``. With
+        ``frozen_scale`` set the scale coordinate is inert: every
+        evaluation sees the frozen value, so a re-optimization cannot
+        leave the caller's basin whatever the objective prefers - the
+        fallback arm of the scale band (see build_rod_framework).
         """
         head = np.asarray(params[1 : 1 + 2 * self.n_families], dtype=float)
         rest = head.reshape(self.n_families, 2)
-        return float(params[0]), rest[:, 0], rest[:, 1]
+        scale = (
+            float(self.frozen_scale)
+            if self.frozen_scale is not None
+            else float(params[0])
+        )
+        return scale, rest[:, 0], rest[:, 1]
 
     def lateral_shifts(self, params: np.ndarray) -> np.ndarray | None:
         """Per-slot fractional displacements from the parameter tail."""
@@ -1663,6 +1673,7 @@ def build_rod_framework(
     verbose: bool = False,
     relax_embedding: bool = False,
     initial_scale: float | None = None,
+    scale_band: float | None = None,
 ) -> Framework:
     """Build a rod framework - straight or helical - from a rod and linkers.
 
@@ -1704,6 +1715,19 @@ def build_rod_framework(
         ``NetMismatchError`` if it does not realize the blueprint net.
     verbose : bool, optional
         Log the optimized cell and residuals.
+    initial_scale : float or None, optional
+        Start the transverse-scale optimization here instead of at the
+        library-net heuristic. A self-derived blueprint (rod
+        self-template) is at the crystal's own size, so its correct
+        start is exactly 1.
+    scale_band : float or None, optional
+        Trust band around ``initial_scale``, as a relative half-width
+        (0.25 = +/-25%). The greedy port-image pairing makes the
+        objective multi-modal over the transverse scale, and a spurious
+        pairing at a compressed cell can outscore the true branch - so
+        when the free solve's scale leaves the band, the build re-solves
+        with the scale frozen at ``initial_scale`` (theta/z0 only) and
+        keeps that solution unconditionally. Requires ``initial_scale``.
 
     Returns
     -------
@@ -1729,6 +1753,8 @@ def build_rod_framework(
         )
     if not rod.arms:
         raise AlignmentError(f"Rod {rod.name!r} has no connection arms.")
+    if scale_band is not None and initial_scale is None:
+        raise ValueError("scale_band needs initial_scale as its reference")
 
     from autografs.rods import STRAIGHT_SCREW_TOL
 
@@ -1850,23 +1876,42 @@ def build_rod_framework(
 
     # optimize: coarse rotation grid per axis family (a full product
     # grid would be 16^families), then refine everything with Nelder-Mead
-    start = build.initial_guess()
-    for family in range(build.n_families):
-        angles = np.linspace(0.0, 2.0 * np.pi, 16, endpoint=False)
+    def solve() -> Any:
+        start = build.initial_guess()
+        for family in range(build.n_families):
+            angles = np.linspace(0.0, 2.0 * np.pi, 16, endpoint=False)
 
-        def value_at(angle: float, family: int = family) -> float:
-            trial = start.copy()
-            trial[1 + 2 * family] = angle
-            return build.objective(trial)
+            def value_at(angle: float, family: int = family) -> float:
+                trial = start.copy()
+                trial[1 + 2 * family] = angle
+                return build.objective(trial)
 
-        start[1 + 2 * family] = min(angles, key=value_at)
-    result = minimize(
-        build.objective,
-        start,
-        method="Nelder-Mead",
-        options={"xatol": 1e-4, "fatol": 1e-6, "maxiter": 2000},
-    )
+            start[1 + 2 * family] = min(angles, key=value_at)
+        return minimize(
+            build.objective,
+            start,
+            method="Nelder-Mead",
+            options={"xatol": 1e-4, "fatol": 1e-6, "maxiter": 2000},
+        )
+
+    result = solve()
     scale, theta, z0 = build.unpack(result.x)
+    if (
+        scale_band is not None
+        and initial_scale is not None
+        and abs(scale / initial_scale - 1.0) > scale_band
+    ):
+        # The free solve left the caller's trust band. The greedy
+        # port-image pairing makes the objective multi-modal over the
+        # transverse scale, and a spurious pairing at a compressed or
+        # inflated cell can genuinely score better than the true branch
+        # (the CAXVOO lesson, again) - so the free objective cannot be
+        # the referee here. Freeze the scale at the reference and
+        # re-solve theta/z0 only; the frozen solution replaces the free
+        # one unconditionally.
+        build.frozen_scale = float(initial_scale)
+        result = solve()
+        scale, theta, z0 = build.unpack(result.x)
     shifts = build.lateral_shifts(result.x)
     # the polytopic arm assignments were fixed at the blueprint cell;
     # re-solve them now that the cell has moved

--- a/src/autografs/rod_build.py
+++ b/src/autografs/rod_build.py
@@ -595,7 +595,19 @@ class _Lateral:
 
 
 class _RodBuild:
-    """Geometry of one rod build, evaluated per (scale, theta, z0)."""
+    """Geometry of one rod build, evaluated per (scale, theta, z0).
+
+    ``initial_scale``, when set, overrides ``initial_guess``'s scale
+    heuristic outright. A self-derived blueprint (a rod self-template)
+    is already at the crystal's own size, so its correct start is
+    exactly 1.0 by construction - the heuristic below measures
+    node-to-lateral separations that were calibrated for idealized
+    library nets and can land whole orders of magnitude off on a real
+    P1 embedding (measured: transverse scale 183 on one corpus
+    structure whose correct value was 1).
+    """
+
+    initial_scale: float | None = None
 
     def __init__(
         self,
@@ -1253,7 +1265,9 @@ class _RodBuild:
 
     def initial_guess(self) -> np.ndarray:
         """(scale, then theta/z0 per family) good enough for Nelder-Mead."""
-        if self.helical:
+        if self.initial_scale is not None:
+            scale0 = float(self.initial_scale)
+        elif self.helical:
             # scale: the rod sits on the run's cylinder, so match the
             # rod's own radius to the (unscaled) blueprint node radius
             spec = self.rod_specs[0]
@@ -1648,6 +1662,7 @@ def build_rod_framework(
     verify_net: bool = False,
     verbose: bool = False,
     relax_embedding: bool = False,
+    initial_scale: float | None = None,
 ) -> Framework:
     """Build a rod framework - straight or helical - from a rod and linkers.
 
@@ -1827,6 +1842,11 @@ def build_rod_framework(
         runs if len(runs) > 1 else runs[0],
         relax_embedding=relax_embedding,
     )
+    # a caller who knows the blueprint's true size (a self-derived
+    # blueprint is at the crystal's own scale by construction) starts
+    # the transverse-scale optimization there instead of at the
+    # library-net heuristic
+    build.initial_scale = initial_scale
 
     # optimize: coarse rotation grid per axis family (a full product
     # grid would be 16^families), then refine everything with Nelder-Mead

--- a/src/autografs/rod_build.py
+++ b/src/autografs/rod_build.py
@@ -1523,9 +1523,26 @@ def rod_fits_topology(topology: Topology, screw_order: int, screw_angle: float) 
                 continue
             if abs(abs(candidate.screw_angle) - abs(screw_angle)) <= 5.0:
                 return True
-        # a 2_1 screw still builds on a straight run: a ditopic linker's
-        # arm sign-flip is a no-op there. Higher orders cannot.
+        # a 2_1 screw still builds on any straight run: a ditopic
+        # linker's arm sign-flip is a no-op there. A higher order builds
+        # on a straight run only when the run chains several nodes whose
+        # own turn matches the screw (#168 - cds: two 4-c nodes 90 deg
+        # apart hosting a 4_1 rod). _select_runs accepts that build and
+        # it validates, so this filter must accept it too; refusing all
+        # straight runs at order > 2 disagreed with the builder.
         if screw_order != 2:
+            for straight in axial_runs(topology):
+                nodes = _run_nodes(topology, straight)
+                if (
+                    len(nodes.slots) > 1
+                    and nodes.even
+                    and _screw_fits(nodes, screw_angle)
+                ):
+                    return True
+            # a single-node straight run cannot turn with the screw:
+            # _select_runs would fall back to one and the closure gate
+            # would reject the build, so refusing here matches the
+            # builder's outcome
             return False
     runs = axial_runs(topology)
     if not runs:

--- a/src/autografs/rods.py
+++ b/src/autografs/rods.py
@@ -449,10 +449,26 @@ def rod_fragment(
     positions = _local_positions(
         structure, rod.atom_indices, anchor_index, rod.internal_bonds
     )
+    # the unwrap walks bond images, so every atom carries a lattice
+    # shift away from its home-cell position. A recorded bond offset is
+    # in the HOME gauge, so reading it against unwrapped coordinates
+    # counts the image twice on the bonds the walk already followed -
+    # ``unwrap_shift`` is what re-expresses one gauge in the other.
+    home_coords = np.asarray(
+        [structure[i].coords for i in rod.atom_indices], dtype=float
+    )
+    unwrap_shift = np.rint(
+        (positions - home_coords) @ np.linalg.inv(structure.lattice.matrix)
+    )
     axial, radial, angular, basis = _cylindrical_frame(positions, rod.axis)
     length = float(rod.repeat_length)
     symbols = [structure[i].specie.symbol for i in rod.atom_indices]
-    axial = (axial - axial.min()) % length
+    axial = axial - axial.min()
+    # keep the unwrapped axial: the modulo below folds an atom that the
+    # walk laid out past one repeat back to the other end, which is a
+    # further whole-repeat shift the bond arithmetic must not inherit
+    axial_unwrapped = axial.copy()
+    axial = axial % length
 
     chemical, order, screw = _chemical_reduction(
         symbols, axial, radial, angular, length, tolerance
@@ -528,11 +544,19 @@ def rod_fragment(
 
         seen: set[tuple[int, int, int]] = set()
         for i, j, off in rod.internal_bonds:
-            a = _template_row(row_of[i])
-            b = _template_row(row_of[j])
-            off_axial = float((np.asarray(off, dtype=float) @ matrix) @ axis_hat)
-            n_i = round((axial[row_of[i]] - kept_axial[a]) / chemical)
-            n_j = round((axial[row_of[j]] + off_axial - kept_axial[b]) / chemical)
+            row_i, row_j = row_of[i], row_of[j]
+            a = _template_row(row_i)
+            b = _template_row(row_j)
+            # the bond's residual image in the UNWRAPPED gauge: zero for
+            # every bond the unwrap walk followed (its image is already
+            # in the coordinates), the true image for the closure bonds
+            # it did not
+            residual = (
+                np.asarray(off, dtype=float) + unwrap_shift[row_i] - unwrap_shift[row_j]
+            )
+            off_axial = float((residual @ matrix) @ axis_hat)
+            n_i = round((axial_unwrapped[row_i] - kept_axial[a]) / chemical)
+            n_j = round((axial_unwrapped[row_j] + off_axial - kept_axial[b]) / chemical)
             m = int(n_j - n_i)
             key = (a, b, m) if (a, b, m) <= (b, a, -m) else (b, a, -m)
             if key in seen:

--- a/src/autografs/utils.py
+++ b/src/autografs/utils.py
@@ -389,14 +389,41 @@ def fragment_to_molgraph(fragment: Fragment) -> MoleculeGraph:
     mmtypes = find_mmtypes(molgraph=mg, uff_lib=uff_lib, uff_symbs=uff_symbs)
     for i, mmtype in enumerate(mmtypes):
         mg.molecule[i].properties["ufftype"] = mmtype
-    # transfer tags from dummies
+    # transfer tags from dummies, AND keep the per-dummy pairing as a
+    # list: a single anchor atom can carry several connections (a
+    # one-atom metal node, a rod anchor, an oxo bridge), and the node
+    # "tags" attribute holds one value, so the last write wins and the
+    # other connections would silently lose their bonds. The list keeps
+    # every (tag, anchor) pair through the strip; fragments_to_networkx
+    # bonds from it. Indices are post-strip.
+    dummy_set = set(dummies_idx)
+    removed_before = {
+        index: sum(1 for d in dummies_idx if d < index)
+        for index in range(len(mg.molecule))
+    }
+    real_indices = [i for i in range(len(mg.molecule)) if i not in dummy_set]
+    coords = mg.molecule.cart_coords
+    anchor_tags: list[tuple[int, int]] = []
     if "tags" in mg.molecule.site_properties:
         for dummy_idx in dummies_idx:
             tag = mg.molecule[dummy_idx].properties["tags"]
             for site in mg.get_connected_sites(dummy_idx):
-                mg.molecule[site.index].properties["tags"] = tag
+                if site.index not in dummy_set:
+                    mg.molecule[site.index].properties["tags"] = tag
+            if tag > 0 and real_indices:
+                # the anchor is the dummy's NEAREST real atom (the
+                # alignment convention), not a perceived bond: on a
+                # crowded one-atom node the neighbour strategy can
+                # decline the longer dummy contacts, and every arm
+                # must keep its anchor regardless
+                nearest = min(
+                    real_indices,
+                    key=lambda i: float(np.linalg.norm(coords[i] - coords[dummy_idx])),
+                )
+                anchor_tags.append((int(tag), nearest - removed_before[nearest]))
     # remove dummies
     mg.remove_nodes(list(dummies_idx))
+    mg.graph.graph["anchor_tags"] = anchor_tags
     return mg
 
 
@@ -470,12 +497,26 @@ def fragments_to_networkx(
                 )
                 full_graph.add_edge(i + offset, j + offset, bond_order=bo)
         offset += this_len
-    # interfragment edges: atoms sharing a positive tag are the two
-    # sides of a blueprint dummy and bond together
+    # interfragment edges: the two sides of a blueprint dummy bond
+    # together. Pairing uses the per-dummy anchor lists rather than the
+    # node "tag" attribute, because an anchor atom carrying several
+    # connections keeps only its last-written tag - bonding from the
+    # attribute silently dropped the others (one-atom nodes, oxo
+    # bridges, any multi-connection anchor).
     nodes_by_tag: dict[int, list[int]] = defaultdict(list)
-    for node, data in full_graph.nodes(data=True):
-        if data["tag"] > 0:
-            nodes_by_tag[data["tag"]].append(node)
+    offset = 0
+    for subgraph in subgraphs:
+        pairs = subgraph.graph.graph.get("anchor_tags")
+        if pairs is None:
+            # graphs from an older path: fall back to the attribute scan
+            for local in range(len(subgraph.molecule)):
+                tag = subgraph.molecule[local].properties.get("tags", 0)
+                if tag and tag > 0:
+                    nodes_by_tag[tag].append(local + offset)
+        else:
+            for tag, local in pairs:
+                nodes_by_tag[tag].append(local + offset)
+        offset += len(subgraph.molecule)
     for tag, nodes in nodes_by_tag.items():
         if len(nodes) == 2:
             full_graph.add_edge(nodes[0], nodes[1], bond_order=1.0)

--- a/tests/test_benchmark_drivers.py
+++ b/tests/test_benchmark_drivers.py
@@ -129,6 +129,24 @@ class TestMappingGap:
         assert gap._slot_verdict(two_connected, [two_connected], 0.35)["wall"] is None
 
 
+class TestSelfTemplate:
+    """The driver that rebuilds a crystal from its own blueprint.
+
+    A structure this library built must survive its own self-templated
+    round trip: the blueprint is its real embedding and the fragments
+    are its own units, so anything short of closed_self means the
+    stage-3 machinery, not the chemistry, broke.
+    """
+
+    def test_selfbuilt_structure_closes(self, mofgen, mof5_cif):
+        st = _load("selftemplate")
+        payload = st.run([mof5_cif], topofile=FIXTURE_PATH, n_jobs=1)
+        record = payload["structures"]["mof5.cif"]
+        assert record["outcome"] == "closed_self"
+        assert 0.9 < record["volume_ratio"] < 1.1
+        json.dumps(payload, default=str)
+
+
 class TestUnidentifiedProbe:
     """The driver that attributes roundtrip's ``unidentified`` bucket.
 

--- a/tests/test_benchmark_drivers.py
+++ b/tests/test_benchmark_drivers.py
@@ -88,3 +88,63 @@ class TestThroughput:
         payload = throughput.run(mofgen, ["not_a_net"], repeats=1)
         assert payload["topologies"]["not_a_net"]["error"] == "unknown topology"
         json.dumps(payload, default=str)
+
+
+class TestMappingGap:
+    """The driver that attributes roundtrip's ``no_mapping`` bucket.
+
+    A structure built from a net's own slots must map back onto it, so
+    the round trip here is trivially satisfiable -- which is the point:
+    if this reports a wall, the predicate or the deconstruction changed
+    under us, not the chemistry.
+    """
+
+    def test_selfbuilt_structure_maps(self, mofgen, mof5_cif):
+        gap = _load("mapping_gap")
+        payload = gap.run([mof5_cif], n_jobs=1)
+        record = payload["structures"]["mof5.cif"]
+        assert record["outcome"] in {"mapped", "geometry", "arm_count"}
+        json.dumps(payload, default=str)
+
+    def test_walls_are_attributed_not_pooled(self, mofgen):
+        """A slot with no right-sized unit is arm_count, not geometry."""
+        gap = _load("mapping_gap")
+        topology = mofgen.topologies["pcu"]
+        two_connected = next(
+            key
+            for key in topology.mappings
+            if len(key.atoms.indices_from_symbol("X")) == 2
+        )
+        six_connected = next(
+            key
+            for key in topology.mappings
+            if len(key.atoms.indices_from_symbol("X")) == 6
+        )
+        # only ditopic units available: the 6-connected slot cannot be
+        # filled at any threshold, and that is a connectivity fact
+        verdict = gap._slot_verdict(six_connected, [two_connected], 0.35)
+        assert verdict["wall"] == "arm_count"
+        assert verdict["best_rmsd"] is None
+        # a slot against itself is a fit, at any threshold
+        assert gap._slot_verdict(two_connected, [two_connected], 0.35)["wall"] is None
+
+
+class TestUnidentifiedProbe:
+    """The driver that attributes roundtrip's ``unidentified`` bucket.
+
+    A structure built from a library net must identify, so the probe on
+    it must land in the ``identified`` outcome with a well-formed
+    quotient: nonzero vertices, a degree profile, and at least one
+    prefilter candidate (itself).
+    """
+
+    def test_selfbuilt_structure_identifies(self, mofgen, mof5_cif):
+        probe = _load("unidentified_probe")
+        payload = probe.run([mof5_cif], topofile=FIXTURE_PATH, n_jobs=1)
+        record = payload["structures"]["mof5.cif"]
+        assert record["outcome"] == "identified"
+        assert record["net"] == ["pcu"]
+        assert record["contracted_vertices"] > 0
+        assert record["n_prefilter_candidates"] >= 1
+        assert not record["sig_empty"]
+        json.dumps(payload, default=str)

--- a/tests/test_cgd.py
+++ b/tests/test_cgd.py
@@ -75,3 +75,75 @@ class TestEntrySplitting:
         """Entry text ending in C/R/Y/S/T/A/L letters is not eaten."""
         topologies = read_cgd_data(TRAILING_LETTERS_CGD)
         assert set(topologies) == {"METAL"}
+
+
+EPINET_DIALECT = """PERIODIC_GRAPH
+ID sqctest
+EDGES
+  1 1 1 0 0
+END
+
+CRYSTAL
+  ID sqctest_relaxed
+  GROUP Pm-3m
+  CELL 1.1 1.1 1.1 90.0 90.0 90.0
+  ATOM\t1 6 0.0 0.0 0.0
+  EDGE\t0.0 0.0 0.0 1.0 0.0 0.0
+END
+
+CRYSTAL
+  ID sqctest_maximal
+  GROUP Pm-3m
+  CELL 1.0 1.0 1.0 90.0 90.0 90.0
+  ATOM\t1 6 0.0 0.0 0.0
+  EDGE\t0.0 0.0 0.0 1.0 0.0 0.0
+\t0.0 0.0 0.0 0.0 1.0 0.0
+\t0.0 0.0 0.0 0.0 0.0 1.0
+END
+"""
+
+
+class TestEpinetDialect:
+    """The EPINET .cgd dialect adapter (coverage plan stage 2).
+
+    The fixture is a SYNTHETIC file - pcu written in EPINET's format
+    conventions (PERIODIC_GRAPH preamble, several CRYSTAL blocks,
+    ID/ATOM keywords, tab-led continuation rows). No EPINET data enters
+    this repository: its CC BY-NC-ND license does not permit it.
+    """
+
+    def test_maximal_block_is_chosen_and_translated(self):
+        from autografs.cgd import epinet_entries
+
+        entry = epinet_entries(EPINET_DIALECT)
+        assert "NAME sqctest" in entry
+        assert "GROUP Pm-3m" in entry
+        assert "CELL 1.0 1.0 1.0 90.0 90.0 90.0" in entry
+        assert entry.count("NODE") == 1
+        # the continuation rows became explicit EDGE lines, and every
+        # edge gained the EDGE_CENTER the importer's slot stitching
+        # needs (EPINET files carry none)
+        assert entry.count("EDGE_CENTER") == 3
+        assert entry.count("EDGE") == 6
+        assert "1.1" not in entry
+
+    def test_translated_entry_parses_and_identifies(self):
+        import os
+
+        from autografs.cgd import epinet_entries, read_cgd_data
+        from autografs.net import identify_net, topology_quotient_edges
+        from autografs.topology_io import load_topologies
+
+        topologies = read_cgd_data(epinet_entries(EPINET_DIALECT))
+        assert set(topologies) == {"sqctest"}
+        fixture = os.path.join(
+            os.path.dirname(__file__), "data", "topologies_fixture.json"
+        )
+        library = load_topologies(fixture)
+        edges = topology_quotient_edges(topologies["sqctest"])
+        assert identify_net(edges, library) == ["pcu"]
+
+    def test_empty_input_is_empty_not_fatal(self):
+        from autografs.cgd import epinet_entries
+
+        assert epinet_entries("PERIODIC_GRAPH\nID x\nEND\n") == ""

--- a/tests/test_deconstruct.py
+++ b/tests/test_deconstruct.py
@@ -810,6 +810,7 @@ class TestRodSelfTemplate:
             min_distance=None,
             bond_tolerance=10.0,
             verify_net=False,
+            initial_scale=1.0,
         )
         built = rebuilt.structure.composition
         experimental = result.structure.composition

--- a/tests/test_deconstruct.py
+++ b/tests/test_deconstruct.py
@@ -563,21 +563,32 @@ def test_hill_formula():
 def _doubly_bridged_pcu() -> Structure:
     """A pcu-like crystal whose x edges carry parallel double bridges.
 
-    One Zn node per cubic cell; single one-carbon bridges along y and z;
-    TWO parallel one-carbon bridges along x, offset to +-1.1 A so they
-    do not bond each other. The node therefore perceives 8 connections
-    where the underlying net has 6 - the doubled-node signature that
-    dominates the census's no_mapping bucket (a paddlewheel bridged by
-    parallel linker pairs reads as 8-connected on a 4-c net).
+    One Zn node per cubic cell; single two-carbon bridges along y and
+    z; TWO parallel two-carbon bridges along x, offset to +-1.2 A so
+    they do not bond each other. The node therefore perceives 8
+    connections where the underlying net has 6 - the doubled-node
+    signature that dominates the census's no_mapping bucket (a
+    paddlewheel bridged by parallel linker pairs reads as 8-connected
+    on a 4-c net). Bridges are two atoms so every bond has its own
+    partner atom: the single Zn still carries all 8 connections on one
+    anchor - the multi-connection-anchor case bond formation must
+    survive - while no linker bonds the same atom pair through two
+    images, which the simple-graph min-image representation cannot
+    hold.
     """
-    a = 4.2
-    species = ["Zn", "C", "C", "C", "C"]
+    a = 5.6
+    lo, hi = 2.1, 3.5  # C-C at 1.4 A, Zn-C at 2.1-2.4 A
+    species = ["Zn"] + ["C"] * 8
     carts = [
         (0.0, 0.0, 0.0),
-        (a / 2, 1.1, 0.0),  # x bridge, upper
-        (a / 2, -1.1, 0.0),  # x bridge, lower (parallel to the upper)
-        (0.0, a / 2, 0.0),  # y bridge, single
-        (0.0, 0.0, a / 2),  # z bridge, single
+        (lo, 1.2, 0.0),  # x bridge, upper pair
+        (hi, 1.2, 0.0),
+        (lo, -1.2, 0.0),  # x bridge, lower pair (parallel to the upper)
+        (hi, -1.2, 0.0),
+        (0.0, lo, 0.0),  # y bridge, single
+        (0.0, hi, 0.0),
+        (0.0, 0.0, lo),  # z bridge, single
+        (0.0, 0.0, hi),
     ]
     return Structure(Lattice.cubic(a), species, carts, coords_are_cartesian=True)
 
@@ -606,7 +617,7 @@ class TestParallelBridgeFusion:
         # the composite carries BOTH bridge molecules on 2 connections,
         # so the fused fragment is ditopic and composition-complete
         composite = next(
-            u for u in result.units if u.kind == "linker" and "C2" in u.name
+            u for u in result.units if u.kind == "linker" and "C4" in u.name
         )
         assert composite.n_connections == 2
         placed = Counter(atom for u in result.units for atom in u.atom_indices)
@@ -620,8 +631,71 @@ class TestParallelBridgeFusion:
         # no-op (a nitrogen swap would not test this - the metal-oxo
         # rule absorbs a carbon-free N into the node)
         structure = _doubly_bridged_pcu()
-        structure.append("H", (2.1, -1.1, 0.9), coords_are_cartesian=True)
+        structure.append("H", (2.1, -1.2, 0.9), coords_are_cartesian=True)
         result = mofgen.deconstruct(structure, fuse_parallel_bridges=True)
         assert result.fused_bridges == 0
         node = next(u for u in result.units if u.kind == "node")
         assert node.n_connections == 8
+
+
+class TestSelfTemplatedRoundTrip:
+    """The structure's own blueprint rebuilds the structure (stage 3).
+
+    topology_from_deconstruction erects one slot per building unit at
+    its real position, with one shared connection point per cut; the
+    rebuild maps each slot to its own unit's representative fragment.
+    No library net is consulted at any point, so this is the round
+    trip with every library wall removed - what remains is the rigid-
+    unit abstraction itself.
+    """
+
+    def _selftemplate(self, mofgen, result):
+        import copy
+
+        from autografs.builder import build_framework
+        from autografs.extract_topology import topology_from_deconstruction
+
+        topology, mapping = topology_from_deconstruction(result)
+        mappings = {
+            index: copy.deepcopy(result.fragments[name])
+            for index, name in mapping.items()
+        }
+        return topology, build_framework(
+            topology, mappings, max_rmsd=0.5, verify_net=True
+        )
+
+    def test_mof5_rebuilds_from_its_own_blueprint(self, mofgen, mof5_deconstruction):
+        result = mof5_deconstruction
+        topology, rebuilt = self._selftemplate(mofgen, result)
+        assert len(topology) == len(result.units)
+        assert (
+            rebuilt.structure.composition.reduced_formula
+            == result.structure.composition.reduced_formula
+        )
+        # the blueprint is the crystal's own embedding, so the
+        # optimized cell must come out at the experimental volume
+        ratio = rebuilt.structure.volume / result.structure.volume
+        assert 0.9 < ratio < 1.1
+
+    def test_doubled_bridge_needs_no_fusion(self, mofgen):
+        """The 8-connected node maps onto its own 8-arm slot natively:
+        the multiplicity wall does not exist for a self-template."""
+        result = mofgen.deconstruct(_doubly_bridged_pcu())
+        topology, rebuilt = self._selftemplate(mofgen, result)
+        node_slot = max(
+            topology.slots, key=lambda s: len(s.atoms.indices_from_symbol("X"))
+        )
+        assert len(node_slot.atoms.indices_from_symbol("X")) == 8
+        assert (
+            rebuilt.structure.composition.reduced_formula
+            == result.structure.composition.reduced_formula
+        )
+
+    def test_rod_structures_have_no_recipe(self, mofgen):
+        from autografs.exceptions import TopologyExtractionError
+        from autografs.extract_topology import topology_from_deconstruction
+
+        result = mofgen.deconstruct(_rod_pillar_structure(1))
+        assert result.blueprint is None
+        with pytest.raises(TopologyExtractionError, match="rod"):
+            topology_from_deconstruction(result)

--- a/tests/test_deconstruct.py
+++ b/tests/test_deconstruct.py
@@ -691,13 +691,20 @@ class TestSelfTemplatedRoundTrip:
             == result.structure.composition.reduced_formula
         )
 
-    def test_rod_structures_have_no_recipe(self, mofgen):
+    def test_rod_structures_record_poe_but_await_run_blueprints(self, mofgen):
         from autografs.exceptions import TopologyExtractionError
         from autografs.extract_topology import topology_from_deconstruction
 
         result = mofgen.deconstruct(_rod_pillar_structure(1))
-        assert result.blueprint is None
-        with pytest.raises(TopologyExtractionError, match="rod"):
+        # the recipe now carries the rod's points of extension in the
+        # quotient's own gauge - the run constructor's raw material
+        recipe = result.blueprint
+        assert recipe is not None and recipe.rod_poe
+        (rod_index, entries), *_ = recipe.rod_poe.items()
+        assert recipe.centers[rod_index] is None
+        assert len(entries) == len(result.rod_units[0].poe_indices)
+        # the point-slot constructor still declines: rods need slot runs
+        with pytest.raises(TopologyExtractionError, match="[Rr]od"):
             topology_from_deconstruction(result)
 
 

--- a/tests/test_deconstruct.py
+++ b/tests/test_deconstruct.py
@@ -771,3 +771,55 @@ class TestCatenatedSelfTemplate:
         # must still share it at the true relative offset
         ratio = rebuilt.structure.volume / result.structure.volume
         assert 0.75 < ratio < 1.1
+
+
+class TestRodSelfTemplate:
+    """A rod framework rebuilds from its own slot-run blueprint.
+
+    The rod's points of extension become node slots on the crystal's
+    own axis, the run is built from the rod's measured repeat rather
+    than detected, and the validated rod builder consumes it unchanged
+    - the last library wall, removed for the single-rod case.
+    """
+
+    def test_pillar_rebuilds_on_its_own_run(self, mofgen):
+        import copy
+
+        from autografs.extract_topology import rod_topology_from_deconstruction
+        from autografs.rod_build import build_rod_framework
+
+        result = mofgen.deconstruct(_rod_pillar_structure(1))
+        topology, run, lateral_mapping, fragment = rod_topology_from_deconstruction(
+            result
+        )
+        assert set(run.slots).isdisjoint(lateral_mapping)
+        laterals = {
+            index: copy.deepcopy(result.fragments[name])
+            for index, name in lateral_mapping.items()
+        }
+        # verify_net stays off: the rod-form verifier re-detects runs
+        # on the blueprint instead of trusting the injected one, and a
+        # distorted self-blueprint fails that detection - a machinery
+        # conservatism recorded in the coverage plan, not a mismatch.
+        # Composition plus exact atom count is the v1 closure gate.
+        rebuilt = build_rod_framework(
+            topology,
+            fragment,
+            laterals,
+            run=run,
+            min_distance=None,
+            bond_tolerance=10.0,
+            verify_net=False,
+        )
+        built = rebuilt.structure.composition
+        experimental = result.structure.composition
+        assert built.reduced_formula == experimental.reduced_formula
+        # the builder stacks at least two repeats (a continuation bond
+        # must join distinct node pairs), so the rebuild is a whole
+        # supercell of the crystal; per-atom volume is the
+        # supercell-invariant packing check
+        assert len(rebuilt.structure) % len(result.structure) == 0
+        per_atom = (rebuilt.structure.volume / len(rebuilt.structure)) / (
+            result.structure.volume / len(result.structure)
+        )
+        assert 0.75 < per_atom < 1.25

--- a/tests/test_deconstruct.py
+++ b/tests/test_deconstruct.py
@@ -699,3 +699,68 @@ class TestSelfTemplatedRoundTrip:
         assert result.blueprint is None
         with pytest.raises(TopologyExtractionError, match="rod"):
             topology_from_deconstruction(result)
+
+
+def _catenated_pcu_pair() -> Structure:
+    """Two interpenetrated single-bridged pcu nets, offset body-center.
+
+    Each net is one Zn plus two-carbon bridges along x, y and z; the
+    second net is the first translated by (1/2, 1/2, 1/2). The closest
+    inter-net contact is ~4 A, so bond perception keeps the components
+    separate and the deconstruction reports fold 2.
+    """
+    a = 5.6
+    lo, hi = 2.1, 3.5
+    base = [
+        (0.0, 0.0, 0.0),
+        (lo, 0.0, 0.0),
+        (hi, 0.0, 0.0),
+        (0.0, lo, 0.0),
+        (0.0, hi, 0.0),
+        (0.0, 0.0, lo),
+        (0.0, 0.0, hi),
+    ]
+    shift = a / 2
+    species = (["Zn"] + ["C"] * 6) * 2
+    carts = base + [(x + shift, y + shift, z + shift) for x, y, z in base]
+    return Structure(Lattice.cubic(a), species, carts, coords_are_cartesian=True)
+
+
+class TestCatenatedSelfTemplate:
+    """A 2-fold interpenetrated pair rebuilds from its own blueprint.
+
+    The recipe holds every component's units, so the erected blueprint
+    is a disconnected quotient whose two nets share the one real cell
+    at their true relative offset; the build places both and the exact
+    verification compares like with like. This is what the library arm
+    structurally cannot do - it rebuilds one net of a catenated pair
+    and fails the composition gate.
+    """
+
+    def test_two_fold_pair_closes(self, mofgen):
+        import copy
+
+        from autografs.builder import build_framework
+        from autografs.extract_topology import topology_from_deconstruction
+
+        result = mofgen.deconstruct(_catenated_pcu_pair())
+        assert result.n_periodic_components == 2
+        topology, mapping = topology_from_deconstruction(result)
+        # one Zn node and three two-carbon bridges per net, two nets
+        assert len(topology) == len(result.units) == 8
+        mappings = {
+            index: copy.deepcopy(result.fragments[name])
+            for index, name in mapping.items()
+        }
+        rebuilt = build_framework(topology, mappings, max_rmsd=0.5, verify_net=True)
+        assert (
+            rebuilt.structure.composition.reduced_formula
+            == result.structure.composition.reduced_formula
+        )
+        assert len(rebuilt) == len(result.structure)
+        # the fixture's synthetic Zn-C bonds (2.1 A) sit above the
+        # covalent target the cell objective optimizes toward, so the
+        # rebuilt cell is correctly a few percent smaller; both nets
+        # must still share it at the true relative offset
+        ratio = rebuilt.structure.volume / result.structure.volume
+        assert 0.75 < ratio < 1.1

--- a/tests/test_deconstruct.py
+++ b/tests/test_deconstruct.py
@@ -811,6 +811,7 @@ class TestRodSelfTemplate:
             bond_tolerance=10.0,
             verify_net=False,
             initial_scale=1.0,
+            scale_band=0.25,
         )
         built = rebuilt.structure.composition
         experimental = result.structure.composition

--- a/tests/test_deconstruct.py
+++ b/tests/test_deconstruct.py
@@ -558,3 +558,70 @@ def test_hill_formula():
     assert _hill_formula(["C", "H", "H", "C", "O"]) == "C2H2O"
     assert _hill_formula(["Zn", "O", "Zn"]) == "OZn2"
     assert _hill_formula(["H", "O", "H"]) == "H2O"
+
+
+def _doubly_bridged_pcu() -> Structure:
+    """A pcu-like crystal whose x edges carry parallel double bridges.
+
+    One Zn node per cubic cell; single one-carbon bridges along y and z;
+    TWO parallel one-carbon bridges along x, offset to +-1.1 A so they
+    do not bond each other. The node therefore perceives 8 connections
+    where the underlying net has 6 - the doubled-node signature that
+    dominates the census's no_mapping bucket (a paddlewheel bridged by
+    parallel linker pairs reads as 8-connected on a 4-c net).
+    """
+    a = 4.2
+    species = ["Zn", "C", "C", "C", "C"]
+    carts = [
+        (0.0, 0.0, 0.0),
+        (a / 2, 1.1, 0.0),  # x bridge, upper
+        (a / 2, -1.1, 0.0),  # x bridge, lower (parallel to the upper)
+        (0.0, a / 2, 0.0),  # y bridge, single
+        (0.0, 0.0, a / 2),  # z bridge, single
+    ]
+    return Structure(Lattice.cubic(a), species, carts, coords_are_cartesian=True)
+
+
+class TestParallelBridgeFusion:
+    """Opt-in fusion of parallel ditopic bridges (coverage plan stage 1).
+
+    Identification's coordination-sequence walk counts a double bridge
+    once; the mapper counts every dummy on the doubled node. Fusion
+    restores agreement by merging the parallel pair into one composite
+    unit with one connection per end - both molecules kept, so
+    composition stays exact.
+    """
+
+    def test_default_leaves_units_alone(self, mofgen):
+        result = mofgen.deconstruct(_doubly_bridged_pcu())
+        assert result.fused_bridges == 0
+        node = next(u for u in result.units if u.kind == "node")
+        assert node.n_connections == 8
+
+    def test_fusion_restores_the_net_arm_count(self, mofgen):
+        result = mofgen.deconstruct(_doubly_bridged_pcu(), fuse_parallel_bridges=True)
+        assert result.fused_bridges == 1
+        node = next(u for u in result.units if u.kind == "node")
+        assert node.n_connections == 6
+        # the composite carries BOTH bridge molecules on 2 connections,
+        # so the fused fragment is ditopic and composition-complete
+        composite = next(
+            u for u in result.units if u.kind == "linker" and "C2" in u.name
+        )
+        assert composite.n_connections == 2
+        placed = Counter(atom for u in result.units for atom in u.atom_indices)
+        assert len(placed) == len(result.structure)
+        assert max(placed.values()) == 1
+        assert result.net_candidates == ["pcu"]
+
+    def test_fusion_requires_identical_composition(self, mofgen):
+        # hang a hydrogen on one of the parallel bridges: CH vs C no
+        # longer match, so nothing fuses and the request is a clean
+        # no-op (a nitrogen swap would not test this - the metal-oxo
+        # rule absorbs a carbon-free N into the node)
+        structure = _doubly_bridged_pcu()
+        structure.append("H", (2.1, -1.1, 0.9), coords_are_cartesian=True)
+        result = mofgen.deconstruct(structure, fuse_parallel_bridges=True)
+        assert result.fused_bridges == 0
+        node = next(u for u in result.units if u.kind == "node")
+        assert node.n_connections == 8

--- a/tests/test_relax_embedding.py
+++ b/tests/test_relax_embedding.py
@@ -461,6 +461,28 @@ class TestRelaxationOnRealNets:
         assert relaxed.structure.volume < 1.25 * fixed.structure.volume
 
 
+class TestMainSolveStaysUnseeded:
+    """The main relaxed solve must NOT get the seeded simplex.
+
+    Measured, not a preference (scripts/benchmarks/
+    calibrate_direction_weight.py): with the main solve's displacement
+    simplex properly seeded, the relaxed objective's true optimum on
+    shape-mismatched nets is the #197 pathology at EVERY weight from
+    0.1 to 2.0 -- pts inflates x2.9 and tbo x2.3 at guard-passing
+    closure, invisible to any closure budget, and inseparable from
+    genuine corrections by any volume screen (largest real corpus win
+    x1.69 vs a fixture pathology at x1.56). Only the closure-only
+    guard reference, whose objective cannot trade volume for
+    alignment, gets the seeded explorer. If you flip this constant,
+    re-run the sweep first.
+    """
+
+    def test_seed_main_solve_is_off(self):
+        from autografs import builder
+
+        assert builder.SEED_MAIN_SOLVE is False
+
+
 class TestMinFreeDisplacements:
     """The population default: relaxation is off below the threshold."""
 

--- a/tests/test_rods.py
+++ b/tests/test_rods.py
@@ -2401,6 +2401,60 @@ class TestSingleUnitContact:
         assert math.isfinite(build.min_inter_unit_contact(placed))
 
 
+class TestMergedPoeMaps:
+    """The grouped points-of-extension convention (fallback tier).
+
+    A paddlewheel-chain rod carries several cut atoms at one axial
+    height; O'Keeffe counts them as one point of extension, the
+    per-atom convention as several. The grouped maps must cluster by
+    height, fold a cluster straddling the repeat boundary back one
+    generator, and keep the chain-plus-wrap link structure.
+    """
+
+    @staticmethod
+    def _maps(heights, repeat=10.0):
+        from autografs.deconstruct import _merged_poe_maps
+
+        lattice = np.diag([repeat, repeat, repeat])
+        frac = np.array([[0.0, 0.0, z / repeat] for z in heights])
+        order = sorted(range(len(heights)), key=lambda i: heights[i])
+        rod = RodUnit(
+            atom_indices=list(range(len(heights))),
+            axis=np.array([0.0, 0.0, 1.0]),
+            repeat_length=repeat,
+            generator=(0, 0, 1),
+            poe_indices=order,
+            n_connections=len(heights),
+            cut_vectors=[],
+            internal_bonds=[],
+        )
+        unwraps = [{i: np.zeros(3) for i in range(len(heights))}]
+        return _merged_poe_maps(frac, lattice, unwraps, [rod], [0], next_vertex=1)
+
+    def test_same_height_atoms_share_a_vertex(self):
+        vertex, _images, links = self._maps([1.0, 1.2, 6.0, 6.1])
+        assert vertex[0] == vertex[1]
+        assert vertex[2] == vertex[3]
+        assert vertex[0] != vertex[2]
+        # two groups: one intra-cell link plus the wrap link
+        voltages = sorted(tuple(int(x) for x in v) for _a, _b, v in links)
+        assert voltages == [(0, 0, 0), (0, 0, 1)]
+
+    def test_wraparound_cluster_folds_back(self):
+        vertex, _images, links = self._maps([0.1, 5.0, 9.8])
+        # 9.8 sits within tolerance of 0.1 one repeat up: same vertex
+        assert vertex[2] == vertex[0]
+        assert vertex[1] != vertex[0]
+        assert len(set(vertex.values())) == 2
+
+    def test_single_group_becomes_a_self_loop(self):
+        vertex, _images, links = self._maps([2.0, 2.3])
+        assert len(set(vertex.values())) == 1
+        (a, b, voltage) = links[0]
+        assert a == b
+        assert tuple(int(x) for x in voltage) == (0, 0, 1)
+
+
 class TestRodNetCompatibility:
     """#214: identification must not offer nets a rod cannot occupy.
 
@@ -2445,4 +2499,34 @@ class TestRodNetCompatibility:
 
         assert rod_fits_topology(
             bundled_topologies["pcu"], screw_order=1, screw_angle=0.0
+        )
+
+    def test_turning_multinode_straight_run_accepts_matching_screw(
+        self, bundled_topologies
+    ):
+        """The filter must agree with the builder on cds-class nets.
+
+        cds carries no helical run (its nodes sit on the axis, so a
+        positional screw fit is degenerate) but chains two 4-connected
+        nodes per period turned 90 degrees apart, and _select_runs
+        accepts - and validates - a 4_1 rod on that straight run. An
+        earlier filter refused every straight run at screw order > 2,
+        so a real 4_1-rod material correctly identified as cds would
+        have been reported as having no rod-compatible net.
+        """
+        from autografs.rod_build import rod_fits_topology
+
+        cds = bundled_topologies["cds"]
+        assert rod_fits_topology(cds, screw_order=4, screw_angle=90.0)
+        # the same run does not host a screw its node turn cannot match
+        assert not rod_fits_topology(cds, screw_order=6, screw_angle=60.0)
+
+    def test_single_node_straight_run_refuses_high_screw(self, bundled_topologies):
+        """pcu's one-node runs cannot turn with a 4_1 screw; the
+        builder's closure gate would reject that build, and the filter
+        must predict the same outcome."""
+        from autografs.rod_build import rod_fits_topology
+
+        assert not rod_fits_topology(
+            bundled_topologies["pcu"], screw_order=4, screw_angle=90.0
         )

--- a/tests/test_rods.py
+++ b/tests/test_rods.py
@@ -945,6 +945,65 @@ class TestRodFragment:
         assert fragment.arms == []
         assert fragment.repeat.screw_order == 4
 
+    def test_template_bonds_survive_an_unwrap_bridge(self):
+        """Every recorded template bond must be a real bond length.
+
+        ``bonds`` carries a repeat offset per bond, and the template is
+        only buildable if evaluating the bond at that offset reproduces
+        the contact. The offset used to be read from the bond's
+        home-cell image against coordinates ``_local_positions`` had
+        already image-corrected, so a bond whose atom the unwrap placed
+        through a periodic image counted that image twice and landed a
+        whole repeat away.
+
+        The pendant below is what exposes it: it hangs off the metal
+        across the c boundary, so it is unreachable through zero-offset
+        bonds and the unwrap must bridge to it - exactly the branched
+        metal-oxo geometry real rod MOFs have, and what a chain fixture
+        (connected in the home gauge whatever the origin) cannot show.
+        """
+        from pymatgen.analysis.local_env import CovalentRadius
+
+        from autografs.rods import rod_fragment
+
+        repeat_length, bond = 3.76, 1.88
+        lattice = Lattice.tetragonal(20.0, repeat_length)
+        # metal mid-cell; the chain oxygen sits a bond below it, the
+        # pendant a bond above - which wraps past c to the cell floor
+        metal_z = 3.0
+        pendant = np.array([1.2, 0.0, 1.45])  # |pendant| == bond
+        coords = [
+            [0.0, 0.0, metal_z],
+            [0.0, 0.0, metal_z - bond],
+            [pendant[0], 0.0, (metal_z + pendant[2]) % repeat_length],
+        ]
+        structure = Structure(
+            lattice, ["Zn", "O", "O"], coords, coords_are_cartesian=True
+        )
+        rod = RodUnit(
+            atom_indices=[0, 1, 2],
+            axis=np.array([0.0, 0.0, 1.0]),
+            repeat_length=repeat_length,
+            generator=(0, 0, 1),
+            poe_indices=[0],
+            n_connections=1,
+            internal_bonds=[(0, 1, (0, 0, 0)), (0, 2, (0, 0, 1))],
+        )
+        fragment = rod_fragment(structure, rod)
+        assert fragment.bonds
+        for a, b, m in fragment.bonds:
+            shift = np.array([0.0, 0.0, m * fragment.repeat.repeat_length])
+            distance = float(
+                np.linalg.norm(fragment.positions[a] - shift - fragment.positions[b])
+            )
+            target = sum(
+                CovalentRadius.radius[fragment.repeat.symbols[row]] for row in (a, b)
+            )
+            assert distance == pytest.approx(target, abs=0.6), (
+                f"bond {a}-{b} at repeat offset {m} spans {distance:.2f} A "
+                f"against a {target:.2f} A target"
+            )
+
 
 class TestRodSerialization:
     def test_round_trip(self, mofgen, tmp_path):


### PR DESCRIPTION
Self-templated round trips — rebuilding each crystal against its **own**
blueprint instead of a cataloged one — plus the deconstruction and
rod-builder fixes that work exposed.

## What this adds

**Self-templated round trips** (`topology_from_deconstruction`,
`scripts/benchmarks/selftemplate.py`). A deconstruction now carries a
`BlueprintRecipe` (unit centroids + cut midpoints in the home gauge),
from which the structure's own net can be erected: one slot per building
unit at its real position, one shared connection point per cut bond.
Rebuilding on that removes net identification, library coverage and slot
capacity from the question, leaving the rigid-unit abstraction itself
under test. Catenated structures are in scope — the recipe holds every
component, so the erected blueprint is a disconnected quotient whose nets
share one cell at their true relative offset.

**Rod self-templates** (`rod_topology_from_deconstruction`): points of
extension are binned by *chemical* repeat into one node slot each, and a
hand-built `SlotRun`/`HelicalRun` is injected into the validated rod
builder rather than re-detected.

**Deconstruction reach**: a grouped-PoE fallback tier and a
rod-compatibility split for candidate nets; opt-in fusion of parallel
ditopic bridges into composite units (the dominant unmapped-unit
mechanism).

**EPINET**: fetcher and CGD dialect adapter for local analysis only.
EPINET is CC BY-NC-ND — nothing derived from it is bundled or
redistributed, and the adapter must synthesize the `EDGE_CENTER` lines
EPINET omits or stitching yields zero quotient edges.

## Bugs this surfaced in production code

- **Multi-connection anchors lost all but the last-tagged bond.** Anchor
  atoms carrying several connections dropped bonds during fragment
  assembly; `utils` now carries per-dummy `(tag, nearest-real-atom)`
  pairs through the strip. This affects **every** build path.
- **Rod template bond offsets were read in the wrong gauge.**
  `_local_positions` unwraps a rod by walking its bond graph, so an atom
  reached through a periodic-image bond carries a lattice shift — and
  the template-bond arithmetic read each bond's recorded *home-gauge*
  image against those unwrapped coordinates, counting the image twice on
  exactly the bonds the walk had followed. Junction bonds landed 15–25 Å
  from 1.4–2.6 Å targets. Fixes every rod build, not just self-templates.
- **The rod build's transverse scale had no trusted reference.** The
  library-net heuristic landed at 183 where 1 was correct on a real P1
  embedding; and because greedy port-image pairing makes the objective
  multi-modal, a spurious compressed pairing can genuinely outscore the
  true branch — so the free objective cannot referee its own basin.
  Callers can now seed the scale and give it a trust band; leaving the
  band re-solves with the scale frozen.
- **The closure-only relaxation guard never converged**, so it lost
  routinely to its own reference; it is now seeded from the fixed-slot
  solution. Census mappings are also sieved at the build gate, so the
  reported failure buckets attribute correctly.

## Measured

Self-templated round trips close **1901/2247 attempted (84.6%; 88.0% on
the curated subset)** against **445 (19.8%)** library-templated on the
identical population — the catalog, not the chemistry, is what bounds
cataloged generation. Median |vr−1| 0.046, worst bond 0.125 Å.

Rod self-templates are **not** folded into that headline: they now match
the finite arm on packing (|vr−1| median 0.033 vs 0.049) but not on
closure (worst-bond median 1.71 Å vs 0.131), the remaining gap being
rod↔linker port pairing. Fusion of parallel bridges closed 405 → 445.

## Testing

Full suite green (ruff, ruff format, mypy clean). New coverage for the
self-template path, catenated pairs, rod self-templates, parallel-bridge
fusion, the CGD dialect adapter and the benchmark drivers. The
rod-gauge regression test needs a rod with a pendant across the cell
boundary — a bare chain stays connected through zero-offset bonds
whatever the origin, so the unwrap never bridges and the bug stays
invisible, which is why the existing pillar fixture never caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
