### PR TITLE
Report LAMMPS relaxation progress, and stop ignoring step budgets

### DIFF
--- a/src/autografs/framework.py
+++ b/src/autografs/framework.py
@@ -672,9 +672,9 @@ class Framework:
         verbose: bool = False,
         *,
         calculator: object | None = None,
-        relax_cell: bool = True,
-        fmax: float = 0.05,
-        steps: int = 500,
+        relax_cell: bool | None = None,
+        fmax: float | None = None,
+        steps: int | None = None,
     ) -> Framework:
         """Relax geometry and cell (LAMMPS/UFF4MOF or any ASE backend).
 
@@ -709,9 +709,15 @@ class Framework:
             ASE path only: relax the cell too (needs stress), by
             default True.
         fmax : float, optional
-            ASE path only: force convergence threshold (eV/A).
+            ASE path only: force convergence threshold (eV/A), by
+            default 0.05.
         steps : int, optional
-            ASE path only: maximum optimizer steps.
+            ASE path only: maximum optimizer steps, by default 500.
+            The LAMMPS backend runs lammps-interface's own minimization
+            protocol and exposes no step or force control, so passing
+            any of these three without a ``calculator`` warns rather
+            than silently doing nothing - a budget that is quietly
+            ignored reads as a converged result.
 
         Returns
         -------
@@ -733,10 +739,26 @@ class Framework:
             return relax_framework_ase(
                 self,
                 calculator,  # type: ignore[arg-type]
-                relax_cell=relax_cell,
-                fmax=fmax,
-                steps=steps,
+                relax_cell=True if relax_cell is None else relax_cell,
+                fmax=0.05 if fmax is None else fmax,
+                steps=500 if steps is None else steps,
                 verbose=verbose,
+            )
+        ignored = [
+            name
+            for name, value in (
+                ("relax_cell", relax_cell),
+                ("fmax", fmax),
+                ("steps", steps),
+            )
+            if value is not None
+        ]
+        if ignored:
+            logger.warning(
+                f"{', '.join(ignored)} only apply to the ASE bridge; the "
+                "LAMMPS backend runs lammps-interface's own minimization "
+                "protocol, which exposes no step or force control. Pass a "
+                "calculator= to control convergence."
             )
         from autografs.relax import relax_framework
 

--- a/src/autografs/relax.py
+++ b/src/autografs/relax.py
@@ -305,6 +305,45 @@ def _write_lammps_inputs(
     return safe_name, np.array(sim.supercell, dtype=int)
 
 
+#: input commands worth announcing: these are the long poles, and a
+#: relaxation that reports nothing between them looks like a hung process
+_LOUD_COMMANDS = ("minimize", "run", "fix", "velocity")
+
+
+def _run_lammps_input(lmp, input_path: Path, name: str) -> None:
+    """Feed a lammps-interface input file command by command.
+
+    ``lmp.file()`` runs the whole script in one opaque call, so a
+    framework of any size sits silent for minutes and is indistinguishable
+    from a hung process. Replaying the commands individually costs
+    nothing and lets the expensive ones be logged as they start.
+    Continuation lines (``&``) are rejoined first, since LAMMPS treats
+    them as a single command.
+    """
+    raw = input_path.read_text(encoding="utf-8").splitlines()
+    commands: list[str] = []
+    buffer = ""
+    for line in raw:
+        stripped = line.split("#", 1)[0].strip()
+        if not stripped:
+            continue
+        if stripped.endswith("&"):
+            buffer += stripped[:-1] + " "
+            continue
+        commands.append(buffer + stripped)
+        buffer = ""
+    if buffer:
+        commands.append(buffer)
+    total = sum(1 for c in commands if c.split()[0] in _LOUD_COMMANDS)
+    done = 0
+    for command in commands:
+        head = command.split()[0]
+        if head in _LOUD_COMMANDS:
+            done += 1
+            logger.info(f"Relaxing {name!r}: [{done}/{total}] {command[:60]}")
+        lmp.command(command)
+
+
 def _launch_lammps():
     """Create an in-process LAMMPS session with a helpful error."""
     lammps, *_ = _import_backends()
@@ -375,7 +414,7 @@ def relax_framework(
         lmp = _launch_lammps()
         try:
             with quiet, contextlib.chdir(workdir):
-                lmp.file(f"in.{safe_name}")
+                _run_lammps_input(lmp, Path(f"in.{safe_name}"), framework.name)
             # gather_atoms orders by atom id, matching the data file
             natoms = lmp.get_natoms()
             raw_x = lmp.gather_atoms("x", 1, 3)


### PR DESCRIPTION
Two things together made a long relaxation indistinguishable from a hung
process.

**No progress output.** `lmp.file()` ran the whole generated input in one
opaque call, so a framework of any size sat silent for minutes. The
commands replay individually at no cost, so they now do, and the
expensive ones are logged as they start:

```
Relaxing ''self-rod'': [1/3] fix 1 all box/relax aniso 0.0 vmax 0.01
Relaxing ''self-rod'': [2/3] minimize 1.0e-15 1.0e-15 10000 100000
Relaxing ''self-rod'': [3/3] minimize 1.0e-15 1.0e-15 10000 100000
```

That output immediately explains the wait: lammps-interface asks for
**10,000 iterations at 1e-15 tolerance, twice**, around a box/relax —
about a minute for 182 atoms. Worth knowing before you conclude something
is stuck.

**Silently discarded arguments.** `relax()` accepted `relax_cell`, `fmax`
and `steps` on the LAMMPS path and threw them away — they only ever
reached the ASE bridge. A caller asking for ten steps got the full tight
minimisation above and had no way to tell, so a *step budget read as a
converged result*. This is not hypothetical: it invalidated a
step-ladder study of ours before it was noticed.

Their defaults become `None` so an explicit value is distinguishable
from a default, and passing one without a `calculator` now warns.

There is nothing to wire them to on this backend: `--tolerance` is
inorganic-cluster detection and `--iter-count` drives parametric sweeps,
neither is a minimiser step count. Real step control means the ASE
bridge, and the warning says so.

## Testing

`tests/test_relax.py` (including `-m slow`, which exercises the command
replay end to end) and `tests/test_framework.py` green; ruff and mypy
clean. Verified live: warning fires, progress logs appear, and a
recombined framework relaxes 1.918 → 2.126 Å closest contact in 67 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)