### PR TITLE
Correct the anisotropy claim: the corpus overturns the probe

### DIFF
--- a/scripts/rods/calibrate_clash_weight.py
+++ b/scripts/rods/calibrate_clash_weight.py
@@ -43,7 +43,7 @@ from autografs import Autografs  # noqa: E402
 from autografs.exceptions import AutografsError  # noqa: E402
 from autografs.rod_build import build_rod_framework  # noqa: E402
 
-WEIGHTS = (0.0, 0.25, 0.5, 1.0, 2.0, 5.0)
+WEIGHTS = (0.0, 0.1, 0.25, 0.5, 1.0, 2.0)
 
 
 def _build(
@@ -90,7 +90,17 @@ def main() -> None:
     parser.add_argument("corpus")
     parser.add_argument("-o", "--output", default="clash-calibration.json")
     parser.add_argument("--limit", type=int, default=26)
+    parser.add_argument(
+        "--anisotropic",
+        action="store_true",
+        help="give each free cell row its own scale while sweeping",
+    )
     args = parser.parse_args()
+    # anisotropy supplies closure headroom the isotropic scale lacks, so
+    # the question this re-run asks is whether a *smaller* weight now
+    # rescues the treatment arm without the control-arm damage that
+    # blocked a default at 0.5
+    rod_build._RodBuild.anisotropic = args.anisotropic
 
     gen = Autografs()
     stock = harvest(gen, _collect(args.corpus)[: args.limit], verbose=False)

--- a/src/autografs/rod_build.py
+++ b/src/autografs/rod_build.py
@@ -706,21 +706,30 @@ class _RodBuild:
     #: both transverse directions, and an isotropic scale can only trade
     #: one against the other.
     #:
-    #: **What it buys is closure, not packing** (measured on
-    #: recombinations): worst inter-unit bond 2.078 -> 0.429, 0.747 ->
-    #: 0.374, 1.935 -> 0.271 A on three structures, while the closest
-    #: contact is unchanged or slightly worse. It also rescues the
-    #: collapse on its own - one build goes from a 2.1 A cell to a sane
-    #: one with *better* closure than the covalent-contact bound
-    #: achieves - so the two are complementary rather than redundant:
-    #: together they reach both a good contact and a good bond where
-    #: either alone reaches one.
+    #: **Corpus-measured, and the honest answer is "it does not pay"**
+    #: (30 structures, two arms, alongside the clash-weight sweep). An
+    #: 8-structure probe suggested it halved the worst inter-unit bond
+    #: (2.078 -> 0.429 and similar) and that claim reached this
+    #: docstring; the population contradicts it. Worst bond is *worse*
+    #: with anisotropy on - control 0.299 -> 0.327 at weight 0 and
+    #: 0.358 -> 0.408 at 0.5 - and combined with the covalent-contact
+    #: bound it is much worse than the bound alone (treatment worst
+    #: bond 0.741 -> 1.381, contact p10 1.012 -> 0.597). Same trap as
+    #: the first DIRECTION_WEIGHT calibration: a few structures showing
+    #: a dramatic effect that the corpus does not reproduce.
     #:
-    #: Off by default: it triples the head of the parameter vector, and
-    #: every validated library build was tuned against the isotropic
-    #: objective. A **diagonal** family stays isotropic regardless - it
-    #: stretches along its own direction rather than along a row, so
-    #: per-row factors have nothing to act on and the mean is used.
+    #: What *does* survive is collapse mitigation on its own: at weight
+    #: 0 the treatment arm's median cell goes 247 -> 599 A^3 and its
+    #: contact 0.330 -> 0.571. So the extra rows help a build that
+    #: would otherwise implode, and hurt one the bound is already
+    #: handling. Keep it off unless building without the bound.
+    #:
+    #: Off by default also because it triples the head of the parameter
+    #: vector and every validated library build was tuned against the
+    #: isotropic objective. A **diagonal** family stays isotropic
+    #: regardless - it stretches along its own direction rather than
+    #: along a row, so per-row factors have nothing to act on and the
+    #: mean is used.
     anisotropic: bool = False
 
     def __init__(


### PR DESCRIPTION
The anisotropic scale landed in #229 documented as **buying closure** —
worst inter-unit bond 2.078 → 0.429 and similar. That came from an
**eight-structure probe**. The 30-structure sweep says the opposite.

| | isotropic | anisotropic |
|---|---|---|
| control w=0 worst bond | **0.299** | 0.327 |
| control w=0.5 worst bond | **0.358** | 0.408 |
| treatment w=0.5 worst bond | **0.741** | 1.381 |
| treatment w=0.5 contact p10 | **1.012** | 0.597 |

Closure is *worse* with anisotropy on, and combined with the
covalent-contact bound (#227) it is much worse than the bound alone. The
two corrections are **alternatives, not complements** — the opposite of
what the probe suggested and what #229 claims.

What survives is collapse mitigation *without* the bound: at weight 0 the
treatment median cell goes 247 → 599 Å³ and contact 0.330 → 0.571. So the
extra rows help a build that would otherwise implode, and hurt one the
bound is already handling.

## Nothing regresses, but the rationale was wrong

The feature was opt-in and stays off, so no build changes. The problem is
that the docstring, commit message and PR body all told the next reader
to turn it on for closure — which the corpus does not support.

This is the first `DIRECTION_WEIGHT` mistake repeated: a handful of
structures showing a dramatic effect the corpus does not reproduce. The
probe table is kept in `research/rod-campaign-log.md`, clearly labelled,
as a worked example of the trap rather than deleted.

The sweep gains `--anisotropic`; its ladder drops 5.0 (already past the
useful ceiling) for **0.1**, since the hypothesis under test was that
anisotropy''s headroom would let a smaller weight suffice. It does not —
the clash weight remains unshippable as a default, for the reason #228
recorded.

Rod suite green; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)