### PR TITLE
Give a monotopic lateral SBU an arm direction it can be placed by

### DIFF
--- a/src/autografs/rod_build.py
+++ b/src/autografs/rod_build.py
@@ -454,7 +454,16 @@ def _species_of(linker: Fragment) -> _Species:
     anchor_rows = _linker_anchor_rows(linker)
     symbols = [site.specie.symbol for site in linker.atoms]
     center = coords[dummy_rows].mean(axis=0)
-    arm_units = _unit_rows(coords[dummy_rows] - center)
+    arms = coords[dummy_rows] - center
+    if len(dummy_rows) == 1:
+        # a monotopic cap has no dummy spread to measure an arm against:
+        # the dummy centroid IS its one dummy, so the difference above is
+        # zero. The direction that orients it is the one its own bond
+        # points along, anchor -> dummy. Rod self-templates raise these
+        # routinely - a solvent capping the rod is a building unit like
+        # any other, where a harvested library drops monotopic caps.
+        arms = coords[dummy_rows] - coords[anchor_rows]
+    arm_units = _unit_rows(arms)
     relief_axis = None
     if len(dummy_rows) == 2 and -arm_units[0] @ arm_units[1] > RELIEF_COLLINEAR_DOT:
         # a straight ditopic linker: its anchors sit on the arm axis, so


### PR DESCRIPTION
`_species_of` measures each arm as the offset of a dummy from the **dummy
centroid**. With a single dummy that centroid *is* the dummy, so the arm
came out zero-length and every monotopic SBU was refused outright with
`Degenerate (zero-length) arm vector` — a cap could never fill a lateral
slot.

The direction is not missing, only measured from the wrong origin: a cap
points along its own bond, anchor → dummy, which is exactly what orients
it against the slot arm. Species with two or more dummies keep the
centroid convention untouched, so this is purely additive — the only
inputs whose behaviour changes are the ones that used to raise.

## Why rod self-templates hit this and a harvested library does not

In a crystal's own blueprint a solvent capping the rod is a building unit
like any other, and gets its own lateral slot. `HarvestResult.building_units`
deliberately drops monotopic caps, so the library path never presented one.

Observed fragments: `cap_C13H9O3_1X`, `cap_CH3_1X`.

## Measured

9 of 215 single-rod attempts in the rod self-template sweep failed this
way; all three traced structures now build.

Full suite green, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)