### PR TITLE
Hand LAMMPS our own bonds and atom types instead of a bare CIF

### DIFF
--- a/src/autografs/elastic.py
+++ b/src/autografs/elastic.py
@@ -366,7 +366,11 @@ def elastic_properties(
     quiet: contextlib.AbstractContextManager = (
         contextlib.nullcontext() if verbose else contextlib.redirect_stdout(sink)
     )
-    with tempfile.TemporaryDirectory(prefix="autografs_elastic_") as tmp:
+    # ignore_cleanup_errors: see relax_framework - a lingering handle on
+    # the staged LAMMPS files must not discard a completed calculation
+    with tempfile.TemporaryDirectory(
+        prefix="autografs_elastic_", ignore_cleanup_errors=True
+    ) as tmp:
         workdir = Path(tmp)
         safe_name, _ = _write_lammps_inputs(
             framework, force_field, cutoff, workdir, quiet

--- a/src/autografs/framework.py
+++ b/src/autografs/framework.py
@@ -48,6 +48,98 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
+#: CIF bond-type codes, the subset every consumer agrees on. Anything
+#: else falls back to a single bond, which is what a reader does anyway.
+_CIF_BOND_TYPES = {1.0: "S", 1.5: "A", 2.0: "D", 3.0: "T", 4.0: "Q"}
+
+
+def _append_cif_bonds(path: Path, framework: Framework) -> None:
+    """Add a ``_geom_bond_*`` loop carrying the framework's own bonds.
+
+    A built framework knows its bonds exactly - they come from the
+    blueprint's dummy correspondences, not from a distance criterion -
+    and a CIF can carry them, so it should. Without the loop every
+    consumer re-perceives bonding from geometry and has to guess, which
+    goes wrong precisely where the chemistry is unusual: multi-metal rod
+    nodes, and any structure whose atoms sit closer than a perception
+    cutoff expects.
+
+    Periodic bonds are what make this non-trivial. The bonded image of
+    the second atom is recorded in ``_geom_bond_site_symmetry_2`` using
+    the standard ``1_555`` encoding (each digit 5 + the lattice
+    translation), with ``.`` for a bond that stays inside the cell -
+    the same convention pymatgen, the CCDC and lammps-interface read.
+    """
+    graph = framework.graph
+    if graph.number_of_edges() == 0:
+        return
+    lines = path.read_text(encoding="utf-8").splitlines()
+    labels = _cif_site_labels(lines)
+    order = sorted(graph.nodes)
+    if len(labels) != len(order):
+        raise ValueError(
+            f"CIF site count ({len(labels)}) does not match the framework's "
+            f"atom count ({len(order)}) in {path}."
+        )
+    label_of = dict(zip(order, labels, strict=True))
+    # wrapped fractional coordinates: the CIF's own frame, so the image
+    # offsets below are the ones a reader will reconstruct
+    structure = framework.structure
+    frac = np.asarray(structure.frac_coords, dtype=float)
+    index_of = {node: i for i, node in enumerate(order)}
+    lattice = structure.lattice
+    rows: list[str] = []
+    for u, v, data in graph.edges(data=True):
+        iu, iv = index_of[u], index_of[v]
+        delta = frac[iu] - frac[iv]
+        image = np.rint(delta).astype(int)
+        distance = float(
+            np.linalg.norm((delta - image) @ np.asarray(lattice.matrix, dtype=float))
+        )
+        if np.any(np.abs(image) > 4):  # unrepresentable in the 1_555 form
+            continue
+        flag = (
+            "." if not np.any(image) else "1_{}{}{}".format(*(5 + image))  # noqa: UP032 - clearer here
+        )
+        code = _CIF_BOND_TYPES.get(round(float(data.get("bond_order", 1.0)), 2), "S")
+        rows.append(f"  {label_of[u]}  {label_of[v]}  {distance:.5f}  {flag}  {code}")
+    if not rows:
+        return
+    lines.extend(
+        [
+            "",
+            "loop_",
+            " _geom_bond_atom_site_label_1",
+            " _geom_bond_atom_site_label_2",
+            " _geom_bond_distance",
+            " _geom_bond_site_symmetry_2",
+            " _ccdc_geom_bond_type",
+            *rows,
+        ]
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _cif_site_labels(lines: list[str]) -> list[str]:
+    """The ``_atom_site_label`` column of a P1 CIF, in file order."""
+    headers = [
+        i for i, line in enumerate(lines) if line.strip().startswith("_atom_site_")
+    ]
+    if not headers:
+        raise ValueError("No _atom_site_ loop found in the CIF.")
+    column = next(
+        i
+        for i, header in enumerate(headers)
+        if lines[header].strip() == "_atom_site_label"
+    )
+    labels = []
+    for i in range(headers[-1] + 1, len(lines)):
+        if not lines[i].strip() or lines[i].strip().startswith(("loop_", "_", "#")):
+            break
+        labels.append(lines[i].split()[column])
+    return labels
+
+
 def _append_cif_charges(path: Path, charges: np.ndarray) -> None:
     """Add an ``_atom_site_charge`` column to a P1 CIF pymatgen wrote.
 
@@ -436,7 +528,12 @@ class Framework:
             site_properties=site_properties,
         )
 
-    def write_cif(self, path: str | Path, symprec: float | None = None) -> Path:
+    def write_cif(
+        self,
+        path: str | Path,
+        symprec: float | None = None,
+        write_bonds: bool = False,
+    ) -> Path:
         """Write the framework to a CIF file.
 
         Parameters
@@ -447,6 +544,13 @@ class Framework:
             If given, pymatgen attempts to detect symmetry with this
             tolerance and writes a symmetrized CIF; None (default)
             writes P1.
+        write_bonds : bool, optional
+            Append a ``_geom_bond_*`` loop carrying the framework's own
+            bonds, with periodic images in the standard ``1_555``
+            encoding. Off by default because it changes what consumers
+            of these files see; on, it spares them re-perceiving a
+            bonding we already know exactly. P1 only - the loop indexes
+            sites, and a symmetrized CIF does not write them all.
 
         Returns
         -------
@@ -457,6 +561,14 @@ class Framework:
 
         path = Path(path)
         CifWriter(self.structure, symprec=symprec).write_file(path)
+        if write_bonds:
+            if symprec is None:
+                _append_cif_bonds(path, self)
+            else:
+                logger.warning(
+                    "Bonds are not written to symmetrized CIFs; use "
+                    "symprec=None to export the _geom_bond_ loop."
+                )
         charges = self.charges
         if charges is not None:
             if symprec is None:

--- a/src/autografs/relax.py
+++ b/src/autografs/relax.py
@@ -199,6 +199,59 @@ def _match_displacements(
     return displacements
 
 
+def _hand_off_atom_types(framework: Framework, graph) -> int:
+    """Give lammps-interface the UFF types we already know.
+
+    A Framework's bond graph is the source of truth for UFF4MOF atom
+    types: ``utils.find_mmtypes`` assigns them from real connectivity,
+    against the table in ``data/uff4mof.py``. Staging goes through a
+    CIF, which cannot carry them, so lammps-interface re-perceives the
+    bonding from geometry and re-types every atom - discarding work we
+    have already done correctly and substituting a guess. On unusual
+    coordination that guess can be a type absent from its own parameter
+    tables (``S_3``, where UFF's sulfur types are ``S_3+2/+4/+6``),
+    which raises KeyError before a single step runs.
+
+    ``ForceFields.detect_ff_terms`` types an atom only when its
+    ``force_field_type`` is still None, so filling it in here is the
+    supported hand-off rather than a monkey-patch.
+
+    The correspondence is positional - ``write_cif`` emits atoms in
+    sorted node order - so it is **verified element by element** and
+    abandoned wholesale on any mismatch, leaving lammps-interface's own
+    typing in place. A wrong type is worse than a guessed one.
+
+    Returns
+    -------
+    int
+        How many atoms were typed from the framework; 0 when the
+        correspondence did not check out.
+    """
+    ours = [
+        framework.graph.nodes[n].get("ufftype") for n in sorted(framework.graph.nodes)
+    ]
+    symbols = [
+        framework.graph.nodes[n].get("symbol") for n in sorted(framework.graph.nodes)
+    ]
+    theirs = list(graph.nodes_iter2(data=True))
+    if len(theirs) != len(ours) or not all(ours):
+        logger.debug(
+            f"Not handing off atom types for {framework.name!r}: "
+            f"{len(ours)} framework atoms against {len(theirs)} staged."
+        )
+        return 0
+    for (_node, data), symbol in zip(theirs, symbols, strict=True):
+        if data.get("element") != symbol:
+            logger.debug(
+                f"Not handing off atom types for {framework.name!r}: staged "
+                f"element {data.get('element')} where the framework has {symbol}."
+            )
+            return 0
+    for (_node, data), uff_type in zip(theirs, ours, strict=True):
+        data["force_field_type"] = uff_type
+    return len(ours)
+
+
 def _write_lammps_inputs(
     framework: Framework,
     force_field: str,
@@ -223,12 +276,17 @@ def _write_lammps_inputs(
     # lammps-interface derives every file name from the cif basename
     safe_name = re.sub(r"[^A-Za-z0-9_-]", "_", framework.name) or "framework"
     cif_path = workdir / f"{safe_name}.cif"
-    framework.write_cif(cif_path)
+    # hand our own bonds over rather than letting lammps-interface
+    # re-perceive them from geometry: they come from the blueprint's
+    # dummy correspondences and are exact, and from_CIF prefers a
+    # _geom_bond_ loop over its own perception when one is present
+    framework.write_cif(cif_path, write_bonds=True)
     options = _make_options(options_cls, str(cif_path), force_field, cutoff)
     try:
         with quiet:
             sim = simulation_cls(options)
             cell, graph = from_cif(str(cif_path))
+            _hand_off_atom_types(framework, graph)
             sim.set_cell(cell)
             sim.set_graph(graph)
             sim.split_graph()
@@ -301,7 +359,13 @@ def relax_framework(
     quiet: contextlib.AbstractContextManager = (
         contextlib.nullcontext() if verbose else contextlib.redirect_stdout(sink)
     )
-    with tempfile.TemporaryDirectory(prefix="autografs_relax_") as tmp:
+    # ignore_cleanup_errors: on Windows a handle on the LAMMPS data file
+    # can outlive lmp.close(), and the resulting PermissionError from the
+    # cleanup would discard a relaxation that had already succeeded. The
+    # staging directory is disposable; the result is not.
+    with tempfile.TemporaryDirectory(
+        prefix="autografs_relax_", ignore_cleanup_errors=True
+    ) as tmp:
         workdir = Path(tmp)
         safe_name, supercell = _write_lammps_inputs(
             framework, force_field, cutoff, workdir, quiet

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -85,6 +85,38 @@ class TestFileExports:
             sorted(reread.lattice.abc), sorted(mof5.lattice.abc), rtol=1e-4
         )
 
+    def test_write_cif_bonds_are_exact(self, mof5, tmp_path):
+        """The bond loop must carry every bond at its true length.
+
+        A built framework knows its bonds from the blueprint's dummy
+        correspondences, so a consumer should never have to re-perceive
+        them from distances. The periodic ones are the point: a bond
+        crossing a boundary is recorded as ``1_555`` plus the lattice
+        translation, and getting that convention wrong yields bonds
+        that span the cell instead of an Angstrom or two.
+        """
+        path = mof5.write_cif(tmp_path / "bonded.cif", write_bonds=True)
+        lines = path.read_text(encoding="utf-8").splitlines()
+        start = next(
+            i for i, line in enumerate(lines) if "_ccdc_geom_bond_type" in line
+        )
+        rows = [line.split() for line in lines[start + 1 :] if line.strip()]
+        assert len(rows) == mof5.graph.number_of_edges()
+
+        crossing = 0
+        for label_1, label_2, distance, flag, kind in rows:
+            assert kind in {"S", "A", "D", "T", "Q"}
+            # every recorded length must be a bond, not a cell-crossing
+            # separation - that is what an inverted image convention
+            # would produce
+            assert 0.5 < float(distance) < 3.5, (label_1, label_2, distance)
+            if flag != ".":
+                crossing += 1
+                assert flag.startswith("1_") and len(flag) == 5
+        # a periodic framework has bonds leaving the cell; none would
+        # mean the images were silently folded away
+        assert crossing > 0
+
     def test_to_ase(self, mof5):
         atoms = mof5.to_ase()
         assert len(atoms) == len(mof5)


### PR DESCRIPTION
`relax()` staged a framework by writing a CIF and letting
`lammps_interface` **re-perceive the bonding from geometry and re-type
every atom**. Both are things the framework already knows exactly —
bonds come from the blueprint''s dummy correspondences, UFF4MOF types
from `utils.find_mmtypes` against `data/uff4mof.py`. A CIF without a
`_geom_bond_` loop carries neither, so that knowledge was discarded at
the door and replaced by a guess.

Both hand-offs are supported paths, not hacks:

- `from_CIF` reads a `_geom_bond_` loop when present, and only perceives
  bonding when there is none (*"No bonds reported in cif file —
  computing bonding.."*).
- `ForceFields.detect_ff_terms` types an atom only `if
  data[''force_field_type''] is None`.

## Changes

**`write_cif(write_bonds=True)`** emits the bond loop: our bond orders as
CCDC type codes, periodic images in the standard `1_555` encoding (each
digit 5 + the lattice translation, `.` in-cell). Opt-in, because it
changes what every consumer of our CIFs sees; `relax.py` opts in.

Verified by round-tripping through `from_CIF`: 148 bonds in and out,
identical min/max/median (0.91 / 2.21 / 1.38 Å), **all 15
boundary-crossing bonds reconstructed at exactly the length written**,
zero spurious long bonds. The periodic convention is the part that can
silently invert, so the new test asserts every recorded length is a bond
rather than a cell-crossing separation, and that boundary-crossing bonds
exist at all.

**`_hand_off_atom_types`** fills `force_field_type` from the framework
before `assign_force_fields`. The CIF correspondence is positional, so it
is verified element-by-element and abandoned wholesale on any mismatch,
leaving lammps-interface''s typing in place — a wrong type is worse than
a guessed one.

## What this fixes

A failure that had nothing to do with UFF4MOF''s coverage:
lammps-interface''s typing emitted `S_3`, a name **absent from its own
parameter tables** (UFF sulfur is `S_3+2/+4/+6`), so any sulfonate linker
raised `KeyError` before a step ran. For the record, UFF4MOF there is a
proper superset of UFF — 0 UFF types missing, 91 metal types added — so
the premise that main-group types are inherited is correct.

Also fixed: both LAMMPS stagers used `TemporaryDirectory` without
`ignore_cleanup_errors`, so on Windows a handle outliving `lmp.close()`
raised `PermissionError` and **discarded an already-completed
relaxation**. Invisible in CI because those tests are `slow`-marked.

## Testing

Full suite green including `tests/test_relax.py -m slow`, which
exercises the new staging path end to end. ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)