### PR TITLE
Calibrate the clash weight; the answer is to keep it off by default

### DIFF
--- a/scripts/rods/calibrate_clash_weight.py
+++ b/scripts/rods/calibrate_clash_weight.py
@@ -1,0 +1,171 @@
+"""Corpus calibration of the covalent-contact bound's weight.
+
+``_RodBuild.clash_weight`` charges for non-bonded atoms closer than the
+sum of their Cordero radii. A weight chosen from one structure is worth
+nothing - the DIRECTION_WEIGHT calibration made exactly that mistake and
+picked a value that was optimal on HKUST-1 and inert on the corpus - so
+this sweeps a population, and a population of two kinds:
+
+* **treatment**: recombinations (one crystal's rod on another's
+  blueprint), which is where overlaps actually occur and where the bound
+  is supposed to help;
+* **control**: self-templates, each structure rebuilt on its own
+  blueprint, which are already faithful. The bound must not move these.
+  A weight that rescues the first arm by degrading the second is not a
+  good weight, and only reporting the pooled figure would hide it.
+
+Both closure (worst inter-unit bond deviation) and packing (closest
+contact) are recorded at every weight, because the bound trades one for
+the other by construction and the whole question is the exchange rate.
+
+Usage:
+    python scripts/rods/calibrate_clash_weight.py MANIFEST -o calib.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import statistics
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "benchmarks"))
+
+from _corpus import collect as _collect  # noqa: E402
+from embedding import bond_residuals  # noqa: E402
+from swap_rod_units import _rehome_laterals, harvest  # noqa: E402
+
+import autografs.rod_build as rod_build  # noqa: E402
+from autografs import Autografs  # noqa: E402
+from autografs.exceptions import AutografsError  # noqa: E402
+from autografs.rod_build import build_rod_framework  # noqa: E402
+
+WEIGHTS = (0.0, 0.25, 0.5, 1.0, 2.0, 5.0)
+
+
+def _build(
+    host: dict, rod, laterals: dict, weight: float, scale_band: float | None
+) -> dict | None:
+    """One build at this weight.
+
+    ``scale_band`` must match how the arm is built in production or the
+    comparison is against a straw man: the self-template path bands the
+    transverse scale (the blueprint is at the crystal's own size), while
+    a recombination deliberately leaves it free because a swapped unit
+    is *not* at that size.
+    """
+    rod_build._RodBuild.clash_weight = weight
+    try:
+        framework = build_rod_framework(
+            host["topology"],
+            rod,
+            {slot: copy.deepcopy(f) for slot, f in laterals.items()},
+            run=host["run"],
+            min_distance=None,
+            bond_tolerance=1e9,  # record closure, never gate on it here
+            verify_net=False,
+            initial_scale=1.0,
+            scale_band=scale_band,
+        )
+    except (AutografsError, KeyError, ValueError):
+        return None
+    except Exception:  # noqa: BLE001 - a build bug is data, not a crash
+        return None
+    finally:
+        rod_build._RodBuild.clash_weight = 0.0
+    residual = bond_residuals(framework)
+    return {
+        "contact": round(float(framework.min_contact()), 3),
+        "worst_bond": round(float(residual["max"]), 3),
+        "median_bond": round(float(residual["median"]), 3),
+        "volume": round(float(framework.structure.volume), 1),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("corpus")
+    parser.add_argument("-o", "--output", default="clash-calibration.json")
+    parser.add_argument("--limit", type=int, default=26)
+    args = parser.parse_args()
+
+    gen = Autografs()
+    stock = harvest(gen, _collect(args.corpus)[: args.limit], verbose=False)
+    print(f"harvested {len(stock)} rod structures", flush=True)
+    if len(stock) < 2:
+        raise SystemExit("need at least two structures")
+
+    # control: every structure on its own blueprint with its own units
+    control = [(entry, entry["rod"], entry["laterals"]) for entry in stock]
+    # treatment: the first compatible linker swap for each host
+    treatment = []
+    for host in stock:
+        for donor in stock:
+            if donor is host:
+                continue
+            if set(host["lateral_arity"].values()) <= set(
+                donor["lateral_arity"].values()
+            ):
+                try:
+                    treatment.append((host, host["rod"], _rehome_laterals(host, donor)))
+                except KeyError:
+                    continue
+                break
+    print(f"{len(control)} control, {len(treatment)} treatment builds per weight\n")
+
+    results: dict[str, dict[str, list]] = {
+        arm: {str(w): [] for w in WEIGHTS} for arm in ("control", "treatment")
+    }
+    # the self-template path bands the scale, the swap path does not
+    bands = {"control": 0.25, "treatment": None}
+    for arm, cases in (("control", control), ("treatment", treatment)):
+        for index, (host, rod, laterals) in enumerate(cases, 1):
+            for weight in WEIGHTS:
+                record = _build(host, rod, laterals, weight, bands[arm])
+                if record is not None:
+                    record["host"] = host["name"]
+                    results[arm][str(weight)].append(record)
+            print(f"  {arm} [{index}/{len(cases)}] {host['name'][:34]}", flush=True)
+
+    summary: dict[str, dict[str, dict]] = {}
+    for arm in ("control", "treatment"):
+        summary[arm] = {}
+        for weight in WEIGHTS:
+            rows = results[arm][str(weight)]
+            if not rows:
+                continue
+            contacts = sorted(r["contact"] for r in rows)
+            summary[arm][str(weight)] = {
+                "n": len(rows),
+                "contact_median": round(statistics.median(contacts), 3),
+                "contact_p10": round(contacts[int(0.1 * len(contacts))], 3),
+                "clash_free": sum(1 for c in contacts if c >= 1.5),
+                "worst_bond_median": round(
+                    statistics.median(r["worst_bond"] for r in rows), 3
+                ),
+                "volume_median": round(statistics.median(r["volume"] for r in rows), 1),
+            }
+    payload = {
+        "study": "clash-weight-calibration",
+        "weights": list(WEIGHTS),
+        "summary": summary,
+        "records": results,
+    }
+    Path(args.output).write_text(json.dumps(payload, indent=1, default=str))
+    print(f"\n-> {args.output}")
+    for arm in ("control", "treatment"):
+        print(f"\n{arm}:")
+        for weight, row in summary[arm].items():
+            print(
+                f"  w={weight:>5}  n={row['n']:3d}  contact {row['contact_median']:6.3f} "
+                f"(p10 {row['contact_p10']:6.3f}, clash-free {row['clash_free']:3d})  "
+                f"worst bond {row['worst_bond_median']:6.3f}  "
+                f"vol {row['volume_median']}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rods/ff_load.py
+++ b/scripts/rods/ff_load.py
@@ -1,0 +1,202 @@
+"""Does our embedding relaxation reduce the force field's workload?
+
+The geometric pipeline and the force field both move atoms, and the
+question is whether the first spares the second any effort. The two swap
+arms make it a paired experiment: identical recombinations, built once
+with the slot centres fixed and once with the symmetry-allowed
+displacements freed, then each handed the *same* full UFF minimization.
+
+FF load is measured three ways, because they can disagree:
+
+* **wall time** - what a screening pipeline actually pays. Fair here
+  only because the comparison is paired: the same recombination has the
+  same atom count in both arms.
+* **max atom displacement** and **RMSD** - how far the field had to move
+  the structure. This is the physical measure of "how wrong was the
+  starting geometry", and unlike time it is hardware-independent.
+* **final energy** - whether the extra freedom also lands in a better
+  minimum, not merely a cheaper path to the same one.
+
+A build that closes its bonds well can still start far from a force
+field's minimum, so none of these is implied by the closure figures
+reported elsewhere.
+
+Usage:
+    python scripts/rods/ff_load.py swaps-fixed swaps-relaxed -o ff-load.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+from autografs.framework import Framework
+
+
+def measure(path: Path) -> dict:
+    """Full UFF minimization of one framework, with its cost."""
+    framework = Framework.load(str(path))
+    before = np.asarray(framework.cart_coords, dtype=float)
+    record: dict = {
+        "name": path.name,
+        "n_atoms": len(before),
+        "contact_before": round(float(framework.min_contact()), 3),
+        "volume_before": round(float(framework.structure.volume), 2),
+    }
+    start = time.perf_counter()
+    try:
+        relaxed = framework.relax()
+    except Exception as exc:  # noqa: BLE001 - a failure is data
+        record["outcome"] = "failed"
+        record["error"] = f"{type(exc).__name__}: {exc}"[:150]
+        return record
+    record["seconds"] = round(time.perf_counter() - start, 1)
+    after = np.asarray(relaxed.cart_coords, dtype=float)
+    # same connectivity and atom order by construction, so the
+    # displacement is a direct atom-by-atom comparison
+    delta = np.linalg.norm(after - before, axis=1)
+    record.update(
+        {
+            "outcome": "relaxed",
+            "contact_after": round(float(relaxed.min_contact()), 3),
+            "volume_after": round(float(relaxed.structure.volume), 2),
+            "max_displacement": round(float(delta.max()), 3),
+            "rmsd_displacement": round(float(np.sqrt((delta**2).mean())), 3),
+            "energy": round(float(relaxed.energy), 2)
+            if relaxed.energy is not None
+            else None,
+        }
+    )
+    return record
+
+
+def _isolated(path: Path, timeout: float) -> dict:
+    """Measure in a child process; LAMMPS can abort at C level."""
+    proc = subprocess.run(  # noqa: S603 - fixed argv, our own module
+        [sys.executable, str(Path(__file__).resolve()), "--one", str(path)],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    for line in reversed(proc.stdout.splitlines()):
+        if line.startswith("{"):
+            try:
+                return json.loads(line)
+            except json.JSONDecodeError:
+                break
+    return {
+        "name": path.name,
+        "outcome": "aborted",
+        "error": (proc.stderr or "")[-150:],
+    }
+
+
+def _frameworks(directory: Path) -> dict[str, Path]:
+    return {
+        p.name: p
+        for p in sorted(directory.glob("*.json"))
+        if p.name not in ("swaps.json", "rods.json")
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("fixed", nargs="?", help="swap dir built with fixed slots")
+    parser.add_argument("relaxed", nargs="?", help="swap dir built with relaxation")
+    parser.add_argument("-o", "--output", default="ff-load.json")
+    parser.add_argument("--timeout", type=float, default=1800.0)
+    parser.add_argument("--one", default=None, help="internal: measure one framework")
+    args = parser.parse_args()
+
+    if args.one:
+        print(json.dumps(measure(Path(args.one)), default=str))
+        return
+    if not (args.fixed and args.relaxed):
+        raise SystemExit("both swap directories are required")
+
+    arms = {
+        "fixed": _frameworks(Path(args.fixed)),
+        "relaxed": _frameworks(Path(args.relaxed)),
+    }
+    # the same recombination is written under the same stem in both
+    # arms; anything unpaired cannot answer the question and is skipped
+    paired = sorted(set(arms["fixed"]) & set(arms["relaxed"]))
+    print(f"{len(paired)} recombinations built in both arms\n")
+
+    results: dict[str, dict] = {"fixed": {}, "relaxed": {}}
+    for index, name in enumerate(paired, 1):
+        for arm in ("fixed", "relaxed"):
+            record = _isolated(arms[arm][name], args.timeout)
+            results[arm][name] = record
+        f, r = results["fixed"][name], results["relaxed"][name]
+        print(
+            f"[{index}/{len(paired)}] {name[:34]:36s} "
+            f"fixed {f.get('seconds', '-')}s/{f.get('max_displacement', '-')}A  "
+            f"relaxed {r.get('seconds', '-')}s/{r.get('max_displacement', '-')}A",
+            flush=True,
+        )
+
+    both = [
+        n
+        for n in paired
+        if results["fixed"][n].get("outcome") == "relaxed"
+        and results["relaxed"][n].get("outcome") == "relaxed"
+    ]
+
+    def _median(arm: str, key: str) -> float | None:
+        values = [
+            results[arm][n][key] for n in both if results[arm][n].get(key) is not None
+        ]
+        return round(statistics.median(values), 3) if values else None
+
+    payload = {
+        "study": "ff-load-vs-embedding-relaxation",
+        "paired": len(paired),
+        "relaxed_in_both": len(both),
+        "medians": {
+            arm: {
+                key: _median(arm, key)
+                for key in (
+                    "seconds",
+                    "max_displacement",
+                    "rmsd_displacement",
+                    "energy",
+                    "contact_before",
+                    "contact_after",
+                )
+            }
+            for arm in ("fixed", "relaxed")
+        },
+        "wins": {
+            key: {
+                "relaxed_lower": sum(
+                    1
+                    for n in both
+                    if results["relaxed"][n][key] < results["fixed"][n][key]
+                ),
+                "fixed_lower": sum(
+                    1
+                    for n in both
+                    if results["relaxed"][n][key] > results["fixed"][n][key]
+                ),
+            }
+            for key in ("seconds", "max_displacement", "rmsd_displacement")
+        },
+        "records": results,
+    }
+    Path(args.output).write_text(json.dumps(payload, indent=1, default=str))
+    print(f"\nrelaxed in both arms: {len(both)}/{len(paired)}")
+    print(f"medians: {json.dumps(payload['medians'], indent=1)}")
+    print(f"wins: {json.dumps(payload['wins'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rods/relax_swaps.py
+++ b/scripts/rods/relax_swaps.py
@@ -1,0 +1,249 @@
+"""How far is a recombined rod framework from a usable structure?
+
+The swap driver produces frameworks whose bonds close but whose atoms
+often do not clear each other: a host blueprint's proportions belong to
+its own units, and neither the single transverse scale nor the
+symmetry-allowed slot displacements can always re-proportion it for a
+different one. The remaining question is practical rather than
+conceptual - is that residual a force field's job, and how much of one?
+
+This driver answers it as a *ladder* instead of a single relaxation.
+Each framework is relaxed in increasing step budgets, carrying the
+result forward, and the closest contact is measured after each rung. A
+structure that clears the contact floor after 10 steps was essentially
+already right; one that needs 500 was not, and one that never does is
+telling us the recombination itself is wrong rather than merely tight.
+
+Reporting the ladder matters: a single "relaxed" number would conflate
+those three populations, and the cost of a rung is what decides whether
+a generative pipeline can afford to screen with it.
+
+Usage:
+    python scripts/rods/relax_swaps.py swaps_dir -o relax-study.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+import time
+import traceback
+from pathlib import Path
+
+from autografs.framework import Framework
+
+# the same floor the swap driver uses to call a build a structure
+CONTACT_FLOOR = 1.5
+# cumulative: each rung continues from the previous one's result, so the
+# x axis is total steps spent, not steps per attempt
+LADDER = (10, 25, 50, 100, 250, 500)
+
+
+def study_one(path: Path, ladder: tuple[int, ...], fmax: float) -> dict:
+    """Relax one framework up the ladder, measuring contact at each rung."""
+    record: dict = {"name": path.name, "rungs": []}
+    try:
+        framework = Framework.load(str(path))
+    except Exception as exc:  # noqa: BLE001 - a bad artifact is data
+        record["outcome"] = "load_failed"
+        record["error"] = f"{type(exc).__name__}: {exc}"[:160]
+        return record
+    record["n_atoms"] = len(framework.structure)
+    record["formula"] = framework.structure.composition.reduced_formula
+    try:
+        record["contact_0"] = round(framework.min_contact(), 3)
+    except Exception:  # noqa: BLE001
+        record["contact_0"] = None
+    # UFF4MOF extends UFF with metal types but lammps_interface's table
+    # is missing some main-group ones (S_3, for instance), so a sulfonate
+    # linker raises KeyError before a single step runs. Plain UFF covers
+    # those, and which one was used is recorded rather than hidden.
+    spent = 0
+    for budget in ladder:
+        step = budget - spent
+        start = time.perf_counter()
+        for field in ("UFF4MOF", "UFF"):
+            try:
+                framework = framework.relax(force_field=field, steps=step, fmax=fmax)
+            except KeyError as exc:
+                record.setdefault("missing_types", []).append(str(exc))
+                continue
+            except Exception as exc:  # noqa: BLE001 - relaxation failure is data
+                record["outcome"] = "relax_failed"
+                record["error"] = f"{type(exc).__name__}: {exc}"[:160]
+                record["traceback"] = traceback.format_exc(limit=3)
+                return record
+            record["force_field"] = field
+            break
+        else:
+            record["outcome"] = "no_force_field"
+            record["error"] = f"no parameters: {record.get('missing_types')}"
+            return record
+        spent = budget
+        contact = framework.min_contact()
+        record["rungs"].append(
+            {
+                "steps": budget,
+                "contact": round(float(contact), 3),
+                "energy": round(float(framework.energy), 3)
+                if framework.energy is not None
+                else None,
+                "seconds": round(time.perf_counter() - start, 2),
+                "clash_free": bool(contact >= CONTACT_FLOOR),
+            }
+        )
+        if contact >= CONTACT_FLOOR:
+            record["outcome"] = "clash_free"
+            record["steps_to_clear"] = budget
+            record["final_contact"] = round(float(contact), 3)
+            record["best_contact"] = round(float(contact), 3)
+            return record
+    # contact is NOT monotonic in the step budget: from a severe overlap
+    # the field's repulsion plus a relaxing cell can drive the structure
+    # through worse geometry before it recovers (measured: 1.917 -> 0.555
+    # in ten steps on a clean synthetic rod). Reporting only the endpoint
+    # would call that a failure and hide a trajectory that was fine in
+    # between, so the best rung is carried alongside the last.
+    contacts = [rung["contact"] for rung in record["rungs"]]
+    record["outcome"] = "still_clashing"
+    record["final_contact"] = contacts[-1] if contacts else None
+    record["best_contact"] = max(contacts) if contacts else None
+    record["best_steps"] = (
+        record["rungs"][contacts.index(max(contacts))]["steps"] if contacts else None
+    )
+    return record
+
+
+def _isolated(path: Path, fmax: float, timeout: float) -> dict:
+    """Study one framework in a child process.
+
+    LAMMPS reports some malformed inputs by aborting at C level, which
+    takes the interpreter with it - one bad recombination would
+    otherwise end the sweep and silently truncate the population. The
+    child's exit status becomes a recorded outcome instead.
+    """
+    proc = subprocess.run(  # noqa: S603 - fixed argv, our own module
+        [
+            sys.executable,
+            str(Path(__file__).resolve()),
+            "--one",
+            str(path),
+            "--fmax",
+            str(fmax),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    for line in reversed(proc.stdout.splitlines()):
+        if line.startswith("{"):
+            try:
+                return json.loads(line)
+            except json.JSONDecodeError:
+                break
+    return {
+        "name": path.name,
+        "outcome": "aborted",
+        "rungs": [],
+        "error": (proc.stderr or proc.stdout or "")[-160:],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("swaps_dir", nargs="?", help="output dir of swap_rod_units.py")
+    parser.add_argument("-o", "--output", default="relax-study.json")
+    parser.add_argument("--fmax", type=float, default=0.05)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--timeout", type=float, default=900.0)
+    parser.add_argument("--one", default=None, help="internal: study one framework")
+    args = parser.parse_args()
+
+    if args.one:  # child process: emit one record as JSON and exit
+        print(json.dumps(study_one(Path(args.one), LADDER, args.fmax), default=str))
+        return
+    if not args.swaps_dir:
+        raise SystemExit("swaps_dir is required")
+
+    directory = Path(args.swaps_dir)
+    frameworks = sorted(p for p in directory.glob("*.json") if p.name != "swaps.json")
+    if args.limit:
+        frameworks = frameworks[: args.limit]
+    if not frameworks:
+        raise SystemExit(f"no saved frameworks in {directory}")
+    print(f"relaxing {len(frameworks)} recombined frameworks up {LADDER}\n")
+
+    records = []
+    for index, path in enumerate(frameworks, 1):
+        try:
+            record = _isolated(path, args.fmax, args.timeout)
+        except subprocess.TimeoutExpired:
+            record = {
+                "name": path.name,
+                "outcome": "timeout",
+                "rungs": [],
+                "error": f"exceeded {args.timeout}s",
+            }
+        records.append(record)
+        if record["outcome"] == "clash_free":
+            tag = (
+                f"clear at {record['steps_to_clear']} steps "
+                f"({record['contact_0']} -> {record['final_contact']} A)"
+            )
+        elif record["outcome"] == "still_clashing":
+            tag = (
+                f"still clashing ({record['contact_0']} -> {record['final_contact']} A)"
+            )
+        else:
+            tag = record["outcome"]
+        print(f"[{index}/{len(frameworks)}] {record['name'][:44]}: {tag}", flush=True)
+
+    cleared = [r for r in records if r["outcome"] == "clash_free"]
+    started_clean = [r for r in cleared if (r.get("contact_0") or 0) >= CONTACT_FLOOR]
+    payload = {
+        "study": "ff-relaxation-ladder",
+        "contact_floor": CONTACT_FLOOR,
+        "ladder": list(LADDER),
+        "n": len(records),
+        "clash_free": len(cleared),
+        "already_clean": len(started_clean),
+        "rescued": len(cleared) - len(started_clean),
+        "still_clashing": sum(1 for r in records if r["outcome"] == "still_clashing"),
+        "failed": sum(
+            1 for r in records if r["outcome"] not in ("clash_free", "still_clashing")
+        ),
+        "by_rung": {
+            str(b): sum(1 for r in cleared if r.get("steps_to_clear") == b)
+            for b in LADDER
+        },
+        # structures whose best rung cleared the floor even though the
+        # last one did not - a relaxation that overshot, not one that
+        # failed
+        "cleared_transiently": sum(
+            1
+            for r in records
+            if r["outcome"] == "still_clashing"
+            and (r.get("best_contact") or 0) >= CONTACT_FLOOR
+        ),
+        "records": records,
+    }
+    times = [
+        rung["seconds"] for r in records for rung in r["rungs"] if rung["steps"] == 10
+    ]
+    if times:
+        payload["seconds_first_rung_median"] = round(statistics.median(times), 2)
+    Path(args.output).write_text(json.dumps(payload, indent=1, default=str))
+    print(
+        f"\n{payload['clash_free']}/{payload['n']} clash-free "
+        f"({payload['rescued']} rescued by relaxation), "
+        f"{payload['still_clashing']} still clashing -> {args.output}"
+    )
+    print(f"cleared at each rung: {payload['by_rung']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rods/swap_rod_units.py
+++ b/scripts/rods/swap_rod_units.py
@@ -1,0 +1,333 @@
+"""Harvest rods and lateral SBUs from real rod MOFs, then recombine them.
+
+The self-templated round trip (coverage plan, rod arm) established that a
+rod structure's own units, on its own blueprint, regenerate it. That is a
+*fidelity* result. This driver asks the generative question it licenses:
+take the blueprint of one crystal, put a **different** crystal's rod or
+linkers on it, and see what builds.
+
+A swap is only offered when the blueprint's own connectivity accepts it:
+
+* a substitute rod must match the run's screw order (a helical run's node
+  slots are the screw's orbit, filled one repeat each) and carry the same
+  number of arms per repeat as the node slot has connection points;
+* a substitute linker must carry as many connection points as the slot it
+  fills.
+
+Everything else the builder decides. In particular the transverse scale
+is seeded at 1 but **not** banded: a self-template is at its own crystal's
+size by construction, and a swapped unit is not, so the cell genuinely has
+to move.
+
+Usage:
+    python scripts/rods/swap_rod_units.py CORPUS -o swaps/ --limit 60
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+import time
+import traceback
+from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "benchmarks"))
+
+from _corpus import collect as _collect  # noqa: E402
+
+from autografs import Autografs  # noqa: E402
+from autografs.exceptions import AutografsError  # noqa: E402
+from autografs.extract_topology import (  # noqa: E402
+    rod_topology_from_deconstruction,
+)
+from autografs.rod_build import build_rod_framework  # noqa: E402
+from autografs.rods import save_rods  # noqa: E402
+
+# below this closest-contact a build is not a candidate structure, whatever
+# its bonds do; the library's own default overlap gate is 1.0 A and a
+# comfortable framework sits well above it
+CONTACT_FLOOR = 1.5
+
+
+def harvest(mofgen: Autografs, paths: list[Path], verbose: bool = True) -> list[dict]:
+    """Deconstruct each structure into a reusable (blueprint, rod, laterals)."""
+    stock: list[dict] = []
+    for index, path in enumerate(paths, 1):
+        try:
+            result = mofgen.deconstruct(str(path))
+            if len(result.rod_units) != 1 or result.n_periodic_components != 1:
+                continue
+            topology, run, mapping, rod = rod_topology_from_deconstruction(result)
+            laterals = {
+                slot: copy.deepcopy(result.fragments[name])
+                for slot, name in mapping.items()
+            }
+        except (AutografsError, ValueError, KeyError, IndexError):
+            continue
+        except Exception:  # noqa: BLE001 - one bad CIF must not kill a harvest
+            continue
+        nodes = run.nodes or run.slots
+        entry = {
+            "name": path.name,
+            "topology": topology,
+            "run": run,
+            "rod": rod,
+            "laterals": laterals,
+            # what a substitute has to match
+            "screw_order": int(rod.repeat.screw_order),
+            "arms_per_repeat": len(rod.arms),
+            "node_arity": len(topology.slots[nodes[0]].atoms.indices_from_symbol("X")),
+            "lateral_arity": {
+                slot: len(fragment.atoms.indices_from_symbol("X"))
+                for slot, fragment in laterals.items()
+            },
+            "rod_formula": _rod_formula(rod),
+            "formula": result.structure.composition.reduced_formula,
+            "repeat": float(rod.repeat.repeat_length),
+        }
+        stock.append(entry)
+        if verbose:
+            print(
+                f"[{index}/{len(paths)}] {path.name}: rod {entry['rod_formula']} "
+                f"screw {entry['screw_order']} arms {entry['arms_per_repeat']}, "
+                f"{len(laterals)} lateral slots",
+                flush=True,
+            )
+    return stock
+
+
+def _rod_formula(rod) -> str:
+    counts = Counter(rod.repeat.symbols)
+    return "".join(f"{s}{counts[s]}" for s in sorted(counts))
+
+
+def _swaps(stock: list[dict]) -> list[tuple[dict, dict, str]]:
+    """Every (host blueprint, donor, kind) pair the connectivity allows."""
+    pairs: list[tuple[dict, dict, str]] = []
+    for host in stock:
+        for donor in stock:
+            if donor is host:
+                continue
+            # rod swap: the run's screw orbit and the node's connection
+            # count are what the blueprint fixes
+            if (
+                donor["screw_order"] == host["screw_order"]
+                and donor["arms_per_repeat"] == host["arms_per_repeat"]
+                and donor["rod_formula"] != host["rod_formula"]
+            ):
+                pairs.append((host, donor, "rod"))
+            # linker swap: the donor must be able to supply a unit of the
+            # right connectivity for every lateral slot the host has.
+            # Slot *indices* are blueprint-local and mean nothing across
+            # structures, so this compares the arities themselves.
+            if donor["lateral_arity"] and host["lateral_arity"]:
+                wanted = set(host["lateral_arity"].values())
+                offered = set(donor["lateral_arity"].values())
+                donor_names = {f.name for f in donor["laterals"].values()}
+                host_names = {f.name for f in host["laterals"].values()}
+                if wanted <= offered and donor_names != host_names:
+                    pairs.append((host, donor, "linkers"))
+    return pairs
+
+
+def _rehome_laterals(host: dict, donor: dict) -> dict:
+    """The donor's fragments on the *host's* lateral slots, by arity.
+
+    Both sides are keyed by their own blueprint's slot indices, which
+    mean nothing to each other; what carries across is how many
+    connection points a slot needs. Donor fragments are offered in a
+    fixed order per arity so a host with several slots of the same
+    arity gets a reproducible assignment rather than an arbitrary one.
+    """
+    by_arity: dict[int, list] = {}
+    for _slot, fragment in sorted(donor["laterals"].items()):
+        arity = len(fragment.atoms.indices_from_symbol("X"))
+        by_arity.setdefault(arity, []).append(fragment)
+    filled: dict = {}
+    cursor: dict[int, int] = {}
+    for slot, arity in sorted(host["lateral_arity"].items()):
+        options = by_arity.get(arity)
+        if not options:
+            raise KeyError(f"donor has no {arity}-connected unit for slot {slot}")
+        index = cursor.get(arity, 0)
+        filled[slot] = options[index % len(options)]
+        cursor[arity] = index + 1
+    return filled
+
+
+def attempt(
+    host: dict, donor: dict, kind: str, max_rmsd: float, relax_embedding: bool = False
+) -> dict:
+    """Build one recombination and report what came out."""
+    record: dict = {
+        "host": host["name"],
+        "donor": donor["name"],
+        "kind": kind,
+        "outcome": None,
+    }
+    rod = host["rod"] if kind == "linkers" else donor["rod"]
+    # slot indices are blueprint-local, so a donor's mapping cannot be
+    # handed to the host as-is - its keys would land on the host's run
+    # slots. Fill the HOST's lateral slots, matching each to a donor
+    # fragment of the same connectivity.
+    laterals = _rehome_laterals(host, donor) if kind == "linkers" else host["laterals"]
+    record["rod_formula"] = _rod_formula(rod)
+    record["linkers"] = sorted({f.name for f in laterals.values()})
+    start = time.perf_counter()
+    try:
+        framework = build_rod_framework(
+            host["topology"],
+            rod,
+            {slot: copy.deepcopy(f) for slot, f in laterals.items()},
+            run=host["run"],
+            max_rmsd=max_rmsd,
+            min_distance=None,
+            bond_tolerance=1.0,
+            verify_net=False,
+            # seeded at the host's own size, but NOT banded: a swapped
+            # unit is not at that size and the cell has to move
+            initial_scale=1.0,
+            # the host blueprint's *proportions* belong to its own units,
+            # and one transverse scale cannot re-proportion it for a
+            # different one - which is the same one-scale limit the
+            # embedding chapter measures, met here generatively. Freeing
+            # the lateral slot centres is the remedy that work proposes.
+            relax_embedding=relax_embedding,
+        )
+    except (AutografsError, KeyError) as exc:
+        record["outcome"] = "refused"
+        record["error"] = f"{type(exc).__name__}: {exc}"[:160]
+        record["seconds"] = time.perf_counter() - start
+        return record
+    except Exception as exc:  # noqa: BLE001 - a build bug is data
+        record["outcome"] = "error"
+        record["error"] = f"{type(exc).__name__}: {exc}"[:160]
+        record["traceback"] = traceback.format_exc(limit=3)
+        record["seconds"] = time.perf_counter() - start
+        return record
+    built = framework.structure
+    record["outcome"] = "built"
+    record["formula"] = built.composition.reduced_formula
+    record["n_atoms"] = len(built)
+    record["cell"] = [round(x, 3) for x in built.lattice.abc]
+    record["min_contact"] = round(framework.min_contact(), 3)
+    # closure and packing are separate claims. A build can satisfy every
+    # bond target and still put two atoms 0.4 A apart, which is not a
+    # candidate structure - it is a starting point for a relaxation. Only
+    # the clash-free ones are worth calling generated.
+    record["clash_free"] = record["min_contact"] >= CONTACT_FLOOR
+    record["novel"] = record["formula"] not in (host["formula"], donor["formula"])
+    record["seconds"] = time.perf_counter() - start
+    record["_framework"] = framework
+    return record
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("corpus", help="directory, glob, manifest, or single CIF")
+    parser.add_argument("-o", "--output", default="rod-swaps")
+    parser.add_argument("--limit", type=int, default=60)
+    parser.add_argument("--max-swaps", type=int, default=40)
+    parser.add_argument("--max-rmsd", type=float, default=0.5)
+    parser.add_argument(
+        "--relax-embedding",
+        action="store_true",
+        help="free the lateral slot centres (symmetry-allowed displacements)",
+    )
+    parser.add_argument("--topofile", default=None)
+    args = parser.parse_args()
+
+    out = Path(args.output)
+    out.mkdir(parents=True, exist_ok=True)
+    corpus = _collect(args.corpus)[: args.limit]
+    mofgen = Autografs(topofile=args.topofile) if args.topofile else Autografs()
+
+    print(f"harvesting from {len(corpus)} structures\n")
+    stock = harvest(mofgen, corpus)
+    print(f"\nharvested {len(stock)} usable rod structures")
+    if len(stock) < 2:
+        raise SystemExit("need at least two to recombine")
+
+    # persist the library itself - this is what was never saved before.
+    # Rods are keyed by source structure: deduplication across sources is
+    # merge_rod's job (harvest.py) and would hide which crystal each came
+    # from, which is exactly the provenance a swap report needs.
+    save_rods(
+        {Path(entry["name"]).stem: entry["rod"] for entry in stock},
+        out / "rods.json",
+    )
+    print(f"wrote {out / 'rods.json'}")
+
+    pairs = _swaps(stock)
+    print(f"{len(pairs)} connectivity-compatible swaps available")
+    # spread the attempts over distinct hosts rather than exhausting one
+    by_host: dict[str, list] = {}
+    for host, donor, kind in pairs:
+        by_host.setdefault(host["name"], []).append((host, donor, kind))
+    ordered: list = []
+    while len(ordered) < args.max_swaps and any(by_host.values()):
+        for key in list(by_host):
+            if by_host[key]:
+                ordered.append(by_host[key].pop(0))
+            if len(ordered) >= args.max_swaps:
+                break
+
+    records = []
+    for index, (host, donor, kind) in enumerate(ordered, 1):
+        record = attempt(
+            host, donor, kind, args.max_rmsd, relax_embedding=args.relax_embedding
+        )
+        framework = record.pop("_framework", None)
+        if framework is not None:
+            stem = f"{index:03d}-{kind}-{record['formula']}"
+            framework.write_cif(str(out / f"{stem}.cif"))
+            record["cif"] = f"{stem}.cif"
+            # CIF drops the bond graph, and relaxation needs it (the
+            # UFF4MOF typing and the inter-unit bonds are exactly what a
+            # rod build establishes), so persist the framework itself too
+            framework.save(str(out / f"{stem}.json"))
+            record["framework"] = f"{stem}.json"
+        records.append(record)
+        tag = record["outcome"]
+        if tag == "built":
+            tag = (
+                f"built {record['formula']} "
+                f"({'novel' if record['novel'] else 'known'}, "
+                f"contact {record['min_contact']}"
+                f"{'' if record['clash_free'] else ' CLASH'})"
+            )
+        print(
+            f"[{index}/{len(ordered)}] {kind}: {host['name'][:24]} "
+            f"<- {donor['name'][:24]} : {tag}",
+            flush=True,
+        )
+
+    payload = {
+        "harvested": len(stock),
+        "swaps_available": len(pairs),
+        "attempted": len(records),
+        "outcomes": dict(Counter(r["outcome"] for r in records)),
+        "novel_built": sum(1 for r in records if r.get("novel")),
+        "novel_clash_free": sum(
+            1 for r in records if r.get("novel") and r.get("clash_free")
+        ),
+        "contact_floor": CONTACT_FLOOR,
+        "records": records,
+        "stock": [
+            {
+                k: v
+                for k, v in entry.items()
+                if k not in ("topology", "run", "rod", "laterals")
+            }
+            for entry in stock
+        ],
+    }
+    (out / "swaps.json").write_text(json.dumps(payload, indent=1, default=str))
+    print(f"\n{payload['outcomes']}, {payload['novel_built']} novel -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/autografs/rod_build.py
+++ b/src/autografs/rod_build.py
@@ -679,10 +679,27 @@ class _RodBuild:
     initial_scale: float | None = None
     frozen_scale: float | None = None
     #: weight on the covalent-contact bound (``clash_penalty``). Zero
-    #: reproduces the closure-only objective bit for bit, which is what
-    #: every validated library build was tuned against, so it stays the
-    #: default until the bound is corpus-calibrated the way
-    #: DIRECTION_WEIGHT was.
+    #: reproduces the closure-only objective bit for bit.
+    #:
+    #: **Calibrated, and the answer was "stay off by default"**
+    #: (scripts/rods/calibrate_clash_weight.py, 30 structures, two arms).
+    #: On recombinations the bound is transformative - without it those
+    #: builds do not merely clash, they *collapse*: median cell volume
+    #: 247 A^3 at weight 0 against 980 at 0.5, because a smaller cell
+    #: closes bonds more easily and nothing charged for the overlap. It
+    #: repairs closure as well as packing there (worst bond 1.316 ->
+    #: 0.741, contact p10 0.146 -> 1.012), so the unbounded objective
+    #: was simply in a degenerate basin.
+    #:
+    #: But on self-templates - faithful builds, the control - closure
+    #: degrades monotonically with the weight (worst bond 0.299 at 0,
+    #: 0.358 at 0.5, 0.400 at 1.0), and at 0.5 that is enough to break a
+    #: validated library build: `unc` stops realizing its own net
+    #: (identify_net returns nothing). A term that rescues pathological
+    #: builds by breaking correct ones cannot be the default, however
+    #: good the treatment arm looks - so callers who are recombining
+    #: opt in, and everything else keeps the objective it was tuned
+    #: against.
     clash_weight: float = 0.0
 
     def __init__(


### PR DESCRIPTION
Two arms, 30 structures, each built the way production builds it —
**recombinations** (treatment, where overlaps occur) and
**self-templates** (control, faithful builds that must not move). The
control bands the transverse scale, the treatment does not; comparing
against a control built differently would have manufactured whichever
answer was wanted.

| weight | control contact / clash-free / worst bond | treatment contact / p10 / worst bond | treatment volume |
|---|---|---|---|
| 0 | 1.032 / 6 / **0.299** | 0.330 / 0.146 / 1.316 | **247 Å³** |
| 0.25 | 1.232 / 9 / 0.321 | 1.246 / 0.657 / 0.748 | 957 |
| 0.5 | 1.277 / 9 / 0.358 | 1.287 / **1.012** / **0.741** | 980 |
| 1.0 | 1.308 / **11** / 0.400 | 1.280 / 0.966 / 0.813 | 984 |
| 5.0 | 1.124 / 6 / 0.497 | 1.397 / 1.186 / 1.049 | 1000 |

## The treatment arm is not a trade-off

Without the bound those builds do not merely clash, they **collapse** —
median cell volume 247 Å³ against 980 at weight 0.5. A smaller cell
closes bonds more easily and nothing charged for the overlap, so closure
improves *with* packing (worst bond 1.316 → 0.741). The unbounded
objective was sitting in a degenerate basin, not at a legitimate optimum.

## The control arm is why the default stays 0.0

Closure degrades monotonically with the weight (0.299 → 0.358 → 0.400),
and at 0.5 that is enough to break a validated library build: **`unc`
stops realizing its own net** — `identify_net` returns nothing where it
returned `[''unc'']`. That is the deciding measurement, and it is the
reason to run the control at all: the treatment arm alone would have
argued for shipping 0.5.

A term that rescues pathological builds by breaking correct ones is
opt-in however good its treatment arm looks. Recombination callers set
it; everything else keeps the objective it was tuned against.

Adds `scripts/rods/calibrate_clash_weight.py` (the sweep) and the rod
recombination/FF-load drivers used along the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)