### PR TITLE
Put a rod self-template's node slots on the rod's own axis line

### DIFF
--- a/src/autografs/extract_topology.py
+++ b/src/autografs/extract_topology.py
@@ -353,6 +353,7 @@ def rod_topology_from_deconstruction(result: Deconstruction, name: str = "self-r
         of extension unambiguously.
     """
     from autografs.net import HelicalRun, SlotRun
+    from autografs.rods import _local_positions
     from autografs.rods import rod_fragment as _rod_fragment
 
     recipe = result.blueprint
@@ -439,6 +440,48 @@ def rod_topology_from_deconstruction(result: Deconstruction, name: str = "self-r
     fragment = _rod_fragment(result.structure, rod_unit, name="self_rod")
     n_bins = max(1, int(fragment.repeat.screw_order))
     axis_hat = np.asarray(rod_unit.axis, dtype=float)
+    axis_hat = axis_hat / np.linalg.norm(axis_hat)
+
+    # The recipe's PoE positions are in the home gauge, so a rod crossing
+    # a cell boundary has some of them wrapped to the far side - and a
+    # wrapped copy sits off the rod's axis. That matters because the
+    # builder anchors placement to the node centre and can only rotate
+    # about, and slide along, the run axis: a centre off the true axis
+    # line is unreachable geometry, no (theta, z0) recovers it (measured:
+    # node centres 7.6-8.0 A off the axis of rods whose own atoms sit
+    # within 2.2 A of it, and a 128-start rotation x phase grid could not
+    # touch the resulting 6 A error). So work in the rod's UNWRAPPED
+    # gauge throughout: heights, the axis line, and the cut midpoints all
+    # shifted by their own atom's unwrap image. The slot then differs
+    # from its home-cell placement by a lattice vector at most, which is
+    # just a periodic image and leaves the quotient unchanged.
+    unwrapped = _local_positions(
+        result.structure,
+        rod_unit.atom_indices,
+        rod_unit.atom_indices[0],
+        rod_unit.internal_bonds,
+    )
+    row_of_site = {site: row for row, site in enumerate(rod_unit.atom_indices)}
+    lattice_matrix = lattice.matrix
+    inverse_matrix = np.linalg.inv(lattice_matrix)
+    poe_shift = {}
+    for atom, _pos in poe_entries:
+        row = row_of_site.get(atom)
+        if row is None:
+            raise TopologyExtractionError(
+                f"Point of extension {atom} is not among the rod's atoms."
+            )
+        home = np.asarray(result.structure[atom].coords, dtype=float)
+        poe_shift[atom] = np.rint((unwrapped[row] - home) @ inverse_matrix)
+    poe_carts = {
+        atom: cart + poe_shift[atom] @ lattice_matrix
+        for atom, cart in poe_carts.items()
+    }
+    # the axis line: perpendicular centroid of the rod's own unwrapped
+    # atoms, which is canonical_rod's convention and the only transverse
+    # origin a screw symmetry admits
+    centroid = unwrapped.mean(axis=0)
+    axis_origin = centroid - float(np.dot(centroid, axis_hat)) * axis_hat
     heights = {
         atom: float(np.dot(poe_carts[atom], axis_hat)) for atom, _pos in poe_entries
     }
@@ -456,22 +499,30 @@ def rod_topology_from_deconstruction(result: Deconstruction, name: str = "self-r
                 f"Chemical repeat {bin_index} holds no point of "
                 "extension; the axial binning does not describe this rod."
             )
-        connections = [
-            (cut_index, mid) for atom in members for cut_index, mid in poe_cuts[atom]
+        # each midpoint follows its own PoE atom into the unwrapped gauge
+        node_cuts = [
+            (cut_index, mid, atom)
+            for atom in members
+            for cut_index, mid in poe_cuts[atom]
         ]
-        if len(connections) <= 2:
+        if len(node_cuts) <= 2:
             raise TopologyExtractionError(
                 f"Chemical repeat {bin_index} carries "
-                f"{len(connections)} connection(s); the rod builder's "
+                f"{len(node_cuts)} connection(s); the rod builder's "
                 "node convention needs more than two per repeat."
             )
-        center = np.mean([poe_carts[atom] for atom in members], axis=0)
-        species = [get_el_sp(min(len(connections), 118))] + ["X"] * len(connections)
+        # ON the axis line, at this repeat's own height - not the PoE
+        # centroid, which is transverse to it
+        center = (
+            axis_origin + float(np.mean([heights[atom] for atom in members])) * axis_hat
+        )
+        species = [get_el_sp(min(len(node_cuts), 118))] + ["X"] * len(node_cuts)
         carts = [center] + [
             lattice.get_cartesian_coords(np.asarray(mid, dtype=float))
-            for _index, mid in connections
+            + poe_shift[atom] @ lattice_matrix
+            for _index, mid, atom in node_cuts
         ]
-        tags = [0] + [cut_index + 1 for cut_index, _mid in connections]
+        tags = [0] + [cut_index + 1 for cut_index, _mid, _atom in node_cuts]
         slots.append(
             Fragment(
                 atoms=Molecule(species, carts, site_properties={"tags": tags}),
@@ -496,7 +547,7 @@ def rod_topology_from_deconstruction(result: Deconstruction, name: str = "self-r
     )
     period = float(rod_unit.repeat_length)
     if fragment.repeat.screw_order > 1:
-        axis_point = np.mean([poe_carts[atom] for atom, _ in poe_entries], axis=0)
+        axis_point = axis_origin
         run: SlotRun | HelicalRun = HelicalRun(
             direction=direction,
             slots=tuple(run_slots),

--- a/tests/test_deconstruct.py
+++ b/tests/test_deconstruct.py
@@ -782,6 +782,42 @@ class TestRodSelfTemplate:
     - the last library wall, removed for the single-rod case.
     """
 
+    def test_node_slots_sit_on_the_rods_own_axis(self, mofgen):
+        """A run node centre must lie on the rod's axis line.
+
+        The builder can only rotate the rod about the run axis and
+        slide it along: a node centre off that line is unreachable
+        geometry, and no (theta, z0) recovers it. Taking the centre as
+        the centroid of the points of extension put it 7.6-8.0 A off
+        the axis on real corpus rods - they are transverse to it, and
+        home-gauge wrapping moves them further - which left the rod ~6 A
+        from its own crystal position with bonds 3-7 A long.
+        """
+        import numpy as np
+
+        from autografs.extract_topology import rod_topology_from_deconstruction
+        from autografs.rods import _local_positions
+
+        result = mofgen.deconstruct(_rod_pillar_structure(1))
+        rod_unit = result.rod_units[0]
+        axis = np.asarray(rod_unit.axis, dtype=float)
+        axis = axis / np.linalg.norm(axis)
+        unwrapped = _local_positions(
+            result.structure,
+            rod_unit.atom_indices,
+            rod_unit.atom_indices[0],
+            rod_unit.internal_bonds,
+        )
+        centroid = unwrapped.mean(axis=0)
+        topology, run, _lateral_mapping, _fragment = rod_topology_from_deconstruction(
+            result
+        )
+        for slot_index in run.slots:
+            centre = np.asarray(topology.slots[slot_index].atoms[0].coords, dtype=float)
+            offset = centre - centroid
+            perpendicular = offset - np.dot(offset, axis) * axis
+            assert np.linalg.norm(perpendicular) == pytest.approx(0.0, abs=1e-6)
+
     def test_pillar_rebuilds_on_its_own_run(self, mofgen):
         import copy
 


### PR DESCRIPTION
A rod self-template's run node slots were placed off the rod's own axis
line, which put the crystal's true geometry **outside** what the
placement can express.

## The defect

`build_rod_framework` places a rod by rotating it about the run axis and
sliding it along — so a run node centre must lie **on** that axis. The
constructor took it as the centroid of the repeat's points of extension,
which are *transverse* to the axis, and read them in the home gauge,
where a rod crossing a cell boundary has some wrapped to the far side.

Measured on two corpus rods whose own atoms sit within 2.2 Å and 3.8 Å of
their axis: node centres **7.65 Å and 7.99 Å off it**. The rod therefore
landed ~6 Å from its own crystal position with inter-unit bonds 3–7 Å
long.

## Why this took three attempts to find

Two plausible explanations were tested and **rejected by measurement**
before the real one turned up:

1. **A missing coarse grid over the axial phase.** Only the rotation
   `theta` had one; `z0` went straight from a single heuristic into
   Nelder-Mead. Adding a joint 16 × 8 grid (128 starts) moved the error
   by 0.1 Å — and was reverted.
2. **Greedy port pairing outscoring the true pairing.** `_pair_ports`
   spends the blueprint's slot-pair budget but lets geometry pick the
   individual ports, and for a self-template the blueprint's tags are a
   complete exact pairing it ignores. That redesign was scoped, then
   turned out unnecessary.

Both stories were consistent with the symptom. Neither was the cause:
the geometry was simply unreachable, so no starting point and no search
could have helped. **Check reachability before redesigning the search.**

## The fix

Node centres now sit on the axis line — the perpendicular centroid of the
rod's unwrapped atoms, which is `canonical_rod`'s own convention and the
only transverse origin a screw symmetry admits — at each repeat's height.
Heights, binning and cut midpoints all move to the rod's unwrapped gauge,
each midpoint following its own atom's image. The slot then differs from
its home-cell placement by a lattice vector at most, which is a periodic
image and leaves the quotient unchanged.

## Measured

Traced Sc rod: **0.01 Å from its own crystal position, 0/20 bonds beyond
1 Å** (was 6.23 Å and 16/20, worst 3.55 Å). Tm rod: 6.59 → 4.58 Å and
32 → 8 bad bonds, so a residual remains there.

Over the 532-structure rod self-template sweep, against the previous
run:

| | before | after |
|---|---|---|
| worst-bond median | 1.710 Å | **0.333 Å** |
| median-bond median | 0.522 Å | **0.116 Å** |
| worst-bond ≥ 3 Å | 36 of 113 | **2 of 114** |
| \|vr−1\| median | 0.033 | 0.042 |

For reference the finite self-template arm (n=1901) runs |vr−1| 0.049,
worst-bond median 0.131 Å, p90 0.836 Å — so the rod arm now matches on
packing and sits within about 2.5× on worst-bond (p90 1.265 Å).

## Testing

Full suite green, ruff and mypy clean. New test asserts every run node
centre lies on the rod's axis line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
