### PR TITLE
Sweep the rod build's axial phase, not just its rotation

### DIFF
--- a/src/autografs/rod_build.py
+++ b/src/autografs/rod_build.py
@@ -1874,19 +1874,36 @@ def build_rod_framework(
     # library-net heuristic
     build.initial_scale = initial_scale
 
-    # optimize: coarse rotation grid per axis family (a full product
-    # grid would be 16^families), then refine everything with Nelder-Mead
+    # optimize: coarse (rotation, axial phase) grid per axis family - a
+    # full product grid over families would be 16^families - then refine
+    # everything with Nelder-Mead. The two are swept TOGETHER because
+    # which arm meets which linker depends on both; the phase spans one
+    # chemical repeat, beyond which the placed rod maps onto itself, and
+    # the offsets are relative to initial_guess so its heuristic
+    # placement stays among the candidates. Sweeping the phase only pays
+    # once the node slots are ON the run axis: while a self-blueprint put
+    # them transverse to it the crystal's placement was unreachable at
+    # every start, and this grid moved a 6 A error by 0.1 A.
     def solve() -> Any:
         start = build.initial_guess()
+        angles = np.linspace(0.0, 2.0 * np.pi, 16, endpoint=False)
+        phases = np.linspace(
+            0.0, float(build.rod.repeat.repeat_length), 8, endpoint=False
+        )
         for family in range(build.n_families):
-            angles = np.linspace(0.0, 2.0 * np.pi, 16, endpoint=False)
+            base_z = float(start[2 + 2 * family])
 
-            def value_at(angle: float, family: int = family) -> float:
+            def value_at(
+                candidate: tuple[float, float], family: int = family, z: float = base_z
+            ) -> float:
                 trial = start.copy()
-                trial[1 + 2 * family] = angle
+                trial[1 + 2 * family] = candidate[0]
+                trial[2 + 2 * family] = z + candidate[1]
                 return build.objective(trial)
 
-            start[1 + 2 * family] = min(angles, key=value_at)
+            angle, phase = min(((a, p) for a in angles for p in phases), key=value_at)
+            start[1 + 2 * family] = angle
+            start[2 + 2 * family] = base_z + phase
         return minimize(
             build.objective,
             start,


### PR DESCRIPTION
The coarse grid that seeds the rod build's Nelder-Mead refinement swept
the rotation about each run axis but **not** the axial phase `z0`, which
went straight from a single heuristic into local refinement.

A rod slid half a repeat presents different arms to the same linkers, so
the axial phase is a genuinely multi-modal coordinate and a local
refinement cannot cross it. Rotation and phase are now swept together —
which arm meets which linker depends on both — with the phase spanning
one chemical repeat, beyond which the placed rod maps onto itself. The
offsets are relative to `initial_guess`, so its heuristic placement stays
among the candidates and this can only lower the objective at the start.

## Why it did nothing until #218

This exact grid was tried *before* the node-slot axis fix and moved a 6 Å
placement error by 0.1 Å, so it was reverted as ineffective. While a
self-blueprint placed its node slots transverse to the run axis, the
crystal's placement was unreachable from **every** start — no search
improvement could have helped. Once the geometry became expressible, the
same grid started paying immediately.

## Measured

Over the 532-structure rod self-template sweep, on top of #218:

| | axis only | axis + phase |
|---|---|---|
| \|vr−1\| median | 0.042 | **0.026** |
| \|vr−1\| p90 | 0.289 | **0.159** |
| worst-bond median | 0.333 Å | **0.291 Å** |
| worst-bond p90 | 1.265 Å | **0.787 Å** |
| median-bond median | 0.116 Å | **0.087 Å** |
| worst-bond in 1–3 Å | 14 of 114 | **6 of 114** |

Per structure: 31 better, 7 marginally worse (largest 0.28 → 0.55 Å), 76
unchanged. A different basin can cost a little on one bond while the
population improves; the p90 moving 1.265 → 0.787 Å is the clearest
signal.

For reference the finite self-template arm (n=1901) runs |vr−1| median
0.049 and worst-bond p90 0.836 Å — so the rod arm now sits at or beyond
it on both, and within about 2.2× on worst-bond median (0.291 vs 0.131).

Cost: 4 s on the rod test suite (81 → 85 s); the objective is cheap
relative to the rest of a build.

## Testing

Full suite green, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
