### PR TITLE
Let a slot run declare its own point-of-extension nodes

### DIFF
--- a/src/autografs/extract_topology.py
+++ b/src/autografs/extract_topology.py
@@ -485,7 +485,12 @@ def rod_topology_from_deconstruction(result: Deconstruction, name: str = "self-r
     heights = {
         atom: float(np.dot(poe_carts[atom], axis_hat)) for atom, _pos in poe_entries
     }
-    z_min = min(heights.values())
+    # slab origin: the rod's OWN lowest atom, which is where
+    # rods.rod_fragment starts counting chemical repeats. Measuring from
+    # the lowest point of extension instead shifts every boundary and
+    # splits a repeat's cuts across two bins, so the blueprint's node
+    # slots stop matching the fragment's arms-per-repeat.
+    z_min = float(np.min(unwrapped @ axis_hat))
     chemical = float(rod_unit.repeat_length) / n_bins
     bins: list[list[int]] = [[] for _ in range(n_bins)]
     for atom, _pos in poe_entries:
@@ -505,11 +510,10 @@ def rod_topology_from_deconstruction(result: Deconstruction, name: str = "self-r
             for atom in members
             for cut_index, mid in poe_cuts[atom]
         ]
-        if len(node_cuts) <= 2:
+        if not node_cuts:
             raise TopologyExtractionError(
-                f"Chemical repeat {bin_index} carries "
-                f"{len(node_cuts)} connection(s); the rod builder's "
-                "node convention needs more than two per repeat."
+                f"Chemical repeat {bin_index} carries no connection to "
+                "any lateral unit, so it has nothing to build against."
             )
         # ON the axis line, at this repeat's own height - not the PoE
         # centroid, which is transverse to it
@@ -548,6 +552,9 @@ def rod_topology_from_deconstruction(result: Deconstruction, name: str = "self-r
     period = float(rod_unit.repeat_length)
     if fragment.repeat.screw_order > 1:
         axis_point = axis_origin
+        # every slot on this run is a point of extension by construction
+        # (one per chemical repeat, no edge centers), which the
+        # builder's dummy-count convention cannot infer - so declare it
         run: SlotRun | HelicalRun = HelicalRun(
             direction=direction,
             slots=tuple(run_slots),
@@ -559,7 +566,13 @@ def rod_topology_from_deconstruction(result: Deconstruction, name: str = "self-r
                 float(axis_point[1]),
                 float(axis_point[2]),
             ),
+            nodes=tuple(run_slots),
         )
     else:
-        run = SlotRun(direction=direction, slots=tuple(run_slots), period=period)
+        run = SlotRun(
+            direction=direction,
+            slots=tuple(run_slots),
+            period=period,
+            nodes=tuple(run_slots),
+        )
     return topology, run, lateral_mapping, fragment

--- a/src/autografs/net.py
+++ b/src/autografs/net.py
@@ -756,11 +756,19 @@ class SlotRun:
         smallest index.
     period : float
         Length of one period along the axis (|direction @ cell|).
+    nodes : tuple[int, ...] or None
+        The run's point-of-extension slots, when the caller knows them.
+        Detection leaves this None and rod building infers them from
+        the blueprint convention (a node out-connects the 2-connected
+        edge centers between them). A hand-built run - a structure's
+        own blueprint, say - has no edge centers to tell apart and
+        every slot on it is a node, which the convention cannot see.
     """
 
     direction: tuple[int, int, int]
     slots: tuple[int, ...]
     period: float
+    nodes: tuple[int, ...] | None = None
 
 
 def axial_runs(
@@ -898,6 +906,9 @@ class HelicalRun:
     axis_point : tuple[float, float, float]
         A cartesian point the screw axis line passes through (the
         perpendicular centroid of one period's node slots).
+    nodes : tuple[int, ...] or None
+        The run's point-of-extension slots when the caller knows them;
+        see :class:`SlotRun`.
     """
 
     direction: tuple[int, int, int]
@@ -906,6 +917,7 @@ class HelicalRun:
     screw_angle: float
     screw_order: int
     axis_point: tuple[float, float, float]
+    nodes: tuple[int, ...] | None = None
 
 
 def _directed_steps(

--- a/src/autografs/net.py
+++ b/src/autografs/net.py
@@ -1162,10 +1162,23 @@ def topology_rod_quotient_edges(
     """
     runs = run if isinstance(run, list) else [run]
     run_slots = {s for a_run in runs for s in a_run.slots}
+    # a run that knows its own nodes is believed, exactly as in rod
+    # building: under the two-connection convention a hand-built run's
+    # node - a chemical repeat binding two laterals - reads as an edge
+    # center and gets contracted away, which silently halves the bond
+    # count the build is then measured against.
     node_slots = {
         s
-        for s in run_slots
-        if len(topology.slots[s].atoms.indices_from_symbol("X")) > 2
+        for a_run in runs
+        for s in (
+            a_run.nodes
+            if a_run.nodes is not None
+            else [
+                t
+                for t in a_run.slots
+                if len(topology.slots[t].atoms.indices_from_symbol("X")) > 2
+            ]
+        )
     }
     adjacency = _adjacency(topology_quotient_edges(topology))
     for slot in (run_slots - node_slots) | set(empty_slots):

--- a/src/autografs/rod_build.py
+++ b/src/autografs/rod_build.py
@@ -256,11 +256,20 @@ def _unwrapped_run_positions(
 
 
 def _node_slots(topology: Topology, run: SlotRun | HelicalRun) -> list[int]:
-    """The run's point-of-extension slots (more than two connections)."""
+    """The run's point-of-extension slots.
+
+    A detected run alternates nodes with 2-connected edge centers, so
+    carrying more than two connections is what marks a node. A run that
+    knows its own nodes says so and is believed: a hand-built run - a
+    structure's own blueprint, say - has no edge centers to tell apart,
+    and a repeat binding only two laterals looks exactly like one under
+    the convention. Reading it literally there dropped real nodes and
+    collapsed the repeat arithmetic.
+    """
+    if run.nodes is not None:
+        return list(run.nodes)
     return [
-        s
-        for s in run.slots
-        if len(topology.slots[s].atoms.indices_from_symbol("X")) > 2
+        s for s in run.slots if len(topology.slots[s].atoms.indices_from_symbol("X")) > 2
     ]
 
 

--- a/src/autografs/rod_build.py
+++ b/src/autografs/rod_build.py
@@ -280,7 +280,9 @@ def _node_slots(topology: Topology, run: SlotRun | HelicalRun) -> list[int]:
     if run.nodes is not None:
         return list(run.nodes)
     return [
-        s for s in run.slots if len(topology.slots[s].atoms.indices_from_symbol("X")) > 2
+        s
+        for s in run.slots
+        if len(topology.slots[s].atoms.indices_from_symbol("X")) > 2
     ]
 
 


### PR DESCRIPTION
Rod building infers a run''s nodes from the blueprint convention: a node
out-connects the 2-connected edge centers between them, so carrying more
than two connections is what marks one.

That reads a **detected** run correctly and a **hand-built** one wrongly.
A structure''s own blueprint has no edge centers to tell apart — every
slot on its run is a node, one per chemical repeat — and a repeat that
happens to bind only two laterals is indistinguishable from an edge
center under the convention. Real nodes were dropped, the repeat
arithmetic collapsed, and the self-template constructor refused such rods
up front (`the rod builder''s node convention needs more than two per
repeat`).

`SlotRun` and `HelicalRun` now carry an optional `nodes`. Detection
leaves it `None` and the library path is untouched; the self-template
constructor sets it, since one slot per chemical repeat is exactly what
it built.

## The convention lives in two places

`topology_rod_quotient_edges` carries its own copy, so honouring `nodes`
in the builder alone fixed only half the path: the quotient still read a
hand-built run''s node as an axial edge center and contracted it away.
That **silently halved the bond count** the build is measured against,
and `_pair_ports` then refused structures whose ports were in fact
exactly right — `expects 2 inter-unit bonds but the rod and the linkers
bring 8 connection points`. Both sites now honour the declaration.

## A related origin bug

The constructor''s axial binning measured from the lowest **point of
extension**, while `rods.rod_fragment` counts chemical repeats from the
lowest **rod atom**. A different origin shifts every slab boundary and
splits a repeat''s cuts across two bins, so the node slots stop matching
the fragment''s arms per repeat. Both now use the rod''s own origin.

## Measured

This was the largest remaining refusal bucket after the diagonal fix — 22
of 215 single-rod attempts, plus the 20 port-budget refusals the halved
count produced. Every traced structure in both buckets now builds.

Full suite green, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)