### PR TITLE
Bin a rod self-template by the rod's own slab decomposition

### DIFF
--- a/src/autografs/extract_topology.py
+++ b/src/autografs/extract_topology.py
@@ -485,16 +485,23 @@ def rod_topology_from_deconstruction(result: Deconstruction, name: str = "self-r
     heights = {
         atom: float(np.dot(poe_carts[atom], axis_hat)) for atom, _pos in poe_entries
     }
-    # slab origin: the rod's OWN lowest atom, which is where
-    # rods.rod_fragment starts counting chemical repeats. Measuring from
-    # the lowest point of extension instead shifts every boundary and
-    # splits a repeat's cuts across two bins, so the blueprint's node
-    # slots stop matching the fragment's arms-per-repeat.
-    z_min = float(np.min(unwrapped @ axis_hat))
+    # bin the points of extension by the rod's OWN decomposition rather
+    # than by axial height. Height binning is only a proxy for it, and
+    # the two part company exactly where rod_fragment's slab cut would
+    # have split an atom cluster and it fell back to a
+    # nearest-to-expected selection: the blueprint then hands a node
+    # slot a different number of cuts than the fragment has arms per
+    # repeat, and the build is refused for a disagreement that is an
+    # artifact of measuring the same decomposition twice.
     chemical = float(rod_unit.repeat_length) / n_bins
+    assignment = fragment.atom_repeats or {}
     bins: list[list[int]] = [[] for _ in range(n_bins)]
     for atom, _pos in poe_entries:
-        index = int(np.floor((heights[atom] - z_min) / chemical + 1e-6))
+        if atom in assignment:
+            index = assignment[atom] % n_bins
+        else:  # a point of extension the fragment did not place
+            z_min = float(np.min(unwrapped @ axis_hat))
+            index = int(np.floor((heights[atom] - z_min) / chemical + 1e-6))
         bins[min(max(index, 0), n_bins - 1)].append(atom)
 
     run_slots: list[int] = []

--- a/src/autografs/rods.py
+++ b/src/autografs/rods.py
@@ -389,6 +389,14 @@ class RodFragment:
         it, identity does not.
     name : str
         Library name, set by ``merge_rod``/harvest.
+    atom_repeats : dict[int, int] or None
+        Which chemical repeat each atom of the *source* structure fell
+        into, keyed by site index — the decomposition this fragment was
+        reduced by, kept so a caller can bin the same rod's points of
+        extension exactly as the arms were binned rather than
+        re-deriving it from axial heights and disagreeing at a slab
+        boundary. Structure-specific and therefore not serialized: a
+        fragment loaded from a sidecar has None.
     """
 
     repeat: RodRepeat
@@ -396,6 +404,7 @@ class RodFragment:
     arms: list[tuple[int, np.ndarray]] = field(repr=False)
     bonds: list[tuple[int, int, int]] = field(repr=False, default_factory=list)
     name: str = "rod"
+    atom_repeats: dict[int, int] | None = field(repr=False, default=None)
 
     @property
     def symbols(self) -> list[str]:
@@ -516,32 +525,50 @@ def rod_fragment(
     # chemical) is unambiguous. Works for straight (screw 0) and
     # helical rods alike; identity does not need bonds - forward
     # building does.
+    axis_hat = basis[2]
+    screw_rad = np.radians(screw)
+    template_axial_all = axial % chemical
+    slab_all = np.floor(axial / chemical + 1e-6)
+    kept = np.flatnonzero(keep)
+    kept_axial = template_axial_all[kept]
+    kept_radial = radial[kept]
+    kept_angular = angular[kept]
+
+    def _template_row(full_row: int) -> int:
+        # nearest kept atom after de-screwing this atom's azimuth by
+        # its slab: slab s sits at (rho, theta + s*screw, z + s*chem)
+        slab = slab_all[full_row]
+        da = np.abs(template_axial_all[full_row] - kept_axial)
+        da = np.minimum(da, chemical - da)
+        drho = np.abs(radial[full_row] - kept_radial)
+        dth = np.abs(
+            (angular[full_row] - slab * screw_rad - kept_angular + np.pi)
+            % (2.0 * np.pi)
+            - np.pi
+        )
+        return int(np.argmin(da + drho + radial[full_row] * dth))
+
+    def _repeat_index(full_row: int) -> int:
+        """Which chemical repeat this atom fell into."""
+        return int(
+            round(
+                (axial_unwrapped[full_row] - kept_axial[_template_row(full_row)])
+                / chemical
+            )
+        )
+
+    # the decomposition itself, in the source structure's own site
+    # indices. Recording it is what lets a caller bin the same rod's
+    # points of extension the way the arms were binned; deriving that
+    # from axial heights instead disagrees wherever `keep` fell back to
+    # a nearest-to-expected selection rather than a clean slab cut.
+    atom_repeats = {
+        int(site): _repeat_index(row) for row, site in enumerate(rod.atom_indices)
+    }
+
     bonds_local: list[tuple[int, int, int]] = []
     if rod.internal_bonds:
-        axis_hat = basis[2]
         matrix = structure.lattice.matrix
-        screw_rad = np.radians(screw)
-        template_axial_all = axial % chemical
-        slab_all = np.floor(axial / chemical + 1e-6)
-        kept = np.flatnonzero(keep)
-        kept_axial = template_axial_all[kept]
-        kept_radial = radial[kept]
-        kept_angular = angular[kept]
-
-        def _template_row(full_row: int) -> int:
-            # nearest kept atom after de-screwing this atom's azimuth by
-            # its slab: slab s sits at (rho, theta + s*screw, z + s*chem)
-            slab = slab_all[full_row]
-            da = np.abs(template_axial_all[full_row] - kept_axial)
-            da = np.minimum(da, chemical - da)
-            drho = np.abs(radial[full_row] - kept_radial)
-            dth = np.abs(
-                (angular[full_row] - slab * screw_rad - kept_angular + np.pi)
-                % (2.0 * np.pi)
-                - np.pi
-            )
-            return int(np.argmin(da + drho + radial[full_row] * dth))
-
         seen: set[tuple[int, int, int]] = set()
         for i, j, off in rod.internal_bonds:
             row_i, row_j = row_of[i], row_of[j]
@@ -555,7 +582,7 @@ def rod_fragment(
                 np.asarray(off, dtype=float) + unwrap_shift[row_i] - unwrap_shift[row_j]
             )
             off_axial = float((residual @ matrix) @ axis_hat)
-            n_i = round((axial_unwrapped[row_i] - kept_axial[a]) / chemical)
+            n_i = _repeat_index(row_i)
             n_j = round((axial_unwrapped[row_j] + off_axial - kept_axial[b]) / chemical)
             m = int(n_j - n_i)
             key = (a, b, m) if (a, b, m) <= (b, a, -m) else (b, a, -m)
@@ -587,6 +614,7 @@ def rod_fragment(
         arms=arms,
         bonds=bonds_local,
         name=name,
+        atom_repeats=atom_repeats,
     )
 
 

--- a/tests/test_rods.py
+++ b/tests/test_rods.py
@@ -11,6 +11,7 @@ the same rod dedupe into one family; a metal swap does not).
 """
 
 import math
+from collections import Counter
 
 import numpy as np
 import pytest
@@ -944,6 +945,37 @@ class TestRodFragment:
         fragment = rod_fragment(structure, rod)
         assert fragment.arms == []
         assert fragment.repeat.screw_order == 4
+
+    @pytest.mark.parametrize("n_repeats", [1, 2])
+    def test_atom_repeats_partition_the_rod_evenly(self, mofgen, n_repeats):
+        """The recorded decomposition must be the one the arms came from.
+
+        ``atom_repeats`` says which chemical repeat each source atom
+        fell into, and a caller (the self-template constructor) bins
+        the rod's points of extension by it. That is only sound if it
+        agrees with the reduction the arms went through, so: every
+        repeat holds the same number of atoms, repeat 0 is exactly the
+        template, and the cut-carrying atoms distribute one arm's worth
+        per repeat.
+        """
+        from autografs.rods import rod_fragment
+
+        result = mofgen.deconstruct(_rod_pillar_structure(n_repeats))
+        rod = result.rod_units[0]
+        fragment = rod_fragment(result.structure, rod)
+        assignment = fragment.atom_repeats
+        assert assignment is not None
+        assert set(assignment) == set(rod.atom_indices)
+        order = fragment.repeat.screw_order
+        counts = Counter(index % max(order, 1) for index in assignment.values())
+        assert set(counts) == set(range(max(order, 1)))
+        assert len(set(counts.values())) == 1, counts
+        assert counts[0] == len(fragment.positions)
+        # the cuts follow the atoms: one repeat's worth of arms each
+        per_repeat = Counter(
+            assignment[site] % max(order, 1) for site, _vector in rod.cut_vectors
+        )
+        assert set(per_repeat.values()) == {len(fragment.arms)}
 
     def test_template_bonds_survive_an_unwrap_bridge(self):
         """Every recorded template bond must be a real bond length.


### PR DESCRIPTION
`rod_fragment` reduces a rod to one chemical repeat by cutting an axial
slab, with a documented fallback: when that cut would split an atom
cluster it keeps the nearest-to-expected atoms by axial order instead.

The self-template constructor re-derived the same decomposition from
axial heights. That is only a *proxy* for it, and the two part company
exactly where the fallback fires — the blueprint then hands a node slot
a different number of cuts than the fragment has arms per repeat, and the
build is refused (`carries 3 arms per repeat but node slot 6 expects 1
lateral connections`) over a disagreement that is an artifact of
measuring one decomposition twice.

`RodFragment` now records the decomposition it actually used —
`atom_repeats`, mapping source site index to chemical repeat — and the
constructor bins the points of extension by it. The mapping is
structure-specific, so it is deliberately **not serialized**: a fragment
loaded from a rods sidecar has `None`, and the caller falls back to the
height heuristic.

`rod_fragment`''s template-row machinery moves out of the internal-bonds
branch so it serves both the bond offsets and the decomposition, and the
bond loop now reuses the shared repeat index rather than recomputing it.

## Measured

All five corpus structures that failed with an arm-count mismatch now
build. That was the last bucket in the rod self-template sweep with a
mechanical cause; what remains is 10 legitimate shape-gate rejections
and 2 diagonal runs that genuinely need a supercell transformation.

## Testing

New test asserts the recorded decomposition is the one the arms came
from: every repeat holds the same number of atoms, repeat 0 is exactly
the template, and the cut-carrying atoms distribute one arm''s worth per
repeat. Full suite green, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)