### PR TITLE
Do not require a caller-supplied rod run to be quotient-adjacent

### DIFF
--- a/src/autografs/rod_build.py
+++ b/src/autografs/rod_build.py
@@ -249,7 +249,18 @@ def _unwrapped_run_positions(
     pos = {run.slots[0]: wrapped[run.slots[0]]}
     cur = run.slots[0]
     for nxt in run.slots[1:]:
-        disp = next(d for w, d in steps[cur] if w == nxt)
+        # a run detected on a blueprint steps between quotient-adjacent
+        # slots, but a caller-supplied run need not: a self-derived
+        # blueprint cuts only rod-to-lateral bonds, so its run nodes -
+        # related through the rod itself - share no edge at all. Fall
+        # back to the minimum image of the two centres, which is the
+        # same displacement whenever an edge does exist and is right by
+        # construction for a self-blueprint (its slot centres are
+        # already unwrapped onto the run axis).
+        disp = next((d for w, d in steps[cur] if w == nxt), None)
+        if disp is None:
+            delta = wrapped[nxt] - wrapped[cur]
+            disp = delta - np.round(delta @ np.linalg.inv(cell)) @ cell
         pos[nxt] = pos[cur] + disp
         cur = nxt
     return pos


### PR DESCRIPTION
`_unwrapped_run_positions` walks a run by stepping between consecutive
slots along blueprint quotient edges. That holds for a run *detected* on
a blueprint, but not for one handed in by a caller: a self-derived
blueprint cuts only rod-to-lateral bonds, so its run node slots — which
are related through the rod itself — share no edge at all. The walk then
raised a bare `StopIteration` out of `build_rod_framework`.

It now falls back to the minimum image between the two slot centres. That
is the same displacement whenever an edge does exist, and it is right by
construction for a self-blueprint, whose centres are already unwrapped
onto the run axis (#218).

Letting a bare `StopIteration` escape was a latent hazard in its own
right: inside a generator it truncates silently instead of raising.

## Measured

All 7 structures failing this way in the 532-structure rod self-template
sweep now build (helical runs of 2 and 4 nodes, directions ⟨100⟩, ⟨001⟩
and ⟨110⟩).

Full suite green, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)